### PR TITLE
Updated source definition to ensure plist is not captured as source.

### DIFF
--- a/VimeoNetworking.podspec
+++ b/VimeoNetworking.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.source = { :git => "https://github.com/vimeo/VimeoNetworking", :tag => s.version.to_s }
 
-  s.source_files  = "VimeoNetworking/VimeoNetworking"
+  s.source_files  = "VimeoNetworking/VimeoNetworking/*.{h,m,swift,cer}"
   s.exclude_files = "VimeoNetworking/VimeoNetworking/VimeoNetworking.h"
 
   s.frameworks = ["Foundation"]


### PR DESCRIPTION
No issue associated with this one. 

Just ensuring that the plist isn't captured as part of the pod's "source". 