### PR TITLE
CAM-211: Added a new value (404 NotFound) HTTPStatusCode enum

### DIFF
--- a/VimeoNetworking/VimeoNetworking/ErrorCode.swift
+++ b/VimeoNetworking/VimeoNetworking/ErrorCode.swift
@@ -66,6 +66,7 @@ public enum HTTPStatusCode: Int
     case BadRequest = 400
     case Unauthorized = 401
     case Forbidden = 403
+    case NotFound = 404
 }
 
 /// `LocalErrorCode` contains codes for all error conditions that can be generated from within the library


### PR DESCRIPTION
#### Ticket
[CAM-211](https://vimean.atlassian.net/browse/CAM-211)

#### Ticket Summary
This ticket is about cancelling all uploads within Cameo-iOS when the user logs out. And the task requires checking if a network failure (video deletion) failed due to a 404. In the case of video deletion this isn't actually a failure, it's just a validation that the video we wanted to delete has already been deleted 👍. 

#### Implementation Summary
A good ol' one liner. 

#### How to Test
Aint no test unless you build Cameo, but that'll be tested as part of the Cameo-iOS PR. 