### PR TITLE
CAM-208: adding convenience methods to NSError extension

### DIFF
--- a/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
+++ b/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
@@ -174,6 +174,9 @@ public extension NSError
     private static let VimeoErrorCodeHeaderKey = "Vimeo-Error-Code"
     private static let VimeoErrorCodeKeyLegacy = "VimeoErrorCode"
     private static let VimeoErrorCodeKey = "error_code"
+    private static let VimeoInvalidParametersKey = "invalid_parameters"
+    private static let VimeoUserMessageKey = "error"
+    private static let VimeoDeveloperMessageKey = "developer_message"
     
         /// Returns the status code of the failing response, if available
     public var statusCode: Int?
@@ -228,5 +231,73 @@ public extension NSError
         }
         
         return nil
+    }
+    
+        /// Returns an array of error codes from the api error JSON dictionary if any exist, otherwise returns an empty array
+    public var vimeoInvalidParametersErrorCodes: [Int] {
+        
+        var errorCodes: [Int] = []
+        
+        guard let json = self.errorResponseBodyJSON else {
+            return errorCodes
+        }
+        
+        guard let invalidParameters = json[self.dynamicType.VimeoInvalidParametersKey] as? NSArray else {
+            return errorCodes
+        }
+        
+        for errorJSON in invalidParameters {
+            if let errorCode = errorJSON[self.dynamicType.VimeoErrorCodeKey] as? String {
+                
+                if let errorCodeInt = Int(errorCode) {
+                    errorCodes.append(errorCodeInt)
+                }
+            }
+        }
+        
+        return errorCodes
+    }
+    
+        /// Returns the first error code from the api error JSON dictionary if it exists, otherwise returns NSNotFound
+    public var vimeoInvalidParametersFirstErrorCode: Int
+    {
+        return self.vimeoInvalidParametersErrorCodes.first ?? NSNotFound
+    }
+    
+        /// Returns an underscore separated string of all the error codes in the the api error JSON dictionary if any exist, otherwise returns nil
+    public var vimeoInvalidParametersErrorCodesString: String?
+    {
+        let errorCodes = self.vimeoInvalidParametersErrorCodes
+        
+        guard errorCodes.count > 0 else {
+            return nil
+        }
+        
+        var result = ""
+        for code in errorCodes {
+            result += "\(code)_"
+        }
+        
+        return result.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "_"))
+    }
+    
+        /// Returns the "error" key from the api error JSON dictionary if it exists, otherwise returns nil
+    public var vimeoUserMessage: String?
+    {
+        guard let json = self.errorResponseBodyJSON else {
+            return nil
+        }
+        
+        return json[self.dynamicType.VimeoUserMessageKey] as? String
+    }
+    
+        /// Returns the "developer_message" key from the api error JSON dictionary if it exists, otherwise returns nil
+    public var vimeoDeveloperMessage: String?
+    {
+        guard let json = self.errorResponseBodyJSON else {
+            return nil
+        }
+        
+        return json[self.dynamicType.VimeoDeveloperMessageKey] as? String
     }
 }


### PR DESCRIPTION
#### Ticket
[CAM-208](https://vimean.atlassian.net/browse/CAM-208)

#### Ticket Summary
Add upload analytics to Cameo that mirror the ones we have in Vimeo iOS

#### Implementation Summary
In order to bring some of the Vimeo analytics code into Cameo I need to add some convenience methods to the NSError extension that were previously defined in VIMNetworking.

#### How to Test
N/A