### PR TITLE
CAM-XXX: Fixed a bug in the NSError extension parsing logic

### DIFF
--- a/VimeoNetworking/VimeoNetworking.xcodeproj/project.pbxproj
+++ b/VimeoNetworking/VimeoNetworking.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		01FD39481CC948F300326408 /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 01FD38F81CC948F200326408 /* VIMVideoUtils.m */; };
 		01FD394B1CC9497900326408 /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 01FD39491CC9497900326408 /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01FD394C1CC9497900326408 /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 01FD394A1CC9497900326408 /* VIMUploadQuota.m */; };
+		3C87D73C1D2C33C7005D760B /* NSErrorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87D73B1D2C33C7005D760B /* NSErrorExtensionTests.swift */; };
 		3C91DA341CCFEBF200DCF8BD /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C91DA321CCFEBF200DCF8BD /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C91DA351CCFEBF200DCF8BD /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C91DA331CCFEBF200DCF8BD /* VIMSoundtrack.m */; };
 		3C91DA3A1CCFF27900DCF8BD /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C91DA371CCFEFB300DCF8BD /* Request+Soundtrack.swift */; };
@@ -203,6 +204,7 @@
 		01FD39491CC9497900326408 /* VIMUploadQuota.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMUploadQuota.h; path = VimeoNetworking/Models/VIMUploadQuota.h; sourceTree = "<group>"; };
 		01FD394A1CC9497900326408 /* VIMUploadQuota.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMUploadQuota.m; path = VimeoNetworking/Models/VIMUploadQuota.m; sourceTree = "<group>"; };
 		0AF246275B609406583D4109 /* Pods_VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C87D73B1D2C33C7005D760B /* NSErrorExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSErrorExtensionTests.swift; sourceTree = "<group>"; };
 		3C91DA321CCFEBF200DCF8BD /* VIMSoundtrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMSoundtrack.h; path = VimeoNetworking/Models/VIMSoundtrack.h; sourceTree = "<group>"; };
 		3C91DA331CCFEBF200DCF8BD /* VIMSoundtrack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMSoundtrack.m; path = VimeoNetworking/Models/VIMSoundtrack.m; sourceTree = "<group>"; };
 		3C91DA371CCFEFB300DCF8BD /* Request+Soundtrack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Request+Soundtrack.swift"; path = "VimeoNetworking/Request+Soundtrack.swift"; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 			children = (
 				01B5C8731CC826D800694F4A /* VimeoNetworkingTests.swift */,
 				01B5C8751CC826D800694F4A /* Info.plist */,
+				3C87D73B1D2C33C7005D760B /* NSErrorExtensionTests.swift */,
 			);
 			path = VimeoNetworkingTests;
 			sourceTree = "<group>";
@@ -689,6 +692,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01B5C8741CC826D800694F4A /* VimeoNetworkingTests.swift in Sources */,
+				3C87D73C1D2C33C7005D760B /* NSErrorExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
+++ b/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
@@ -247,11 +247,8 @@ public extension NSError
         }
         
         for errorJSON in invalidParameters {
-            if let errorCode = errorJSON[self.dynamicType.VimeoErrorCodeKey] as? String {
-                
-                if let errorCodeInt = Int(errorCode) {
-                    errorCodes.append(errorCodeInt)
-                }
+            if let errorCode = errorJSON[self.dynamicType.VimeoErrorCodeKey] as? Int {
+                errorCodes.append(errorCode)
             }
         }
         
@@ -262,6 +259,17 @@ public extension NSError
     public var vimeoInvalidParametersFirstErrorCode: Int
     {
         return self.vimeoInvalidParametersErrorCodes.first ?? NSNotFound
+    }
+    
+    public var vimeoInvalidParametersFirstVimeoUserMessage: String? {
+        
+        guard let json = self.errorResponseBodyJSON,
+            invalidParameters = json[self.dynamicType.VimeoInvalidParametersKey] as? NSArray else {
+            return nil
+        }
+        
+        let errorJSON = invalidParameters.firstObject
+        return errorJSON?[self.dynamicType.VimeoUserMessageKey] as? String
     }
     
         /// Returns an underscore separated string of all the error codes in the the api error JSON dictionary if any exist, otherwise returns nil

--- a/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
+++ b/VimeoNetworking/VimeoNetworking/NSError+Extensions.swift
@@ -199,9 +199,9 @@ public extension NSError
         
         if let response = self.userInfo[AFNetworkingOperationFailingURLResponseErrorKey],
             let headers = response.allHeaderFields,
-            let vimeoErrorCode = (headers[self.dynamicType.VimeoErrorCodeHeaderKey] as? NSNumber)?.integerValue
+            let vimeoErrorCode = headers[self.dynamicType.VimeoErrorCodeHeaderKey] as? String
         {
-            return vimeoErrorCode
+            return Int(vimeoErrorCode)
         }
         
         if let json = self.errorResponseBodyJSON,

--- a/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
+++ b/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
@@ -1,0 +1,91 @@
+//
+//  NSErrorExtensionTests.swift
+//  VimeoNetworking
+//
+//  Created by Westendorf, Michael on 7/5/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import XCTest
+
+class NSErrorExtensionTests: XCTestCase {
+    
+    var testApiError: NSError!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let fakeErrorJSON = ["link": NSNull(),
+                             "error": "You have provided an invalid parameter. Please contact developer of this application.",
+                             "developer_message": "The parameters passed to this API endpoint did not pass Vimeo\'s validation. Please check the invalid_parameters list for more information",
+                             "error_code": 2204,
+                             "invalid_parameters": [
+                                    ["developer_message": "Password and/or email provided are invalid",
+                                     "error": "Unable to log in Please enter a valid email address and/or password",
+                                     "error_code": 2218,
+                                     "field": "password"
+                                    ]
+                                ]
+                            ]
+        
+        let fakeErrorData = try! NSJSONSerialization.dataWithJSONObject(fakeErrorJSON, options: NSJSONWritingOptions.init(rawValue: 0))
+        
+        let userInfo = [NSLocalizedDescriptionKey: "Request failed: bad request (400)", "com.alamofire.serialization.response.error.data": fakeErrorData]
+        self.testApiError = NSError(domain: "com.vimeo.networking-test", code: -1011, userInfo: userInfo)
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testVimeoInvalidParametersErrorCodes() {
+        XCTAssertEqual(self.testApiError.vimeoInvalidParametersErrorCodes.count, 1)
+        XCTAssertEqual(self.testApiError.vimeoInvalidParametersErrorCodes[0], 2218)
+    }
+    
+    func testVimeoInvalidParametersFirstErrorCode() {
+        XCTAssertEqual(self.testApiError.vimeoInvalidParametersFirstErrorCode, 2218)
+    }
+    
+    func testVimeoInvalidParametersErrorCodesString() {
+        XCTAssertEqual(self.testApiError.vimeoInvalidParametersErrorCodesString, "2218")
+    }
+    
+    func testVimeoUserMessage() {
+        XCTAssertEqual(self.testApiError.vimeoUserMessage, "You have provided an invalid parameter. Please contact developer of this application.")
+    }
+    
+    func testVimeoDeveloperMessage() {
+        XCTAssertEqual(self.testApiError.vimeoDeveloperMessage, "The parameters passed to this API endpoint did not pass Vimeo\'s validation. Please check the invalid_parameters list for more information")
+    }
+    
+    func testVimeoServerErrorCode() {
+        XCTAssertNotNil(self.testApiError.vimeoServerErrorCode)
+        XCTAssertEqual(self.testApiError.vimeoServerErrorCode!, 2204)
+    }
+    
+    func testLocalizedDescription() {
+        XCTAssertEqual(self.testApiError.localizedDescription, "Request failed: bad request (400)")
+    }
+    
+    func testErrorResponseBodyJSON() {
+        XCTAssertNotNil(self.testApiError.errorResponseBodyJSON)
+        
+        let invalidParameters = self.testApiError.errorResponseBodyJSON!["invalid_parameters"]
+        XCTAssertNotNil(invalidParameters)
+        
+        XCTAssertNotNil(invalidParameters as? NSArray)
+        
+        let invalidParamsDict = invalidParameters![0]
+        XCTAssertEqual(invalidParamsDict["error"], "Unable to log in Please enter a valid email address and/or password")
+        XCTAssertEqual(invalidParamsDict["developer_message"], "Password and/or email provided are invalid")
+        XCTAssertEqual(invalidParamsDict["error_code"], 2218)
+        XCTAssertEqual(invalidParamsDict["field"], "password")
+    }
+    
+    func testVimeoInvalidParametersFirstVimeoUserMessage() {
+        XCTAssertEqual(self.testApiError.vimeoInvalidParametersFirstVimeoUserMessage, "Unable to log in Please enter a valid email address and/or password")
+    }
+    
+}

--- a/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
+++ b/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
@@ -60,9 +60,26 @@ class NSErrorExtensionTests: XCTestCase {
         XCTAssertEqual(self.testApiError.vimeoDeveloperMessage, "The parameters passed to this API endpoint did not pass Vimeo\'s validation. Please check the invalid_parameters list for more information")
     }
     
-    func testVimeoServerErrorCode() {
+    func testVimeoServerErrorCodeInJSONErrorBody() {
         XCTAssertNotNil(self.testApiError.vimeoServerErrorCode)
         XCTAssertEqual(self.testApiError.vimeoServerErrorCode!, 2204)
+    }
+    
+    func testLegacyVimeoServerErrorCode() {
+        var userInfo = self.testApiError.userInfo
+        userInfo["VimeoErrorCode"] = 4101
+        let error = NSError(domain: self.testApiError.domain, code: self.testApiError.code, userInfo: userInfo)
+        
+        XCTAssertEqual(error.vimeoServerErrorCode, 4101)
+    }
+    
+    func testVimeoResponseHeaderServerErrorCode() {
+        let fakeResponse = NSHTTPURLResponse(URL: NSURL(string: "vimeo-networking-tests")!, statusCode: 403, HTTPVersion: "1.0", headerFields: ["Vimeo-Error-Code": "4101"])
+        var userInfo = self.testApiError.userInfo
+        userInfo["com.alamofire.serialization.response.error.response"] = fakeResponse
+        let error = NSError(domain: self.testApiError.domain, code: self.testApiError.code, userInfo: userInfo)
+        
+        XCTAssertEqual(error.vimeoServerErrorCode, 4101)
     }
     
     func testLocalizedDescription() {


### PR DESCRIPTION
#### Ticket
N/A

#### Ticket Summary
Fixed a bug in the NSError extension parsing logic for the invalid_parameters array returned in the error JSON object.

#### Implementation Summary
In the vimeoInvalidParametersErrorCodes property we were incorrectly casting the value of the "error_code" field to a String and then attempting to cast it to an Int before adding it to the returned array.  The value was already an Int in the JSON data, so the cast to string was failing which caused us to always return an empty array.  I fixed the logic to remove the incorrect String cast.  I also added a set of unit tests to make sure all of the properties in the extension are returning the correct values.  This commit also includes a new convenience property to get the VimeoUserMessage from the invalid parameters error JSON object.

#### How to Test
1. Run the unit tests.
