### PR TITLE
Adding associatedtype Element to MappableResponse 

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Mappable.swift
+++ b/VimeoNetworking/VimeoNetworking/Mappable.swift
@@ -15,6 +15,8 @@ private let DefaultModelKeyPath = "data"
  */
 public protocol MappableResponse
 {
+    associatedtype Element
+    
         /// Returns the class type used by `VIMObjectMapper` to deserialize the response
     static var mappingClass: AnyClass? { get }
     
@@ -22,6 +24,8 @@ public protocol MappableResponse
     static var modelKeyPath: String? { get }
     
     func validateModel() throws
+    
+    func arrayValue() -> [Element]
 }
 
 /**
@@ -29,6 +33,8 @@ public protocol MappableResponse
  */
 extension VIMModelObject: MappableResponse
 {
+    public typealias Element = VIMModelObject
+    
     public static var mappingClass: AnyClass?
     {
         return self
@@ -49,6 +55,11 @@ extension VIMModelObject: MappableResponse
         {
             throw error
         }
+    }
+    
+    public func arrayValue() -> [Element]
+    {
+        return [self]
     }
 }
 
@@ -105,6 +116,11 @@ extension Array: MappableResponse
             }
         }
     }
+    
+    public func arrayValue() -> [Element]
+    {
+        return self
+    }
 }
 
 /**
@@ -112,6 +128,8 @@ extension Array: MappableResponse
  */
 public class VIMNullResponse: MappableResponse
 {
+    public typealias Element = VIMNullResponse
+    
     public static var mappingClass: AnyClass?
     {
         return self
@@ -125,5 +143,10 @@ public class VIMNullResponse: MappableResponse
     public func validateModel() throws
     {
         // NO-OP: a null response object is always valid
+    }
+    
+    public func arrayValue() -> [Element]
+    {
+        return [self]
     }
 }

--- a/VimeoNetworking/VimeoNetworking/Mappable.swift
+++ b/VimeoNetworking/VimeoNetworking/Mappable.swift
@@ -15,17 +15,21 @@ private let DefaultModelKeyPath = "data"
  */
 public protocol MappableResponse
 {
+    /// The base class of the mapped response, used for restricting generic parameters to the base model class
     associatedtype Element
     
-        /// Returns the class type used by `VIMObjectMapper` to deserialize the response
+    /// Returns the class type used by `VIMObjectMapper` to deserialize the response
     static var mappingClass: AnyClass? { get }
     
-        /// Optionally returns a nested JSON key to reference for mapping
+    /// Optionally returns a nested JSON key to reference for mapping
     static var modelKeyPath: String? { get }
     
+    /**
+     Implemented by model objects to ensure that their own values are valid for use, called as a step in model object parsing, parsing will fail if this throws an error
+     
+     - throws: An error if a model object's values are somehow invalid.
+     */
     func validateModel() throws
-    
-    func arrayValue() -> [Element]
 }
 
 /**
@@ -55,11 +59,6 @@ extension VIMModelObject: MappableResponse
         {
             throw error
         }
-    }
-    
-    public func arrayValue() -> [Element]
-    {
-        return [self]
     }
 }
 
@@ -116,11 +115,6 @@ extension Array: MappableResponse
             }
         }
     }
-    
-    public func arrayValue() -> [Element]
-    {
-        return self
-    }
 }
 
 /**
@@ -143,10 +137,5 @@ public class VIMNullResponse: MappableResponse
     public func validateModel() throws
     {
         // NO-OP: a null response object is always valid
-    }
-    
-    public func arrayValue() -> [Element]
-    {
-        return [self]
     }
 }


### PR DESCRIPTION
This fixes an issue where we couldn't cast an Array response to an expected array of model objects correctly.  By adding the associated type, it allows us to restrict the generic parameters in a function or class as such: `<ModelType: MappableResponse where ModelType.Element: VIMModelObject>`.  This merely makes explicit what we already know, that we're only requesting model objects from the api, and it also fixes our ability to make that cast: `let newItems = response.model as? [ModelType.Element]`