### PR TITLE
TVOS-228: Row Streams View Controller on tvOS

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Request+Cache.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Cache.swift
@@ -13,10 +13,16 @@ public extension Request
         /// Generates a unique cache key for a request, taking into account endpoint and parameters
     var cacheKey: String
     {
-        var cacheKey = self.path
+        var cacheKey = "cached" + self.path
         
         for (key, value) in self.parameters
         {
+            if key == "fields"
+            {
+                // avoiding the field filtering key due to excessive length
+                continue
+            }
+            
             cacheKey += key
             cacheKey += value.description
         }

--- a/VimeoNetworking/VimeoNetworking/ResponseCache.swift
+++ b/VimeoNetworking/VimeoNetworking/ResponseCache.swift
@@ -26,31 +26,18 @@ final internal class ResponseCache
     }
     
     /**
-     Attempts to retrieve a response for a request
+     Attempts to retrieve a response dictionary for a request
      
      - parameter request:    the request for which the cache should be queried
-     - parameter completion: returns `.Success(Response)`, if found in cache, or `.Success(nil)` for a cache miss.  Returns `.Failure(NSError)` if an error occurred.
+     - parameter completion: returns `.Success(ResponseDictionary)`, if found in cache, or `.Success(nil)` for a cache miss.  Returns `.Failure(NSError)` if an error occurred.
      */
-    func responseForRequest<ModelType>(request: Request<ModelType>, completion: ResultCompletion<Response<ModelType>?>.T)
+    func responseForRequest<ModelType>(request: Request<ModelType>, completion: ResultCompletion<VimeoClient.ResponseDictionary?>.T)
     {
         let key = request.cacheKey
         
         if let responseDictionary = self.memoryCache.responseDictionaryForKey(key)
         {
-            do
-            {
-                let modelObject: ModelType = try VIMObjectMapper.mapObject(responseDictionary, modelKeyPath: request.modelKeyPath)
-                let response = Response(model: modelObject, json: responseDictionary, isCachedResponse: true, isFinalResponse: request.cacheFetchPolicy == .CacheOnly)
-                
-                completion(result: .Success(result: response))
-            }
-            catch let error
-            {
-                self.memoryCache.removeResponseDictionaryForKey(key)
-                self.diskCache.removeResponseDictionaryForKey(key)
-                
-                completion(result: .Failure(error: error as NSError))
-            }
+            completion(result: .Success(result: responseDictionary))
         }
         else
         {
@@ -58,19 +45,7 @@ final internal class ResponseCache
                 
                 if let responseDictionary = responseDictionary
                 {
-                    do
-                    {
-                        let modelObject: ModelType = try VIMObjectMapper.mapObject(responseDictionary, modelKeyPath: request.modelKeyPath)
-                        let response = Response(model: modelObject, json: responseDictionary, isCachedResponse: true, isFinalResponse: request.cacheFetchPolicy == .CacheOnly)
-                        
-                        completion(result: .Success(result: response))
-                    }
-                    catch let error
-                    {
-                        self.diskCache.removeResponseDictionaryForKey(key)
-                        
-                        completion(result: .Failure(error: error as NSError))
-                    }
+                    completion(result: .Success(result: responseDictionary))
                 }
                 else
                 {


### PR DESCRIPTION
#### Ticket
[https://vimean.atlassian.net/browse/TVOS-228](https://vimean.atlassian.net/browse/TVOS-228)

#### Ticket Summary
Implement a Streams view controller that can present and scroll sections as rows individually

#### Implementation Summary

**see Vimeo-tvOS PR for context on the user-facing feature** 

Modified two things relating to caching:
* cache keys now all start with "cached" (for aesthetics really) and they omit the "fields" parameter because it was making our filenames too long
* `ResponseCache` no longer generates an actual `Response` object from the response dictionary.  It instead passes control of this dictionary back to `VimeoClient` for parsing into the final `Response` object.  This is to allow the parsing of pagination parameters to stay contained in `VimeoClient`, but it's also nice to consolidate this architecturally. 