### PR TITLE
TVOS-85: Feed Stream

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Request.swift
+++ b/VimeoNetworking/VimeoNetworking/Request.swift
@@ -186,8 +186,8 @@ public struct Request<ModelType: MappableResponse>
             }
             self.itemsPerPage = itemsPerPage
             
-            var additionalParameters: VimeoClient.RequestParameters = queryParameters
-            parameters?.forEach { (key, object) in
+            var additionalParameters = parameters ?? [:]
+            queryParameters.forEach { (key, object) in
                 additionalParameters[key] = object
             }
             self.additionalParameters = additionalParameters


### PR DESCRIPTION
#### Ticket
[TVOS-85](https://vimean.atlassian.net/browse/TVOS-85)
[TVOS-81](https://vimean.atlassian.net/browse/TVOS-81)

#### Implementation Summary
* Tweaked the ways next page `Request`s are generated and accessed for more consistency.
* When you init a `Request` with a `path`, it will now strip any query string parameters correctly and put them in the parameters and pagination variables as appropriate.
* You can now get a `Request.URI`, which is the path plus a query string of any parameters. This simplifies stream next page requests.