### PR TITLE
Dispatch VimeoClient task success/failure to a background queue for parsing

### DIFF
--- a/VimeoNetworking/VimeoNetworking/VimeoClient.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoClient.swift
@@ -232,13 +232,17 @@ final public class VimeoClient
         let parameters = request.parameters
         
         let success: (NSURLSessionDataTask, AnyObject?) -> Void = { (task, responseObject) in
-            networkRequestCompleted = true
-            self.handleTaskSuccess(request: request, task: task, responseObject: responseObject, completionQueue: completionQueue, completion: completion)
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)) {
+                networkRequestCompleted = true
+                self.handleTaskSuccess(request: request, task: task, responseObject: responseObject, completionQueue: completionQueue, completion: completion)
+            }
         }
         
         let failure: (NSURLSessionDataTask?, NSError) -> Void = { (task, error) in
-            networkRequestCompleted = true
-            self.handleTaskFailure(request: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)) {
+                networkRequestCompleted = true
+                self.handleTaskFailure(request: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
+            }
         }
         
         let task: NSURLSessionDataTask?


### PR DESCRIPTION
Incorrectly assumed that AFNetworking returned us to a background queue in their completion blocks, but they actually default to the main queue, so all our model object parsing and whatnot was being done there 😱 