### PR TITLE
TVOS-354: Adding VIMBadge to video objects

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Models/VIMBadge.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMBadge.swift
@@ -1,0 +1,29 @@
+//
+//  VIMBadge.swift
+//  Pods
+//
+//  Created by Huebner, Rob on 9/16/16.
+//
+//
+
+import Foundation
+
+/// VIMBadge contains the text and/or icons used to display a badge on a video item
+public class VIMBadge: VIMModelObject
+{
+    dynamic public var type: String?
+    dynamic public var festival: String?
+    dynamic public var link: String?
+    dynamic public var text: String?
+    dynamic public var pictures: VIMPictureCollection?
+    
+    public override func getClassForObjectKey(key: String) -> AnyClass?
+    {
+        if key == "pictures"
+        {
+            return VIMPictureCollection.self
+        }
+        
+        return nil
+    }
+}

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.h
@@ -35,6 +35,7 @@
 @class VIMAppeal;
 @class VIMVideoLog;
 @class VIMVideoPlayRepresentation;
+@class VIMBadge;
 
 extern NSString * __nonnull VIMContentRating_Language;
 extern NSString * __nonnull VIMContentRating_Drugs;
@@ -82,6 +83,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 @property (nonatomic, strong, nullable) NSNumber *numPlays;
 @property (nonatomic, strong, nullable) NSArray *categories;
 @property (nonatomic, copy, nullable) NSString *password;
+@property (nonatomic, strong, nullable) VIMBadge *badge;
 
 @property (nonatomic, assign) VIMVideoProcessingStatus videoStatus;
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
@@ -41,6 +41,8 @@
 #import "VIMVideoPlayRepresentation.h"
 #import "VIMVideoDRMFiles.h"
 
+#import <VimeoNetworking/VimeoNetworking-Swift.h>
+
 NSString *VIMContentRating_Language = @"language";
 NSString *VIMContentRating_Drugs = @"drugs";
 NSString *VIMContentRating_Violence = @"violence";
@@ -130,6 +132,11 @@ NSString *VIMContentRating_Safe = @"safe";
     if ([key isEqualToString:@"play"])
     {
         return [VIMVideoPlayRepresentation class];
+    }
+    
+    if ([key isEqualToString:@"badge"])
+    {
+        return [VIMBadge class];
     }
     
     return nil;

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -206,7 +206,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.trigger+json",
             "application/vnd.vimeo.category+json",
             "application/vnd.vimeo.channel+json",
-            "application/vnd.vimeo.song+json"]
+            "application/vnd.vimeo.song+json",
+            "application/vnd.vimeo.ondemand.page+json"]
         )
     }
 }


### PR DESCRIPTION
#### Ticket
[TVOS-354](https://vimean.atlassian.net/browse/TVOS-354)

#### Ticket Summary
Add VOD flourishes to our existing VideoCell, for VOD videos appearing everywhere else in the app but the Purchases list. This includes a VOD icon in the top left and a Trailer/"X days left" small VODItemStatusView in the top right.

#### Implementation Summary

- Added VIMBadge for API returned badges
- Added badge field to video