### PR TITLE
TVOS-353/5: VOD Item Cell and Purchases List

### DIFF
--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -206,7 +206,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.trigger+json",
             "application/vnd.vimeo.category+json",
             "application/vnd.vimeo.channel+json",
-            "application/vnd.vimeo.song+json"]
+            "application/vnd.vimeo.song+json",
+            "application/vnd.vimeo.ondemand.page+json"]
         )
     }
 }


### PR DESCRIPTION
#### Ticket
[TVOS-353](https://vimean.atlassian.net/browse/TVOS-353)
[TVOS-355](https://vimean.atlassian.net/browse/TVOS-355)

#### Ticket Summary

- DEV | Build a cell for VOD items
  - Build a collection view cell for VIMVODItem display on tvOS.
  - This includes a VOD icon in the top left and a Trailer/"X days left" small VODItemStatusView in the top right.  It also includes an "N videos" label in place of what would be the duration label on a VideoCell.
- DEV | Add purchases stream to Library page
  - This should be a relatively straightforward addition to our Library page, we should already have a stream for our VOD library that returns objects of type VIMVODItem

#### Implementation Summary

- added the VOD item content type to the accepted JSON types header

#### How to Test
Log into various VOD test accounts, listed here: https://vimean.atlassian.net/wiki/display/QA/VOD+Accounts

Check:
- that purchases stream shows up correctly on the Library page
- that VOD item cells display correctly for each of owned/rented/subscribed/unowned(trailer) title and series items

Note:
- Crashing when the VOD item cell is clicked is expected, that view is getting added in the next PR