### PR TITLE
Resolve compatibility issues with iOS project

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
@@ -41,6 +41,7 @@
 #import "VIMVideoPlayRepresentation.h"
 #import "VIMVideoDRMFiles.h"
 
+// This is tempoaray to make VIMBadgeModel.swift visible for the TV-OS project [NL] 09/23/2016
 #if TARGET_OS_TV
     #import <VimeoNetworking/VimeoNetworking-Swift.h>
 #endif

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
@@ -41,7 +41,9 @@
 #import "VIMVideoPlayRepresentation.h"
 #import "VIMVideoDRMFiles.h"
 
-#import <VimeoNetworking/VimeoNetworking-Swift.h>
+#if TARGET_OS_TV
+    #import <VimeoNetworking/VimeoNetworking-Swift.h>
+#endif
 
 NSString *VIMContentRating_Language = @"language";
 NSString *VIMContentRating_Drugs = @"drugs";


### PR DESCRIPTION
#### Ticket
NA

#### Ticket Summary
The iOS project does not support `VimeoNetworking` as a Cocoapod yet, but this is forthcoming. The TVOS project does, and needs to import this header file to make a new model written in swift visible to `VIMVideo` written in Objective-C. 

#### Implementation Summary
Wrap import in macro to check OS.

#### How to Test
See parent PR. 