### PR TITLE
TVOS-373: Add model object for Programmed Content endpoint

### DIFF
--- a/VimeoNetworking/VimeoNetworking.xcodeproj/project.pbxproj
+++ b/VimeoNetworking/VimeoNetworking.xcodeproj/project.pbxproj
@@ -98,6 +98,28 @@
 		01FD39481CC948F300326408 /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 01FD38F81CC948F200326408 /* VIMVideoUtils.m */; };
 		01FD394B1CC9497900326408 /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 01FD39491CC9497900326408 /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01FD394C1CC9497900326408 /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 01FD394A1CC9497900326408 /* VIMUploadQuota.m */; };
+		3C6F88591D9972B3006A24F4 /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88581D9972B3006A24F4 /* VIMProgrammedContent.swift */; };
+		3C6F885B1D997C8B006A24F4 /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F885A1D997C8B006A24F4 /* Request+ProgrammedContent.swift */; };
+		3C6F885D1D997FA3006A24F4 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F885C1D997FA3006A24F4 /* VIMBadge.swift */; };
+		3C6F88621D997FF1006A24F4 /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F885E1D997FF1006A24F4 /* VIMVideoPlayRepresentation.m */; };
+		3C6F88631D997FF1006A24F4 /* VIMVideoPlayRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F885F1D997FF1006A24F4 /* VIMVideoPlayRepresentation.h */; };
+		3C6F88641D997FF1006A24F4 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88601D997FF1006A24F4 /* VIMUserBadge.m */; };
+		3C6F88651D997FF1006A24F4 /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F88611D997FF1006A24F4 /* VIMUserBadge.h */; };
+		3C6F88701D99805E006A24F4 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88681D99805E006A24F4 /* VIMVideoHLSFile.m */; };
+		3C6F88711D99805E006A24F4 /* VIMVideoHLSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F88691D99805E006A24F4 /* VIMVideoHLSFile.h */; };
+		3C6F88721D99805E006A24F4 /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F886A1D99805E006A24F4 /* VIMVideoDRMFiles.m */; };
+		3C6F88731D99805E006A24F4 /* VIMVideoDRMFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F886B1D99805E006A24F4 /* VIMVideoDRMFiles.h */; };
+		3C6F88741D99805E006A24F4 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F886C1D99805E006A24F4 /* VIMVideoDASHFile.m */; };
+		3C6F88751D99805E006A24F4 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F886D1D99805E006A24F4 /* VIMVideoDASHFile.h */; };
+		3C6F88781D998086006A24F4 /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88761D998086006A24F4 /* VIMVideoProgressiveFile.m */; };
+		3C6F88791D998086006A24F4 /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F88771D998086006A24F4 /* VIMVideoProgressiveFile.h */; };
+		3C6F887E1D9980C1006A24F4 /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F887A1D9980C1006A24F4 /* VIMVideoPlayFile.m */; };
+		3C6F887F1D9980C1006A24F4 /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F887B1D9980C1006A24F4 /* VIMVideoPlayFile.h */; };
+		3C6F88801D9980C1006A24F4 /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F887C1D9980C1006A24F4 /* VIMVideoFairPlayFile.m */; };
+		3C6F88811D9980C1006A24F4 /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C6F887D1D9980C1006A24F4 /* VIMVideoFairPlayFile.h */; };
+		3C6F88861D9998CB006A24F4 /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88581D9972B3006A24F4 /* VIMProgrammedContent.swift */; };
+		3C6F88871D999C18006A24F4 /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBEFB1CEBA2030093DDF4 /* VIMModelObject.m */; };
+		3C6F88881D999C20006A24F4 /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBEFD1CEBA2030093DDF4 /* VIMObjectMapper.m */; };
 		3C91DA341CCFEBF200DCF8BD /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C91DA321CCFEBF200DCF8BD /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3C91DA351CCFEBF200DCF8BD /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C91DA331CCFEBF200DCF8BD /* VIMSoundtrack.m */; };
 		3C91DA3A1CCFF27900DCF8BD /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C91DA371CCFEFB300DCF8BD /* Request+Soundtrack.swift */; };
@@ -211,6 +233,25 @@
 		01FD39491CC9497900326408 /* VIMUploadQuota.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMUploadQuota.h; path = VimeoNetworking/Models/VIMUploadQuota.h; sourceTree = "<group>"; };
 		01FD394A1CC9497900326408 /* VIMUploadQuota.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMUploadQuota.m; path = VimeoNetworking/Models/VIMUploadQuota.m; sourceTree = "<group>"; };
 		0AF246275B609406583D4109 /* Pods_VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C6F88581D9972B3006A24F4 /* VIMProgrammedContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VIMProgrammedContent.swift; path = VimeoNetworking/Models/VIMProgrammedContent.swift; sourceTree = "<group>"; };
+		3C6F885A1D997C8B006A24F4 /* Request+ProgrammedContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Request+ProgrammedContent.swift"; path = "VimeoNetworking/Request+ProgrammedContent.swift"; sourceTree = "<group>"; };
+		3C6F885C1D997FA3006A24F4 /* VIMBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VIMBadge.swift; path = VimeoNetworking/Models/VIMBadge.swift; sourceTree = "<group>"; };
+		3C6F885E1D997FF1006A24F4 /* VIMVideoPlayRepresentation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoPlayRepresentation.m; path = VimeoNetworking/Models/VIMVideoPlayRepresentation.m; sourceTree = "<group>"; };
+		3C6F885F1D997FF1006A24F4 /* VIMVideoPlayRepresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoPlayRepresentation.h; path = VimeoNetworking/Models/VIMVideoPlayRepresentation.h; sourceTree = "<group>"; };
+		3C6F88601D997FF1006A24F4 /* VIMUserBadge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMUserBadge.m; path = VimeoNetworking/Models/VIMUserBadge.m; sourceTree = "<group>"; };
+		3C6F88611D997FF1006A24F4 /* VIMUserBadge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMUserBadge.h; path = VimeoNetworking/Models/VIMUserBadge.h; sourceTree = "<group>"; };
+		3C6F88681D99805E006A24F4 /* VIMVideoHLSFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoHLSFile.m; path = VimeoNetworking/Models/VIMVideoHLSFile.m; sourceTree = "<group>"; };
+		3C6F88691D99805E006A24F4 /* VIMVideoHLSFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoHLSFile.h; path = VimeoNetworking/Models/VIMVideoHLSFile.h; sourceTree = "<group>"; };
+		3C6F886A1D99805E006A24F4 /* VIMVideoDRMFiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoDRMFiles.m; path = VimeoNetworking/Models/VIMVideoDRMFiles.m; sourceTree = "<group>"; };
+		3C6F886B1D99805E006A24F4 /* VIMVideoDRMFiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoDRMFiles.h; path = VimeoNetworking/Models/VIMVideoDRMFiles.h; sourceTree = "<group>"; };
+		3C6F886C1D99805E006A24F4 /* VIMVideoDASHFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoDASHFile.m; path = VimeoNetworking/Models/VIMVideoDASHFile.m; sourceTree = "<group>"; };
+		3C6F886D1D99805E006A24F4 /* VIMVideoDASHFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoDASHFile.h; path = VimeoNetworking/Models/VIMVideoDASHFile.h; sourceTree = "<group>"; };
+		3C6F88761D998086006A24F4 /* VIMVideoProgressiveFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoProgressiveFile.m; path = VimeoNetworking/Models/VIMVideoProgressiveFile.m; sourceTree = "<group>"; };
+		3C6F88771D998086006A24F4 /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoProgressiveFile.h; path = VimeoNetworking/Models/VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
+		3C6F887A1D9980C1006A24F4 /* VIMVideoPlayFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoPlayFile.m; path = VimeoNetworking/Models/VIMVideoPlayFile.m; sourceTree = "<group>"; };
+		3C6F887B1D9980C1006A24F4 /* VIMVideoPlayFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoPlayFile.h; path = VimeoNetworking/Models/VIMVideoPlayFile.h; sourceTree = "<group>"; };
+		3C6F887C1D9980C1006A24F4 /* VIMVideoFairPlayFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMVideoFairPlayFile.m; path = VimeoNetworking/Models/VIMVideoFairPlayFile.m; sourceTree = "<group>"; };
+		3C6F887D1D9980C1006A24F4 /* VIMVideoFairPlayFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMVideoFairPlayFile.h; path = VimeoNetworking/Models/VIMVideoFairPlayFile.h; sourceTree = "<group>"; };
 		3C91DA321CCFEBF200DCF8BD /* VIMSoundtrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VIMSoundtrack.h; path = VimeoNetworking/Models/VIMSoundtrack.h; sourceTree = "<group>"; };
 		3C91DA331CCFEBF200DCF8BD /* VIMSoundtrack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VIMSoundtrack.m; path = VimeoNetworking/Models/VIMSoundtrack.m; sourceTree = "<group>"; };
 		3C91DA371CCFEFB300DCF8BD /* Request+Soundtrack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Request+Soundtrack.swift"; path = "VimeoNetworking/Request+Soundtrack.swift"; sourceTree = "<group>"; };
@@ -327,6 +368,7 @@
 				016259BF1CD017170004D4AF /* Request+Category.swift */,
 				016259C01CD017170004D4AF /* Request+Channel.swift */,
 				01B061E61CCFBBB000F515E6 /* Request+Toggle.swift */,
+				3C6F885A1D997C8B006A24F4 /* Request+ProgrammedContent.swift */,
 			);
 			name = "Request Constructors";
 			sourceTree = "<group>";
@@ -392,6 +434,23 @@
 		01FD394D1CC9508200326408 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3C6F887A1D9980C1006A24F4 /* VIMVideoPlayFile.m */,
+				3C6F887B1D9980C1006A24F4 /* VIMVideoPlayFile.h */,
+				3C6F887C1D9980C1006A24F4 /* VIMVideoFairPlayFile.m */,
+				3C6F887D1D9980C1006A24F4 /* VIMVideoFairPlayFile.h */,
+				3C6F88761D998086006A24F4 /* VIMVideoProgressiveFile.m */,
+				3C6F88771D998086006A24F4 /* VIMVideoProgressiveFile.h */,
+				3C6F88681D99805E006A24F4 /* VIMVideoHLSFile.m */,
+				3C6F88691D99805E006A24F4 /* VIMVideoHLSFile.h */,
+				3C6F886A1D99805E006A24F4 /* VIMVideoDRMFiles.m */,
+				3C6F886B1D99805E006A24F4 /* VIMVideoDRMFiles.h */,
+				3C6F886C1D99805E006A24F4 /* VIMVideoDASHFile.m */,
+				3C6F886D1D99805E006A24F4 /* VIMVideoDASHFile.h */,
+				3C6F885E1D997FF1006A24F4 /* VIMVideoPlayRepresentation.m */,
+				3C6F885F1D997FF1006A24F4 /* VIMVideoPlayRepresentation.h */,
+				3C6F88601D997FF1006A24F4 /* VIMUserBadge.m */,
+				3C6F88611D997FF1006A24F4 /* VIMUserBadge.h */,
+				3C6F885C1D997FA3006A24F4 /* VIMBadge.swift */,
 				01FD38BF1CC948F200326408 /* VIMAccount.h */,
 				01FD38C01CC948F200326408 /* VIMAccount.m */,
 				01FD38C11CC948F200326408 /* VIMActivity.h */,
@@ -445,6 +504,7 @@
 				3C91DA321CCFEBF200DCF8BD /* VIMSoundtrack.h */,
 				3C91DA331CCFEBF200DCF8BD /* VIMSoundtrack.m */,
 				018483871CE0D9E2008305A4 /* PinCodeInfo.swift */,
+				3C6F88581D9972B3006A24F4 /* VIMProgrammedContent.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -473,6 +533,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C6F88711D99805E006A24F4 /* VIMVideoHLSFile.h in Headers */,
 				01FD39471CC948F300326408 /* VIMVideoUtils.h in Headers */,
 				01FD393F1CC948F300326408 /* VIMVideo.h in Headers */,
 				01FD392B1CC948F300326408 /* VIMPictureCollection.h in Headers */,
@@ -485,6 +546,8 @@
 				01FD39411CC948F300326408 /* VIMVideoFile.h in Headers */,
 				01FD39291CC948F300326408 /* VIMPicture.h in Headers */,
 				01FD39111CC948F300326408 /* VIMActivity.h in Headers */,
+				3C6F88791D998086006A24F4 /* VIMVideoProgressiveFile.h in Headers */,
+				3C6F88751D99805E006A24F4 /* VIMVideoDASHFile.h in Headers */,
 				01FD39371CC948F300326408 /* VIMTrigger.h in Headers */,
 				01FD392F1CC948F300326408 /* VIMPrivacy.h in Headers */,
 				01FD390F1CC948F300326408 /* VIMAccount.h in Headers */,
@@ -492,6 +555,8 @@
 				01FD39151CC948F300326408 /* VIMCategory.h in Headers */,
 				01FD39431CC948F300326408 /* VIMVideoLog.h in Headers */,
 				01FD39171CC948F300326408 /* VIMChannel.h in Headers */,
+				3C6F88731D99805E006A24F4 /* VIMVideoDRMFiles.h in Headers */,
+				3C6F887F1D9980C1006A24F4 /* VIMVideoPlayFile.h in Headers */,
 				3C91DA341CCFEBF200DCF8BD /* VIMSoundtrack.h in Headers */,
 				01FD39351CC948F300326408 /* VIMTag.h in Headers */,
 				014A1E061CE26C4F00EC4681 /* Objc_ExceptionCatcher.h in Headers */,
@@ -500,9 +565,12 @@
 				01FD39261CC948F300326408 /* VIMInteraction.h in Headers */,
 				01FD393B1CC948F300326408 /* VIMUploadTicket.h in Headers */,
 				01FD393D1CC948F300326408 /* VIMUser.h in Headers */,
+				3C6F88651D997FF1006A24F4 /* VIMUserBadge.h in Headers */,
+				3C6F88811D9980C1006A24F4 /* VIMVideoFairPlayFile.h in Headers */,
 				01FD391B1CC948F300326408 /* VIMConnection.h in Headers */,
 				01B5C8681CC826D800694F4A /* VimeoNetworking.h in Headers */,
 				01CDBEFF1CEBA2030093DDF4 /* VIMModelObject.h in Headers */,
+				3C6F88631D997FF1006A24F4 /* VIMVideoPlayRepresentation.h in Headers */,
 				01FD39241CC948F300326408 /* VIMGroup.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -653,6 +721,7 @@
 				01FD39231CC948F300326408 /* VimeoSessionManager+Constructors.swift in Sources */,
 				01FD39201CC948F300326408 /* VimeoRequestSerializer.swift in Sources */,
 				01FD39281CC948F300326408 /* VIMObjectMapper+Generic.swift in Sources */,
+				3C6F88641D997FF1006A24F4 /* VIMUserBadge.m in Sources */,
 				01FD39161CC948F300326408 /* VIMCategory.m in Sources */,
 				01FD39181CC948F300326408 /* VIMChannel.m in Sources */,
 				01FD39421CC948F300326408 /* VIMVideoFile.m in Sources */,
@@ -664,7 +733,11 @@
 				01FD39461CC948F300326408 /* VIMVideoPreference.m in Sources */,
 				01FD38FF1CC948F200326408 /* Mappable.swift in Sources */,
 				01FD393E1CC948F300326408 /* VIMUser.m in Sources */,
+				3C6F88591D9972B3006A24F4 /* VIMProgrammedContent.swift in Sources */,
 				01FD39211CC948F300326408 /* VimeoResponseSerializer.swift in Sources */,
+				3C6F88721D99805E006A24F4 /* VIMVideoDRMFiles.m in Sources */,
+				3C6F88801D9980C1006A24F4 /* VIMVideoFairPlayFile.m in Sources */,
+				3C6F88781D998086006A24F4 /* VIMVideoProgressiveFile.m in Sources */,
 				01FD38FA1CC948F200326408 /* AppConfiguration.swift in Sources */,
 				01FD39361CC948F300326408 /* VIMTag.m in Sources */,
 				01FD39381CC948F300326408 /* VIMTrigger.m in Sources */,
@@ -679,7 +752,10 @@
 				016259C21CD017170004D4AF /* Request+Channel.swift in Sources */,
 				01FD39081CC948F200326408 /* Result.swift in Sources */,
 				01FD39141CC948F300326408 /* VIMAppeal.m in Sources */,
+				3C6F885D1D997FA3006A24F4 /* VIMBadge.swift in Sources */,
+				3C6F885B1D997C8B006A24F4 /* Request+ProgrammedContent.swift in Sources */,
 				01FD39061CC948F200326408 /* Response.swift in Sources */,
+				3C6F887E1D9980C1006A24F4 /* VIMVideoPlayFile.m in Sources */,
 				01FD392E1CC948F300326408 /* VIMPreference.m in Sources */,
 				01FD38F91CC948F200326408 /* AccountStore.swift in Sources */,
 				01FD38FC1CC948F200326408 /* Constants.swift in Sources */,
@@ -688,6 +764,7 @@
 				01FD39021CC948F200326408 /* Request+Authentication.swift in Sources */,
 				01FD39221CC948F300326408 /* VimeoSessionManager.swift in Sources */,
 				01FD390A1CC948F200326408 /* String+Parameters.swift in Sources */,
+				3C6F88621D997FF1006A24F4 /* VIMVideoPlayRepresentation.m in Sources */,
 				01B061E11CCE992D00F515E6 /* ErrorCode.swift in Sources */,
 				01FD391C1CC948F300326408 /* VIMConnection.m in Sources */,
 				01FD39441CC948F300326408 /* VIMVideoLog.m in Sources */,
@@ -697,9 +774,11 @@
 				01FD393C1CC948F300326408 /* VIMUploadTicket.m in Sources */,
 				01FD391A1CC948F300326408 /* VIMComment.m in Sources */,
 				01FD38FE1CC948F200326408 /* KeychainStore.swift in Sources */,
+				3C6F88741D99805E006A24F4 /* VIMVideoDASHFile.m in Sources */,
 				01FD39041CC948F200326408 /* Request+User.swift in Sources */,
 				01FD39121CC948F300326408 /* VIMActivity.m in Sources */,
 				01FD392A1CC948F300326408 /* VIMPicture.m in Sources */,
+				3C6F88701D99805E006A24F4 /* VIMVideoHLSFile.m in Sources */,
 				01FD392C1CC948F300326408 /* VIMPictureCollection.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -708,7 +787,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C6F88881D999C20006A24F4 /* VIMObjectMapper.m in Sources */,
+				3C6F88861D9998CB006A24F4 /* VIMProgrammedContent.swift in Sources */,
 				01B5C8741CC826D800694F4A /* VimeoNetworkingTests.swift in Sources */,
+				3C6F88871D999C18006A24F4 /* VIMModelObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VimeoNetworking/VimeoNetworking/Models/VIMConnection.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMConnection.h
@@ -53,6 +53,7 @@ extern NSString *const __nonnull VIMConnectionNameVODItem;
 extern NSString *const __nonnull VIMConnectionNameVODTrailer;
 extern NSString *const __nonnull VIMConnectionNameRecommendedChannels;
 extern NSString *const __nonnull VIMConnectionNameRecommendedUsers;
+extern NSString *const __nonnull VIMConnectionNameContents;
 
 @interface VIMConnection : VIMModelObject
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMConnection.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMConnection.m
@@ -53,6 +53,7 @@ NSString *const VIMConnectionNameVODItem = @"ondemand";
 NSString *const VIMConnectionNameVODTrailer = @"trailer";
 NSString *const VIMConnectionNameRecommendedChannels = @"recommended_channels";
 NSString *const VIMConnectionNameRecommendedUsers = @"recommended_users";
+NSString *const VIMConnectionNameContents = @"contents";
 
 @interface VIMConnection()
 @property (nonatomic, strong, nullable) NSNumber *extra_total;

--- a/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
@@ -1,0 +1,95 @@
+//
+//  VIMCinemaItem.swift
+//  VimeoNetworking
+//
+//  Created by Westendorf, Michael on 9/26/16.
+//  Copyright © 2016 Vimeo (https://vimeo.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public class VIMProgrammedContent: VIMModelObject
+{
+    dynamic public var uri: String?
+    dynamic public var name: String?
+    dynamic public var type: String?
+    dynamic public var content: NSArray?
+ 
+    dynamic private var metadata: [NSObject: AnyObject]?
+    dynamic private var connections: [NSObject: AnyObject]?
+    
+    private struct Constants
+    {
+        static let ConnectionsKey = "connections"
+    }
+    
+    // MARK: Public API
+    
+    public func connectionWithName(connectionName: String) -> VIMConnection?
+    {
+        return self.connections?[connectionName] as? VIMConnection
+    }
+    
+    override public func getClassForCollectionKey(key: String!) -> AnyClass!
+    {
+        if key == "content"
+        {
+            return VIMVideo.self
+        }
+        
+        return nil
+    }
+    
+    override public func getClassForObjectKey(key: String!) -> AnyClass!
+    {
+        if key == "metadata"
+        {
+            return NSMutableDictionary.self
+        }
+        
+        return nil
+    }
+    
+    override public func didFinishMapping()
+    {
+        self.parseConnections()
+    }
+    
+    // MARK: Parsing Helpers
+    
+    private func parseConnections()
+    {
+        guard let dict = self.metadata?[Constants.ConnectionsKey] as? [String: AnyObject] else
+        {
+            return
+        }
+     
+        self.connections = [NSObject: AnyObject]()
+        for (key, value) in dict
+        {
+            if let valueDict = value as? [NSObject: AnyObject]
+            {
+                self.connections?[key] = VIMConnection(keyValueDictionary: valueDict)
+            }
+        }
+    }
+    
+}

--- a/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
@@ -39,6 +39,8 @@ public class VIMProgrammedContent: VIMModelObject
     private struct Constants
     {
         static let ConnectionsKey = "connections"
+        static let ContentKey = "content"
+        static let MetadataKey = "metadata"
     }
     
     // MARK: Public API
@@ -50,26 +52,31 @@ public class VIMProgrammedContent: VIMModelObject
     
     override public func getClassForCollectionKey(key: String!) -> AnyClass!
     {
-        if key == "content"
+        if key == Constants.ContentKey
         {
             return VIMVideo.self
         }
         
-        return nil
+        return super.getClassForCollectionKey(key)
     }
     
     override public func getClassForObjectKey(key: String!) -> AnyClass!
     {
-        if key == "metadata"
+        if key == Constants.MetadataKey
         {
             return NSMutableDictionary.self
         }
+        else if key == Constants.ContentKey
+        {
+            return NSArray.self
+        }
         
-        return nil
+        return super.getClassForObjectKey(key)
     }
     
     override public func didFinishMapping()
     {
+        super.didFinishMapping()
         self.parseConnections()
     }
     
@@ -77,7 +84,7 @@ public class VIMProgrammedContent: VIMModelObject
     
     private func parseConnections()
     {
-        guard let dict = self.metadata?[Constants.ConnectionsKey] as? [String: AnyObject] else
+        guard let dict = self.metadata?[Constants.ConnectionsKey] as? [NSObject: AnyObject] else
         {
             return
         }

--- a/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMProgrammedContent.swift
@@ -74,9 +74,13 @@ public class VIMProgrammedContent: VIMModelObject
         return super.getClassForObjectKey(key)
     }
     
-    override public func didFinishMapping()
+    public override func didFinishMapping()
     {
-        super.didFinishMapping()
+        //Note: the super implementation of this method is not being called here because this method does not actually exist in the base class (VIMModelObject).  This method is declared optional in the VIMMappable protocol
+        //that VIMModelObject implements.  There seems to be a bug in swift where the compiler is seeing the optional method as a part of the base class, so it won't compile unless we include the override keyword.
+        //Calling super.didFinishMapping() will cause the app to crash because of an unknown selector, however if you attempt to test to see if the selector exists before calling it (super.respondsToSelector), the check will
+        //succeed even though the method exists in the subclass and not the super class.  [MW] 10/3/16
+        
         self.parseConnections()
     }
     

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.h
@@ -25,6 +25,7 @@
 //
 
 @import Foundation;
+@import UIKit;
 #import "VIMVideoPlayFile.h"
 
 @interface VIMVideoProgressiveFile : VIMVideoPlayFile

--- a/VimeoNetworking/VimeoNetworking/Request+ProgrammedContent.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+ProgrammedContent.swift
@@ -1,0 +1,29 @@
+//
+//  Request+ProgrammedContent.swift
+//  VimeoNetworking
+//
+//  Created by Westendorf, Michael on 9/26/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+/// `Request` returning an array of `VIMVideo`
+public typealias CinemaContentRequest = Request<[VIMProgrammedContent]>
+
+public extension Request
+{
+    private static var CinemaPath: String { return "/programmed/cinema" }
+    
+    // MARK: -
+    
+    /**
+     Create a `Request` to get the content for the Cinema
+     
+     - returns: a new `Request`
+     */
+    public static func getCinemaContentRequest() -> Request
+    {
+        return Request(path: self.CinemaPath)
+    }
+}

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -207,7 +207,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.category+json",
             "application/vnd.vimeo.channel+json",
             "application/vnd.vimeo.song+json",
-            "application/vnd.vimeo.ondemand.page+json"]
+            "application/vnd.vimeo.ondemand.page+json",
+            "application/vnd.vimeo.programmed.cinema+json"]
         )
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBEF61CEB9C100093DDF4 /* ModelObjectValidationTests.swift */; };
 		01FD38A71CC9289200326408 /* VimeoNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01FD38A61CC9289200326408 /* VimeoNetworking.framework */; };
 		3BD1FD0AE4F6ED52E4C3A08E /* Pods_VimeoNetworkingExample_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B5E5EDEAB2776A3E8F6391A /* Pods_VimeoNetworkingExample_iOSUITests.framework */; };
+		3C6F88841D999878006A24F4 /* programmed_cinema.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C6F88821D999878006A24F4 /* programmed_cinema.json */; };
+		3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88831D999878006A24F4 /* FakeDataSource.swift */; };
 		CC22A6749CADF4DA91D73F04 /* Pods_VimeoNetworkingExample_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D22A36411CC71C284010480 /* Pods_VimeoNetworkingExample_iOSTests.framework */; };
 		DEB396A3F44BBFBE9A602F1A /* Pods_VimeoNetworkingExample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46114AFA04898F979611854A /* Pods_VimeoNetworkingExample_iOS.framework */; };
 /* End PBXBuildFile section */
@@ -62,6 +64,8 @@
 		097D1643FEAE7486DB0CB7D6 /* Pods-VimeoNetworkingExample-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSTests/Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		128A8B3EE78B0F2F924E5E24 /* Pods-VimeoNetworkingExample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		2B5E5EDEAB2776A3E8F6391A /* Pods_VimeoNetworkingExample_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C6F88821D999878006A24F4 /* programmed_cinema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = programmed_cinema.json; sourceTree = "<group>"; };
+		3C6F88831D999878006A24F4 /* FakeDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeDataSource.swift; sourceTree = "<group>"; };
 		46114AFA04898F979611854A /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C94F08ECDA88F9FB4D6805A /* Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSTests/Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7D75E4A99C867B547C8DF8D5 /* Pods-VimeoNetworkingExample-iOSUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSUITests/Pods-VimeoNetworkingExample-iOSUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -140,6 +144,8 @@
 		018B9FAF1C9B34050054650E /* VimeoNetworkingExample-iOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				3C6F88821D999878006A24F4 /* programmed_cinema.json */,
+				3C6F88831D999878006A24F4 /* FakeDataSource.swift */,
 				018B9FB01C9B34050054650E /* VimeoNetworkingExample_iOSTests.swift */,
 				01CDBEF61CEB9C100093DDF4 /* ModelObjectValidationTests.swift */,
 				018B9FB21C9B34050054650E /* Info.plist */,
@@ -303,6 +309,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C6F88841D999878006A24F4 /* programmed_cinema.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -456,6 +463,7 @@
 			files = (
 				01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */,
 				018B9FB11C9B34050054650E /* VimeoNetworkingExample_iOSTests.swift in Sources */,
+				3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/FakeDataSource.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/FakeDataSource.swift
@@ -1,0 +1,42 @@
+//
+//  FakeDataSource.swift
+//  Vimeo
+//
+//  Created by Westendorf, Michael on 7/25/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+
+import Foundation
+@testable import VimeoNetworkingExample_iOS
+
+class FakeDataSource<T: VIMMappable>
+{
+    private let mapper = VIMObjectMapper()
+    
+    var items: [T]?
+    var error: NSError?
+    
+    init(jsonData: [String: AnyObject], keyPath: String)
+    {                
+        mapper.addMappingClass(T.self, forKeypath: keyPath)
+        
+        let mappedData = mapper.applyMappingToJSON(jsonData)
+        if let objects = mappedData["data"] as? [T]
+        {
+            self.items = objects
+        }
+        else if let object = mappedData as? T
+        {
+            self.items = [object]
+        }
+    }
+
+    static func loadJSONFile(jsonFileName: String, withExtension: String) -> [String: AnyObject]
+    {
+        let jsonFilePath = NSBundle.mainBundle().pathForResource(jsonFileName, ofType: withExtension)
+        let jsonData = NSData(contentsOfFile: jsonFilePath!)
+        let jsonDict = try! NSJSONSerialization.JSONObjectWithData(jsonData!, options: NSJSONReadingOptions.AllowFragments)
+        
+        return (jsonDict as? [String: AnyObject])!
+    }
+}

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/programmed_cinema.json
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/programmed_cinema.json
@@ -1,0 +1,15314 @@
+{
+    "total": 6,
+    "data": [
+        {
+            "uri": "/categories/travel",
+            "name": "Travel",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/1242270",
+                    "name": "TCSC TV Spot",
+                    "description": null,
+                    "link": "https://vimeo.com/1242270",
+                    "duration": 30,
+                    "width": 480,
+                    "language": null,
+                    "height": 324,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1242270?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"480\" height=\"324\" frameborder=\"0\" title=\"TCSC TV Spot\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-06-27T12:56:54+00:00",
+                    "modified_time": "2016-09-13T03:07:54+00:00",
+                    "release_time": "2008-06-27T12:56:54+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1242270/pictures/57245121",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/57245121_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57245121_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/57245121_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57245121_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/57245121_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57245121_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 432,
+                                "link": "https://i.vimeocdn.com/video/57245121_640x432.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57245121_640x432.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 648,
+                                "link": "https://i.vimeocdn.com/video/57245121_960x648.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57245121_960x648.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "cf7f0d1b538f2d2f4ff8b57089c2fe3bc15028bb"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/turksandcaicos",
+                            "name": "Turks & Caicos",
+                            "tag": "Turks & Caicos",
+                            "canonical": "turksandcaicos",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/turksandcaicos/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 661
+                                    }
+                                }
+                            },
+                            "resource_key": "af414cb9835874eeb2ddd448664cf65373998a59"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 2459
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1242270/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1242270/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1242270/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "pictures": {
+                                "uri": "/videos/1242270/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1242270/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/357053",
+                        "name": "TCSC",
+                        "link": "https://vimeo.com/user357053",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-01-29T13:49:42+00:00",
+                        "account": "basic",
+                        "pictures": null,
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/357053/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/357053/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/357053/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/357053/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/357053/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/357053/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/357053/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "following": {
+                                    "uri": "/users/357053/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/357053/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/357053/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/357053/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/357053/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/357053/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 71
+                                },
+                                "watchlater": {
+                                    "uri": "/users/357053/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/357053/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/357053/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 0
+                                }
+                            }
+                        },
+                        "resource_key": "f98d6fab96919986dbafc8235510c31f658c2abb",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 324,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451076487?s=1242270_1473803811_f020fa5392b41de617943b484bc08d7c&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-09T14:37:42+00:00",
+                            "fps": 30,
+                            "size": 3142908,
+                            "md5": "817fd59f1cebe35edcf9e0236ddbd91c"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451076487/hls?s=1242270_1473800211_aa44837af39a6b746c22b9899da3e260&oauth2_token_id=903107513",
+                            "created_time": "2015-12-09T14:37:42+00:00",
+                            "fps": 30,
+                            "size": 3142908,
+                            "md5": "817fd59f1cebe35edcf9e0236ddbd91c",
+                            "link_secure": "https://player.vimeo.com/play/451076487/hls?s=1242270_1473800211_aa44837af39a6b746c22b9899da3e260&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 324,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451076487?s=1242270_2947596822_fb932ab77bff3a077e134e8ac177a5e3&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=TCSC%2BTV%2BSpot112.mp4",
+                            "created_time": "2015-12-09T14:37:42+00:00",
+                            "fps": 30,
+                            "size": 3142908,
+                            "md5": "817fd59f1cebe35edcf9e0236ddbd91c"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "f88581891b86c01524114c72af590c2a3e7a8695",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/1298153",
+                    "name": "Launch event recap",
+                    "description": null,
+                    "link": "https://vimeo.com/1298153",
+                    "duration": 191,
+                    "width": 480,
+                    "language": null,
+                    "height": 320,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1298153?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"480\" height=\"320\" frameborder=\"0\" title=\"Launch event recap\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-07-07T19:23:55+00:00",
+                    "modified_time": "2016-09-13T03:07:23+00:00",
+                    "release_time": "2008-07-07T19:23:55+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1298153/pictures/57846385",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/57846385_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57846385_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/57846385_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57846385_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/57846385_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57846385_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 427,
+                                "link": "https://i.vimeocdn.com/video/57846385_640x427.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57846385_640x427.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 641,
+                                "link": "https://i.vimeocdn.com/video/57846385_960x641.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57846385_960x641.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "d6dfbbc5f1514032ac7725699615c5f03a00186a"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/turksandcaicos",
+                            "name": "Turks & Caicos",
+                            "tag": "Turks & Caicos",
+                            "canonical": "turksandcaicos",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/turksandcaicos/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 661
+                                    }
+                                }
+                            },
+                            "resource_key": "670404b7b0d09895f72e0302cccc2f72986a1067"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 3568
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1298153/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1298153/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1298153/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/1298153/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1298153/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/357053",
+                        "name": "TCSC",
+                        "link": "https://vimeo.com/user357053",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-01-29T13:49:42+00:00",
+                        "account": "basic",
+                        "pictures": null,
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/357053/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/357053/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/357053/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/357053/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/357053/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/357053/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/357053/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "following": {
+                                    "uri": "/users/357053/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/357053/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/357053/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/357053/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/357053/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/357053/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 71
+                                },
+                                "watchlater": {
+                                    "uri": "/users/357053/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/357053/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/357053/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 0
+                                }
+                            }
+                        },
+                        "resource_key": "f98d6fab96919986dbafc8235510c31f658c2abb",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451523363?s=1298153_1473803811_d9ccdf8da273b59e2ad27b7c611d45f8&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-10T10:40:42+00:00",
+                            "fps": 30,
+                            "size": 20342662,
+                            "md5": "51882d3e750a3b29976fe4fbf2bc4f2d"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451523363/hls?s=1298153_1473800211_710f66a4fae04cfe933415e3acfb4e45&oauth2_token_id=903107513",
+                            "created_time": "2015-12-10T10:40:42+00:00",
+                            "fps": 30,
+                            "size": 20342662,
+                            "md5": "51882d3e750a3b29976fe4fbf2bc4f2d",
+                            "link_secure": "https://player.vimeo.com/play/451523363/hls?s=1298153_1473800211_710f66a4fae04cfe933415e3acfb4e45&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/451523363?s=1298153_2947596822_5f7ac78c98fb7ba55dbd452c0cf1d802&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Launch%2Bevent%2Brecap112.mp4",
+                            "created_time": "2015-12-10T10:40:42+00:00",
+                            "fps": 30,
+                            "size": 20342662,
+                            "md5": "51882d3e750a3b29976fe4fbf2bc4f2d"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "9d0c332f20b73e22fa67b79528b5512b9e2ecbba",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/3598221",
+                    "name": "Team Desert Taxi - Mongol Rally 2008",
+                    "description": "http://jeffreydonenfeld.com/blog/2009/03/team-desertaxi-video-2008-mongol-rally/\n\nWe are 3 students from London who, under the inspiration and guidance of Jimmy Walker of New York, have entered the Mongol Rally. An enormous adventure in aid of the wonderful charity Mercy Corps.\n\nEvery year the Mongol rally departs from London's Hyde Park for the Gobi desert and outer Mongolia in cars which you would usually associate with a scrap heap. Our ultimate aim is to raise an awful lot of money for charity and seeing if our banger can make it half way round the world on \"roads\" generally reserved for goats. Mercy Corps is most deserving.  \n\nTo this end we have bought ourselves an ancient black cab off eBay with the hope of not having to push it too far on it's way to Ulaanbaatar, Mongolia. We strike forth into the unknown on the 19th of July 2008. We will keep you up to date on our progress through 2 continents, 18 countries 3 deserts, across 11 mountain ranges and on to our fundraising target of £10,000.\n\nWe are doing this to help raise money for some thoroughly worthy causes that are very close to us. We hope you will join us in supporting them.",
+                    "link": "https://vimeo.com/3598221",
+                    "duration": 813,
+                    "width": 640,
+                    "language": null,
+                    "height": 480,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/3598221?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"640\" height=\"480\" frameborder=\"0\" title=\"Team Desert Taxi - Mongol Rally 2008\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-03-12T14:32:51+00:00",
+                    "modified_time": "2016-09-13T14:10:22+00:00",
+                    "release_time": "2009-03-12T14:32:51+00:00",
+                    "content_rating": [
+                        "safe"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/3598221/pictures/4389424",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/4389424_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/4389424_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/4389424_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/4389424_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/4389424_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/4389424_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/4389424_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/4389424_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/4389424_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/4389424_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "462bad9a80696ca4742588e2779c84fdf06d3c58"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/jameswalker",
+                            "name": "James Walker",
+                            "tag": "James Walker",
+                            "canonical": "jameswalker",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/jameswalker/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 83
+                                    }
+                                }
+                            },
+                            "resource_key": "71f576765df0c541152409bb4e5a16a6fbe4af3c"
+                        },
+                        {
+                            "uri": "/tags/maxfurman",
+                            "name": "Max Furman",
+                            "tag": "Max Furman",
+                            "canonical": "maxfurman",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/maxfurman/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "0372d5c02d4e606692e008573ee2cffa7bf4aaf5"
+                        },
+                        {
+                            "uri": "/tags/charlesoliver",
+                            "name": "Charles Oliver",
+                            "tag": "Charles Oliver",
+                            "canonical": "charlesoliver",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/charlesoliver/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 9
+                                    }
+                                }
+                            },
+                            "resource_key": "2bc9eecc84b200b36643db8f49911e73429d11d1"
+                        },
+                        {
+                            "uri": "/tags/edwardmonckton",
+                            "name": "Edward Monckton",
+                            "tag": "Edward Monckton",
+                            "canonical": "edwardmonckton",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/edwardmonckton/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "d2f3bd9e8b4628553ada40c9b147f348c0ccf424"
+                        },
+                        {
+                            "uri": "/tags/mongolrally2008",
+                            "name": "Mongol Rally 2008",
+                            "tag": "Mongol Rally 2008",
+                            "canonical": "mongolrally2008",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mongolrally2008/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "88f01f9bdfda2382dc08781cb0939958151309e7"
+                        },
+                        {
+                            "uri": "/tags/mongolrally2009",
+                            "name": "Mongol Rally 2009",
+                            "tag": "Mongol Rally 2009",
+                            "canonical": "mongolrally2009",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mongolrally2009/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 33
+                                    }
+                                }
+                            },
+                            "resource_key": "eefdc3b92c4fdb74da1d0b257193ad4b410e0d0f"
+                        },
+                        {
+                            "uri": "/tags/londontaxi",
+                            "name": "London Taxi",
+                            "tag": "London Taxi",
+                            "canonical": "londontaxi",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/londontaxi/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 45
+                                    }
+                                }
+                            },
+                            "resource_key": "3936b5070d712cb40b6f5b495f77df2844dc7be7"
+                        },
+                        {
+                            "uri": "/tags/teamdesertaxi",
+                            "name": "teamdesertaxi",
+                            "tag": "teamdesertaxi",
+                            "canonical": "teamdesertaxi",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/teamdesertaxi/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "0fd2bd5ac114a7f39d0e83fcdc2726154d3ecc6a"
+                        },
+                        {
+                            "uri": "/tags/teamdeserttaxi",
+                            "name": "Team Desert Taxi",
+                            "tag": "Team Desert Taxi",
+                            "canonical": "teamdeserttaxi",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/teamdeserttaxi/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "a99488c4a1fc6d6fa8daaf2622747a1382a52617"
+                        },
+                        {
+                            "uri": "/tags/mongolrally",
+                            "name": "Mongol Rally",
+                            "tag": "Mongol Rally",
+                            "canonical": "mongolrally",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mongolrally/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 337
+                                    }
+                                }
+                            },
+                            "resource_key": "eb2512c53df54d8ea17a62f48ee42f18eed84155"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 24318
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/3598221/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "credits": {
+                                "uri": "/videos/3598221/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/3598221/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 99
+                            },
+                            "pictures": {
+                                "uri": "/videos/3598221/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/3598221/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/309451",
+                        "name": "Jeffzilla",
+                        "link": "https://vimeo.com/jeffzilla",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2007-12-03T21:12:42+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/309451/pictures/1098111",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1098111_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1098111_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1098111_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1098111_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "807fa4ee5e6a0f30f6853279eebdd257c0ff2ef5"
+                        },
+                        "websites": [
+                            {
+                                "name": "JeffreyDonenfeld.com",
+                                "link": "JeffreyDonenfeld.com",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/309451/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/309451/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "appearances": {
+                                    "uri": "/users/309451/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/309451/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/309451/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/309451/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/309451/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 11
+                                },
+                                "following": {
+                                    "uri": "/users/309451/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 5
+                                },
+                                "groups": {
+                                    "uri": "/users/309451/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/309451/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 32
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/309451/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/309451/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/309451/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "watchlater": {
+                                    "uri": "/users/309451/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "shared": {
+                                    "uri": "/users/309451/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/309451/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "97166bdef871b9c3b4234f20e75de3b4d22c6254",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 480,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/895166?s=3598221_1473803811_9102ba6fade4b866538b6a62abd4c49e&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-03-12T16:57:15+00:00",
+                            "fps": 29.97,
+                            "size": 72428092,
+                            "md5": "5a781ca48b5780ecabfd077a21e53df9"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/895166/hls?s=3598221_1473800211_57d340c3972962701baf991cf2a2a54b&oauth2_token_id=903107513",
+                            "created_time": "2009-03-12T16:57:15+00:00",
+                            "fps": 29.97,
+                            "size": 72428092,
+                            "md5": "5a781ca48b5780ecabfd077a21e53df9",
+                            "link_secure": "https://player.vimeo.com/play/895166/hls?s=3598221_1473800211_57d340c3972962701baf991cf2a2a54b&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 480,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/895166?s=3598221_2947596822_bf6c4f53e2d0481466f446eb61b2c9cc&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Team%2BDesert%2BTaxi%2B-%2BMongol%2BRally%2B2008107.mp4",
+                            "created_time": "2009-03-12T16:57:15+00:00",
+                            "fps": 29.97,
+                            "size": 72428092,
+                            "md5": "5a781ca48b5780ecabfd077a21e53df9"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "1fde9d3adb6bccb7fb779fa3357760c5a9746603",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/326014",
+                    "name": "Apartment Gypsies",
+                    "description": "Sponteneous Jam session at my friend Larisa's house.",
+                    "link": "https://vimeo.com/326014",
+                    "duration": 174,
+                    "width": 400,
+                    "language": null,
+                    "height": 300,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/326014?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"400\" height=\"300\" frameborder=\"0\" title=\"Apartment Gypsies\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-10-01T17:43:59+00:00",
+                    "modified_time": "2016-09-11T16:08:02+00:00",
+                    "release_time": "2007-10-01T17:43:59+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/326014/pictures/49139846",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/49139846_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49139846_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/49139846_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49139846_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/49139846_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49139846_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/49139846_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49139846_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/49139846_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49139846_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "b56b3c2ef0e0f1da364b628479357b214f6c57e8"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/fun",
+                            "name": "fun",
+                            "tag": "fun",
+                            "canonical": "fun",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fun/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 189091
+                                    }
+                                }
+                            },
+                            "resource_key": "9b9e9ab4f302eb8853eebf390b7527c1bcf92e42"
+                        },
+                        {
+                            "uri": "/tags/music",
+                            "name": "music",
+                            "tag": "music",
+                            "canonical": "music",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/music/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 764672
+                                    }
+                                }
+                            },
+                            "resource_key": "3dfa1c70331390a01947e6323e151c897c2d19fb"
+                        },
+                        {
+                            "uri": "/tags/love",
+                            "name": "love",
+                            "tag": "love",
+                            "canonical": "love",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/love/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 241832
+                                    }
+                                }
+                            },
+                            "resource_key": "18bbd3bbf671e736490b920e6eec004086788922"
+                        },
+                        {
+                            "uri": "/tags/larisafuchs",
+                            "name": "larisa fuchs",
+                            "tag": "larisa fuchs",
+                            "canonical": "larisafuchs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/larisafuchs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 0
+                                    }
+                                }
+                            },
+                            "resource_key": "ffe2ad452efb7dd01a79a2d58630a39376e262c9"
+                        },
+                        {
+                            "uri": "/tags/reggiewatts",
+                            "name": "reggie watts",
+                            "tag": "reggie watts",
+                            "canonical": "reggiewatts",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/reggiewatts/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 458
+                                    }
+                                }
+                            },
+                            "resource_key": "1dca50036802ca4900e759e44c6b14fc9484d46e"
+                        },
+                        {
+                            "uri": "/tags/luminesentorchestra",
+                            "name": "luminesent orchestra",
+                            "tag": "luminesent orchestra",
+                            "canonical": "luminesentorchestra",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/luminesentorchestra/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "45e5c1992b4774f125cc5e328babd7e989de6b13"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 3617
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/326014/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 7
+                            },
+                            "credits": {
+                                "uri": "/videos/326014/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/326014/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 12
+                            },
+                            "pictures": {
+                                "uri": "/videos/326014/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/326014/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/148662",
+                        "name": "Reggie Watts",
+                        "link": "https://vimeo.com/reggiewatts",
+                        "location": "NY",
+                        "bio": "I was born the day that many people died but also on a day when a few were resusitated. Which leads me here to write these words for you tonight. Don't call it a come-back, call it an everlasting love whose nature is defined by eventuality in an era of need.\n\nSo thats how I got into comedy.",
+                        "created_time": "2006-12-21T07:02:13+00:00",
+                        "account": "pro",
+                        "pictures": {
+                            "uri": "/users/148662/pictures/1056592",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "d0ba4e39df7c42d26358271ffd7bc9f1300712c4"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "www.vimeo.com/reggie",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/148662/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/148662/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "appearances": {
+                                    "uri": "/users/148662/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 118
+                                },
+                                "categories": {
+                                    "uri": "/users/148662/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/148662/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 19
+                                },
+                                "feed": {
+                                    "uri": "/users/148662/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/148662/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2215
+                                },
+                                "following": {
+                                    "uri": "/users/148662/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 35
+                                },
+                                "groups": {
+                                    "uri": "/users/148662/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/148662/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 96
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/148662/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 11
+                                },
+                                "portfolios": {
+                                    "uri": "/users/148662/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/148662/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 199
+                                },
+                                "watchlater": {
+                                    "uri": "/users/148662/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "shared": {
+                                    "uri": "/users/148662/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 548
+                                },
+                                "pictures": {
+                                    "uri": "/users/148662/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "e451b65aaa44b5fa457a707e86e1d608cdc3b8ab",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/15090279?s=326014_1473803811_2e9700109fdde2d3ae7dc633a9ecb713&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2010-02-01T22:01:49+00:00",
+                            "fps": 30,
+                            "size": 6742051,
+                            "md5": "d0fccf6974bfc3a9f6b3bd378f6aacb3"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/15090279/hls?s=326014_1473800211_4c3f1f06685892222757ff99db476e66&oauth2_token_id=903107513",
+                            "created_time": "2010-02-01T22:01:49+00:00",
+                            "fps": 30,
+                            "size": 6742051,
+                            "md5": "d0fccf6974bfc3a9f6b3bd378f6aacb3",
+                            "link_secure": "https://player.vimeo.com/play/15090279/hls?s=326014_1473800211_4c3f1f06685892222757ff99db476e66&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/15090279?s=326014_2947596822_84e7103ebc079d365b4df41b00f518ad&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Apartment%2BGypsies116.mp4",
+                            "created_time": "2010-02-01T22:01:49+00:00",
+                            "fps": 30,
+                            "size": 6742051,
+                            "md5": "d0fccf6974bfc3a9f6b3bd378f6aacb3"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "2d1740527038ef33f5116c9462e83994f0c4980d",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/3023428",
+                    "name": "MaxfieldCamille",
+                    "description": "Camille and new friends Michelle and Paul enjoy a bit of paradise.",
+                    "link": "https://vimeo.com/3023428",
+                    "duration": 147,
+                    "width": 504,
+                    "language": null,
+                    "height": 380,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/3023428?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"504\" height=\"380\" frameborder=\"0\" title=\"MaxfieldCamille\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-01-31T01:02:35+00:00",
+                    "modified_time": "2016-09-13T13:17:33+00:00",
+                    "release_time": "2009-01-31T01:02:35+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/3023428/pictures/61028014",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/61028014_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/61028014_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/61028014_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/61028014_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/61028014_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/61028014_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 483,
+                                "link": "https://i.vimeocdn.com/video/61028014_640x483.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/61028014_640x483.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 725,
+                                "link": "https://i.vimeocdn.com/video/61028014_960x725.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/61028014_960x725.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "75c19666ebce772b64041057781676a27251ba6a"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/camilledalmais",
+                            "name": "Camille Dalmais",
+                            "tag": "Camille Dalmais",
+                            "canonical": "camilledalmais",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/camilledalmais/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5
+                                    }
+                                }
+                            },
+                            "resource_key": "c84419df06488488e2bbda4c5d15f474d81fb7e2"
+                        },
+                        {
+                            "uri": "/tags/reggiewatts",
+                            "name": "reggie watts",
+                            "tag": "reggie watts",
+                            "canonical": "reggiewatts",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/reggiewatts/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 458
+                                    }
+                                }
+                            },
+                            "resource_key": "777add08dd40cb1c70421b624975f06adcb36933"
+                        },
+                        {
+                            "uri": "/tags/australia",
+                            "name": "australia",
+                            "tag": "australia",
+                            "canonical": "australia",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/australia/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 80627
+                                    }
+                                }
+                            },
+                            "resource_key": "3ee21080cd04e21f4eaaa9402e3bfb1262ad8da3"
+                        },
+                        {
+                            "uri": "/tags/bluemountains",
+                            "name": "blue mountains",
+                            "tag": "blue mountains",
+                            "canonical": "bluemountains",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/bluemountains/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 928
+                                    }
+                                }
+                            },
+                            "resource_key": "cbd737b7fe788c18b08d0afb753414d8d5a192fa"
+                        },
+                        {
+                            "uri": "/tags/fun",
+                            "name": "fun",
+                            "tag": "fun",
+                            "canonical": "fun",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fun/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 189091
+                                    }
+                                }
+                            },
+                            "resource_key": "5cc9ddadc21d273c437461a04bfb2ef5c3e5c0db"
+                        },
+                        {
+                            "uri": "/tags/paradise",
+                            "name": "paradise",
+                            "tag": "paradise",
+                            "canonical": "paradise",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/paradise/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 9177
+                                    }
+                                }
+                            },
+                            "resource_key": "3d0daeda09ae7bbcdccdc5bc59cafa9b6f23899a"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 6001
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/3023428/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 4
+                            },
+                            "credits": {
+                                "uri": "/videos/3023428/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/3023428/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 12
+                            },
+                            "pictures": {
+                                "uri": "/videos/3023428/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/3023428/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/148662",
+                        "name": "Reggie Watts",
+                        "link": "https://vimeo.com/reggiewatts",
+                        "location": "NY",
+                        "bio": "I was born the day that many people died but also on a day when a few were resusitated. Which leads me here to write these words for you tonight. Don't call it a come-back, call it an everlasting love whose nature is defined by eventuality in an era of need.\n\nSo thats how I got into comedy.",
+                        "created_time": "2006-12-21T07:02:13+00:00",
+                        "account": "pro",
+                        "pictures": {
+                            "uri": "/users/148662/pictures/1056592",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1056592_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "d0ba4e39df7c42d26358271ffd7bc9f1300712c4"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "www.vimeo.com/reggie",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/148662/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/148662/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "appearances": {
+                                    "uri": "/users/148662/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 118
+                                },
+                                "categories": {
+                                    "uri": "/users/148662/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/148662/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 19
+                                },
+                                "feed": {
+                                    "uri": "/users/148662/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/148662/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2215
+                                },
+                                "following": {
+                                    "uri": "/users/148662/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 35
+                                },
+                                "groups": {
+                                    "uri": "/users/148662/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/148662/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 96
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/148662/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 11
+                                },
+                                "portfolios": {
+                                    "uri": "/users/148662/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/148662/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 199
+                                },
+                                "watchlater": {
+                                    "uri": "/users/148662/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "shared": {
+                                    "uri": "/users/148662/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 548
+                                },
+                                "pictures": {
+                                    "uri": "/users/148662/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "e451b65aaa44b5fa457a707e86e1d608cdc3b8ab",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 424,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/460845943?s=3023428_1473803811_370b7e0e0acd4436de4afb1372f96a98&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2016-01-03T09:02:25+00:00",
+                            "fps": 30,
+                            "size": 7336285,
+                            "md5": "96ce031c2c8310755ccc844190375326"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/460845934?s=3023428_1473803811_4e20d27ed2df28b0019377e163e2ff15&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2016-01-03T09:02:25+00:00",
+                            "fps": 30,
+                            "size": 15631774,
+                            "md5": "92fa597d6070ae880d457b547ec6c48d"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/460845943,460845934/hls?s=3023428_1473800211_ed3d37837c390fff09ae979e7c5918a1&oauth2_token_id=903107513",
+                            "created_time": "2016-01-03T09:02:25+00:00",
+                            "fps": 30,
+                            "size": 7336285,
+                            "md5": "96ce031c2c8310755ccc844190375326",
+                            "link_secure": "https://player.vimeo.com/play/460845943,460845934/hls?s=3023428_1473800211_ed3d37837c390fff09ae979e7c5918a1&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 424,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/460845943?s=3023428_2947596822_5bcf9af6761b2e70a1f5b3446c9e8e7d&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=MaxfieldCamille116.mp4",
+                            "created_time": "2016-01-03T09:02:25+00:00",
+                            "fps": 30,
+                            "size": 7336285,
+                            "md5": "96ce031c2c8310755ccc844190375326"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/460845934?s=3023428_2947596822_ad2580281768955bd5d3d17a963580ac&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=MaxfieldCamille112.mp4",
+                            "created_time": "2016-01-03T09:02:25+00:00",
+                            "fps": 30,
+                            "size": 15631774,
+                            "md5": "92fa597d6070ae880d457b547ec6c48d"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "b921936c702ccbbed6ee123a98b283e06a6bdb36",
+                    "embed_presets": null
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/travel/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 173617
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/travel",
+                "name": "Travel",
+                "link": "https://vimeo.com/categories/travel",
+                "top_level": true,
+                "pictures": {
+                    "uri": "/videos/179663026/pictures/587789963",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/587789963_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/587789963_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/587789963_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/587789963_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/587789963_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/587789963_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 360,
+                            "link": "https://i.vimeocdn.com/video/587789963_640x360.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/587789963_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 540,
+                            "link": "https://i.vimeocdn.com/video/587789963_960x540.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/587789963_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "074676f85f43291b11d86965f333da6ba5417fc5"
+                },
+                "last_video_featured_time": null,
+                "parent": null,
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/travel/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 29399
+                        },
+                        "groups": {
+                            "uri": "/categories/travel/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 5926
+                        },
+                        "users": {
+                            "uri": "/categories/travel/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 2971
+                        },
+                        "videos": {
+                            "uri": "/categories/travel/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 173617
+                        }
+                    }
+                },
+                "subcategories": [
+                    {
+                        "uri": "/categories/travel/subcategories/africa",
+                        "name": "Africa",
+                        "link": "https://vimeo.com/categories/travel/africa/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/antarctica",
+                        "name": "Antarctica",
+                        "link": "https://vimeo.com/categories/travel/antarctica/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/asia",
+                        "name": "Asia",
+                        "link": "https://vimeo.com/categories/travel/asia/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/australasia",
+                        "name": "Australasia",
+                        "link": "https://vimeo.com/categories/travel/australasia/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/europe",
+                        "name": "Europe",
+                        "link": "https://vimeo.com/categories/travel/europe/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/northamerica",
+                        "name": "North America",
+                        "link": "https://vimeo.com/categories/travel/northamerica/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/southamerica",
+                        "name": "South America",
+                        "link": "https://vimeo.com/categories/travel/southamerica/videos"
+                    },
+                    {
+                        "uri": "/categories/travel/subcategories/space",
+                        "name": "Space!",
+                        "link": "https://vimeo.com/categories/travel/space/videos"
+                    }
+                ],
+                "resource_key": "9884bb14a11d9d80337387d4ae21d90e09bee867"
+            }
+        },
+        {
+            "uri": "/categories/narrative/subcategories/drama",
+            "name": "Drama",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/26444560",
+                    "name": "Bath",
+                    "description": null,
+                    "link": "https://vimeo.com/thatiana/bath",
+                    "duration": 408,
+                    "width": 640,
+                    "language": null,
+                    "height": 360,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/26444560?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"640\" height=\"360\" frameborder=\"0\" title=\"Bath\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2011-07-14T20:15:38+00:00",
+                    "modified_time": "2016-09-13T11:12:02+00:00",
+                    "release_time": "2011-07-14T20:15:38+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/26444560/pictures/174650774",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/174650774_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/174650774_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/174650774_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/174650774_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/174650774_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/174650774_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 357,
+                                "link": "https://i.vimeocdn.com/video/174650774_640x357.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/174650774_640x357.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 536,
+                                "link": "https://i.vimeocdn.com/video/174650774_960x536.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/174650774_960x536.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "f2f0fef8e375756f8a03ffc0f5ef8c1b1c8528de"
+                    },
+                    "tags": [],
+                    "stats": {
+                        "plays": null
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/26444560/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "credits": {
+                                "uri": "/videos/26444560/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/26444560/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 23
+                            },
+                            "pictures": {
+                                "uri": "/videos/26444560/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/26444560/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/5504292",
+                        "name": "Thatiana",
+                        "link": "https://vimeo.com/thatiana",
+                        "location": null,
+                        "bio": "Thatiana is an interdisciplinary artist and friend to cats.",
+                        "created_time": "2010-12-16T23:23:08+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/5504292/pictures/2982234",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/2982234_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/2982234_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/2982234_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/2982234_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "0821ca4051bbdc49886aa024f96a5f0f66c9cf0e"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "www.thatianaoliveira.com",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/5504292/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/5504292/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/5504292/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/5504292/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/5504292/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/5504292/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/5504292/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 209
+                                },
+                                "following": {
+                                    "uri": "/users/5504292/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "groups": {
+                                    "uri": "/users/5504292/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/5504292/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/5504292/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/5504292/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/5504292/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "watchlater": {
+                                    "uri": "/users/5504292/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/5504292/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "pictures": {
+                                    "uri": "/users/5504292/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "3060685173678e58418e0499cc16632146cb86ad",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/58727448?s=26444560_1473803811_8eeca62c71fa8b8bfa83d50a2c12738d&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2011-07-14T20:57:54+00:00",
+                            "fps": 29.97,
+                            "size": 36443421,
+                            "md5": "7721659ffb3f082c18ca8f15b5cd8118"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/58727448/hls?s=26444560_1473800211_05509a5d8db400fa51d95fe0a4ca389e&oauth2_token_id=903107513",
+                            "created_time": "2011-07-14T20:57:54+00:00",
+                            "fps": 29.97,
+                            "size": 36443421,
+                            "md5": "7721659ffb3f082c18ca8f15b5cd8118",
+                            "link_secure": "https://player.vimeo.com/play/58727448/hls?s=26444560_1473800211_05509a5d8db400fa51d95fe0a4ca389e&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/58727448?s=26444560_2947596822_75c6f68c167847c9928465cbf292b967&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Bath107.mp4",
+                            "created_time": "2011-07-14T20:57:54+00:00",
+                            "fps": 29.97,
+                            "size": 36443421,
+                            "md5": "7721659ffb3f082c18ca8f15b5cd8118"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "2be6ef27f71cb78357fd2ef943ee0b46606bebcc",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/87786037",
+                    "name": "Hyperscape",
+                    "description": "HYPERSCAPE\nPoint Taken 1\n\nMartial dance story over de kracht van ontwijken en de schoonheid van meegeven. In drie onderling verbonden delen – een solo in een witte cel, een luchtgevecht in een jeugdgevangenis, en een ontsnappingsrun – gaan dansers en urban tricksters een freerun duet en duel aan met een meebewegende camera. Point Taken is een project waarbij vier teams van in Nederland wonende en werkende choreografen en filmmakers gezamenlijk een dansfilm maken.\n\nProducent: Stichting Balls\n\nScenario: Wilko BelloMarco Gerris\nRegie: Wilko Bello\nCamera: Jonathan Weijland\nMontage: Herman P. Koerts\nChoreografie: Marco Gerris\nGeluid: Paul Gies van de Klink\n\nNetherlands 2010\n\nMeer informatie: http://www.mediafonds.nl/toekenning/79815/point-taken-hyperscape",
+                    "link": "https://vimeo.com/87786037",
+                    "duration": 529,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/87786037?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Hyperscape\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2014-02-27T17:20:22+00:00",
+                    "modified_time": "2016-09-13T12:07:32+00:00",
+                    "release_time": "2014-02-27T17:20:22+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": "by",
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "whitelist",
+                        "download": false,
+                        "add": true,
+                        "comments": "nobody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/87786037/pictures/466083556",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/466083556_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/466083556_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/466083556_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/466083556_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/466083556_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/466083556_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466083556_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "af998bad1f9c3df26d0e6e5a351966c78f731c73"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/hyperscape",
+                            "name": "Hyperscape",
+                            "tag": "Hyperscape",
+                            "canonical": "hyperscape",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hyperscape/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "50b31e878f52f1f022ab3c552e15f266b0f6502d"
+                        },
+                        {
+                            "uri": "/tags/mediafonds",
+                            "name": "Media Fonds",
+                            "tag": "Media Fonds",
+                            "canonical": "mediafonds",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mediafonds/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 73
+                                    }
+                                }
+                            },
+                            "resource_key": "a3d4fc853166b4998838dbeabaed7cc47f2eed65"
+                        },
+                        {
+                            "uri": "/tags/fondspodiumkunsten",
+                            "name": "Fonds Podiumkunsten",
+                            "tag": "Fonds Podiumkunsten",
+                            "canonical": "fondspodiumkunsten",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fondspodiumkunsten/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 30
+                                    }
+                                }
+                            },
+                            "resource_key": "53a27641d26986390c1cba743e4294e177098b69"
+                        },
+                        {
+                            "uri": "/tags/ntr",
+                            "name": "NTR",
+                            "tag": "NTR",
+                            "canonical": "ntr",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ntr/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 501
+                                    }
+                                }
+                            },
+                            "resource_key": "bc16790f12f0f469394d0996486cadbba9fcc9bf"
+                        },
+                        {
+                            "uri": "/tags/cinedans",
+                            "name": "Cinedans",
+                            "tag": "Cinedans",
+                            "canonical": "cinedans",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cinedans/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 134
+                                    }
+                                }
+                            },
+                            "resource_key": "af93bf72ebdbd5bc02b8ddec3cb2643ea3b8b5e9"
+                        },
+                        {
+                            "uri": "/tags/pointtaken",
+                            "name": "Point Taken",
+                            "tag": "Point Taken",
+                            "canonical": "pointtaken",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pointtaken/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 23
+                                    }
+                                }
+                            },
+                            "resource_key": "0f047fbcf1410371477d32c0dd6eefcb2cfe5ca7"
+                        },
+                        {
+                            "uri": "/tags/1",
+                            "name": "1",
+                            "tag": "1",
+                            "canonical": "1",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/1/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17116
+                                    }
+                                }
+                            },
+                            "resource_key": "5cc08549b4062479bbcca68151738a11a3a2062a"
+                        },
+                        {
+                            "uri": "/tags/stichtingballs",
+                            "name": "Stichting Balls",
+                            "tag": "Stichting Balls",
+                            "canonical": "stichtingballs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/stichtingballs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "79fe4d6053c8e84f1b9163957cdecafd8a1c073b"
+                        },
+                        {
+                            "uri": "/tags/wilkobello",
+                            "name": "Wilko Bello",
+                            "tag": "Wilko Bello",
+                            "canonical": "wilkobello",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/wilkobello/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5
+                                    }
+                                }
+                            },
+                            "resource_key": "bba5a36a27127399345c0ff23ce446efe4853b46"
+                        },
+                        {
+                            "uri": "/tags/marcogerris",
+                            "name": "Marco Gerris",
+                            "tag": "Marco Gerris",
+                            "canonical": "marcogerris",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/marcogerris/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 16
+                                    }
+                                }
+                            },
+                            "resource_key": "89f8331274bec9366666820706c0fa6727b9bc4e"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 487
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/87786037/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/87786037/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/87786037/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/87786037/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/87786037/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/25387665",
+                        "name": "Point Taken",
+                        "link": "https://vimeo.com/pointtaken",
+                        "location": "Netherlands",
+                        "bio": "Media Fonds and the Fonds Podiumkunsten, in collaboration with NTR and Cinedans present:\nPOINT TAKEN\nwww.pointtaken.nl",
+                        "created_time": "2014-02-23T23:49:37+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/25387665/pictures/7208586",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "91bf8a46fa27cd19a8bddf2f02df4afd743465ea"
+                        },
+                        "websites": [
+                            {
+                                "name": "Point Taken Official",
+                                "link": "http://www.pointtaken.nl/",
+                                "description": "Point Taken | Media Fonds"
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/25387665/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/25387665/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "appearances": {
+                                    "uri": "/users/25387665/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/25387665/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/25387665/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/25387665/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/25387665/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 113
+                                },
+                                "following": {
+                                    "uri": "/users/25387665/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/25387665/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/25387665/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/25387665/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/25387665/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/25387665/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 32
+                                },
+                                "watchlater": {
+                                    "uri": "/users/25387665/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/25387665/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/25387665/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "0bdc30c166c0e9d27fda1589dc40f3e20934e22c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231203480?s=87786037_1473803811_c88e83d092983a4d5f465a50ae32f284&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-02-27T19:30:55+00:00",
+                            "fps": 25,
+                            "size": 175406935,
+                            "md5": "03dc5daa16ca7785a431acc9a230b7d7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231203474?s=87786037_1473803811_4f1679a9c7194194511ec85614bd4957&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-02-27T19:30:54+00:00",
+                            "fps": 25,
+                            "size": 57155346,
+                            "md5": "b0eed677b3301c0c5358768b98755639"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231203480,231203474/hls?s=87786037_1473800211_7d8ab50b91fb5bad0327e9c82d17116a&oauth2_token_id=903107513",
+                            "created_time": "2014-02-27T19:30:55+00:00",
+                            "fps": 25,
+                            "size": 175406935,
+                            "md5": "03dc5daa16ca7785a431acc9a230b7d7",
+                            "link_secure": "https://player.vimeo.com/play/231203480,231203474/hls?s=87786037_1473800211_7d8ab50b91fb5bad0327e9c82d17116a&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231203480?s=87786037_2947596822_880ad09ee110b3cba788bb10747005bd&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hyperscape113.mp4",
+                            "created_time": "2014-02-27T19:30:55+00:00",
+                            "fps": 25,
+                            "size": 175406935,
+                            "md5": "03dc5daa16ca7785a431acc9a230b7d7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231203474?s=87786037_2947596822_a425fc8e97c5221c0fdb3420b244f254&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hyperscape112.mp4",
+                            "created_time": "2014-02-27T19:30:54+00:00",
+                            "fps": 25,
+                            "size": 57155346,
+                            "md5": "b0eed677b3301c0c5358768b98755639"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "40c97792f8a5fdc50fa923f61b3bda53a128dd3b",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/87913182",
+                    "name": "Hyperscape  - Making of",
+                    "description": "HYPERSCAPE - MAKING OF\nPoint Taken 1\n\nNetherlands 2010\nMeer informatie: mediafonds.nl/toekenning/79815/point-taken-hyperscape",
+                    "link": "https://vimeo.com/87913182",
+                    "duration": 515,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/87913182?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Hyperscape  - Making of\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2014-03-01T00:50:28+00:00",
+                    "modified_time": "2016-09-07T21:08:12+00:00",
+                    "release_time": "2014-03-01T00:50:28+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": "by",
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "whitelist",
+                        "download": false,
+                        "add": true,
+                        "comments": "nobody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/87913182/pictures/466342442",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/466342442_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/466342442_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/466342442_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/466342442_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/466342442_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/466342442_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466342442_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "46e201779494d2a6718bab6dfb0b4672eacd3f61"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/hyperscape",
+                            "name": "Hyperscape",
+                            "tag": "Hyperscape",
+                            "canonical": "hyperscape",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hyperscape/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "6163e3349dd7d64149bb0f115a9e07b11c4d2159"
+                        },
+                        {
+                            "uri": "/tags/mediafonds",
+                            "name": "Media Fonds",
+                            "tag": "Media Fonds",
+                            "canonical": "mediafonds",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mediafonds/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 73
+                                    }
+                                }
+                            },
+                            "resource_key": "b7b4f51a87b3ab00a5c13163a8c780b9d7968943"
+                        },
+                        {
+                            "uri": "/tags/fondspodiumkunsten",
+                            "name": "Fonds Podiumkunsten",
+                            "tag": "Fonds Podiumkunsten",
+                            "canonical": "fondspodiumkunsten",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fondspodiumkunsten/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 30
+                                    }
+                                }
+                            },
+                            "resource_key": "930afcb5c53251c04224e7a893f95ed904bf34bf"
+                        },
+                        {
+                            "uri": "/tags/ntr",
+                            "name": "NTR",
+                            "tag": "NTR",
+                            "canonical": "ntr",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ntr/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 501
+                                    }
+                                }
+                            },
+                            "resource_key": "14c160771f9b9d6342a23b1e59d31faee969013e"
+                        },
+                        {
+                            "uri": "/tags/cinedans",
+                            "name": "Cinedans",
+                            "tag": "Cinedans",
+                            "canonical": "cinedans",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cinedans/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 134
+                                    }
+                                }
+                            },
+                            "resource_key": "76d55705ba8d404617ffb1ef95798272e9481b49"
+                        },
+                        {
+                            "uri": "/tags/pointtaken",
+                            "name": "Point Taken",
+                            "tag": "Point Taken",
+                            "canonical": "pointtaken",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pointtaken/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 23
+                                    }
+                                }
+                            },
+                            "resource_key": "f9860f4339bd767d6a584dd5ffdecd6e7eb463fa"
+                        },
+                        {
+                            "uri": "/tags/1",
+                            "name": "1",
+                            "tag": "1",
+                            "canonical": "1",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/1/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17116
+                                    }
+                                }
+                            },
+                            "resource_key": "e75dfd79ad2c8725439affb92f4ee4216e40466a"
+                        },
+                        {
+                            "uri": "/tags/stichtingballs",
+                            "name": "Stichting Balls",
+                            "tag": "Stichting Balls",
+                            "canonical": "stichtingballs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/stichtingballs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "f39cab11b0439634aad482e7b0d25f23e4e212d6"
+                        },
+                        {
+                            "uri": "/tags/wilkobello",
+                            "name": "Wilko Bello",
+                            "tag": "Wilko Bello",
+                            "canonical": "wilkobello",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/wilkobello/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5
+                                    }
+                                }
+                            },
+                            "resource_key": "260239e898366820d572c4ec2becde4edacbbeb5"
+                        },
+                        {
+                            "uri": "/tags/marcogerris",
+                            "name": "Marco Gerris",
+                            "tag": "Marco Gerris",
+                            "canonical": "marcogerris",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/marcogerris/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 16
+                                    }
+                                }
+                            },
+                            "resource_key": "3fe0140b61dcbe67ace86e44c44eda3024ac78af"
+                        },
+                        {
+                            "uri": "/tags/makingof",
+                            "name": "Making of",
+                            "tag": "Making of",
+                            "canonical": "makingof",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/makingof/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 40931
+                                    }
+                                }
+                            },
+                            "resource_key": "d50fe586078c01c8f5f78aaafdd6ec8869387d1d"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 454
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/87913182/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/87913182/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/87913182/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "pictures": {
+                                "uri": "/videos/87913182/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/87913182/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/25387665",
+                        "name": "Point Taken",
+                        "link": "https://vimeo.com/pointtaken",
+                        "location": "Netherlands",
+                        "bio": "Media Fonds and the Fonds Podiumkunsten, in collaboration with NTR and Cinedans present:\nPOINT TAKEN\nwww.pointtaken.nl",
+                        "created_time": "2014-02-23T23:49:37+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/25387665/pictures/7208586",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "91bf8a46fa27cd19a8bddf2f02df4afd743465ea"
+                        },
+                        "websites": [
+                            {
+                                "name": "Point Taken Official",
+                                "link": "http://www.pointtaken.nl/",
+                                "description": "Point Taken | Media Fonds"
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/25387665/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/25387665/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "appearances": {
+                                    "uri": "/users/25387665/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/25387665/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/25387665/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/25387665/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/25387665/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 113
+                                },
+                                "following": {
+                                    "uri": "/users/25387665/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/25387665/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/25387665/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/25387665/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/25387665/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/25387665/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 32
+                                },
+                                "watchlater": {
+                                    "uri": "/users/25387665/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/25387665/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/25387665/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "0bdc30c166c0e9d27fda1589dc40f3e20934e22c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231608201?s=87913182_1473803811_205eba5abd6c6634685536f8590105ee&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T02:49:25+00:00",
+                            "fps": 25,
+                            "size": 171590049,
+                            "md5": "e10db356e66788c184908f7b3f78b342"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231608200?s=87913182_1473803811_cf491d11c2b35316f5352e2935b7e009&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T02:49:25+00:00",
+                            "fps": 25,
+                            "size": 53907974,
+                            "md5": "45730749e4571561d7f45b4a65e3fcbf"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231608201,231608200/hls?s=87913182_1473800211_a7da0712759484cbc1401cc624ed1329&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T02:49:25+00:00",
+                            "fps": 25,
+                            "size": 171590049,
+                            "md5": "e10db356e66788c184908f7b3f78b342",
+                            "link_secure": "https://player.vimeo.com/play/231608201,231608200/hls?s=87913182_1473800211_a7da0712759484cbc1401cc624ed1329&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231608201?s=87913182_2947596822_be30a6618e0bf1b854ae2bc0479d0e33&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hyperscape%2B%2B-%2BMaking%2Bof113.mp4",
+                            "created_time": "2014-03-01T02:49:25+00:00",
+                            "fps": 25,
+                            "size": 171590049,
+                            "md5": "e10db356e66788c184908f7b3f78b342"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231608200?s=87913182_2947596822_4b4286b88e8491a26f6a99758656249e&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hyperscape%2B%2B-%2BMaking%2Bof112.mp4",
+                            "created_time": "2014-03-01T02:49:25+00:00",
+                            "fps": 25,
+                            "size": 53907974,
+                            "md5": "45730749e4571561d7f45b4a65e3fcbf"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "60e8a52ddecfd793f60077db67515a7819efe811",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/87934029",
+                    "name": "Hypnagogia: A borderland state",
+                    "description": "HYPNAGOGIA\nPoint Taken 2\n\nDansfilm over de overgangssituatie tussen waken en slapen, hypnagogia. Een choreograaf die worstelt met zijn nieuwe creatie vindt tijdens een droom de sleutel tot zijn stuk. Point Taken is een project waarbij vier teams van in Nederland wonende en werkende choreografen en filmmakers gezamenlijk een dansfilm maken.\n\nExtern producent: Family Affair Films\n\nRegie: Frank Scheffer\nCamera: Melle van Essen\nMontage: Riekje Ziengs\nChoreografie: Muhanad Rasheed\nGeluid: Menno Euwe\n\nNetherlands 2011\n\nMeer informatie: http://www.mediafonds.nl/toekenning/85304/point-taken-hypnagogia",
+                    "link": "https://vimeo.com/87934029",
+                    "duration": 748,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/87934029?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Hypnagogia: A borderland state\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2014-03-01T12:53:13+00:00",
+                    "modified_time": "2016-09-10T13:09:04+00:00",
+                    "release_time": "2014-03-01T12:53:13+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": "by",
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "whitelist",
+                        "download": false,
+                        "add": true,
+                        "comments": "nobody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/87934029/pictures/466343594",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/466343594_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/466343594_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/466343594_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/466343594_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/466343594_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/466343594_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/466343594_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "55c2dee6bc4a13e8606b8d25a0e19cbfff6188c3"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/pointtaken",
+                            "name": "Point Taken",
+                            "tag": "Point Taken",
+                            "canonical": "pointtaken",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pointtaken/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 23
+                                    }
+                                }
+                            },
+                            "resource_key": "e4e70904074c455b19bb5cb6372a8a0394d4dcab"
+                        },
+                        {
+                            "uri": "/tags/2",
+                            "name": "2",
+                            "tag": "2",
+                            "canonical": "2",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/2/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 22658
+                                    }
+                                }
+                            },
+                            "resource_key": "c85854a2ad4ea58df7ec939acc4eb518288bf208"
+                        },
+                        {
+                            "uri": "/tags/mediafonds",
+                            "name": "Media Fonds",
+                            "tag": "Media Fonds",
+                            "canonical": "mediafonds",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mediafonds/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 73
+                                    }
+                                }
+                            },
+                            "resource_key": "a2bd8aab41a7b946b7ea9ed00584aa9760c9928b"
+                        },
+                        {
+                            "uri": "/tags/fondspodiumkunsten",
+                            "name": "Fonds Podiumkunsten",
+                            "tag": "Fonds Podiumkunsten",
+                            "canonical": "fondspodiumkunsten",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fondspodiumkunsten/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 30
+                                    }
+                                }
+                            },
+                            "resource_key": "cb3fa64728837885ea805aabf0b7012b25e0fbd5"
+                        },
+                        {
+                            "uri": "/tags/ntr",
+                            "name": "NTR",
+                            "tag": "NTR",
+                            "canonical": "ntr",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ntr/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 501
+                                    }
+                                }
+                            },
+                            "resource_key": "0b4243a5097c5918b037c030fc758f9e8eed6f68"
+                        },
+                        {
+                            "uri": "/tags/cinedans",
+                            "name": "Cinedans",
+                            "tag": "Cinedans",
+                            "canonical": "cinedans",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cinedans/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 134
+                                    }
+                                }
+                            },
+                            "resource_key": "3ad62c77714023919299ad72c5b0b77ee8dd188a"
+                        },
+                        {
+                            "uri": "/tags/hypnagogia",
+                            "name": "Hypnagogia",
+                            "tag": "Hypnagogia",
+                            "canonical": "hypnagogia",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hypnagogia/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 94
+                                    }
+                                }
+                            },
+                            "resource_key": "40dd5869dadb39065b93011d855d86cf20b9559f"
+                        },
+                        {
+                            "uri": "/tags/familyaffairfilms",
+                            "name": "Family Affair Films",
+                            "tag": "Family Affair Films",
+                            "canonical": "familyaffairfilms",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/familyaffairfilms/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 12
+                                    }
+                                }
+                            },
+                            "resource_key": "57b9ef6bddd270ecc5d1f24e91302f043d2f3a56"
+                        },
+                        {
+                            "uri": "/tags/frankscheffer",
+                            "name": "Frank Scheffer",
+                            "tag": "Frank Scheffer",
+                            "canonical": "frankscheffer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/frankscheffer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7
+                                    }
+                                }
+                            },
+                            "resource_key": "c80b31dc9feae62c183f6d542fc8245ec7b96f6a"
+                        },
+                        {
+                            "uri": "/tags/mellevanessen",
+                            "name": "Melle van Essen",
+                            "tag": "Melle van Essen",
+                            "canonical": "mellevanessen",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mellevanessen/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 10
+                                    }
+                                }
+                            },
+                            "resource_key": "87ba1eb864f9225237f3cae8ccc979964d964d35"
+                        },
+                        {
+                            "uri": "/tags/riekjeziengs",
+                            "name": "Riekje Ziengs",
+                            "tag": "Riekje Ziengs",
+                            "canonical": "riekjeziengs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/riekjeziengs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3
+                                    }
+                                }
+                            },
+                            "resource_key": "6d3492f2453bfaac9be977aa978a143e2010df16"
+                        },
+                        {
+                            "uri": "/tags/muhanadrasheed",
+                            "name": "Muhanad Rasheed",
+                            "tag": "Muhanad Rasheed",
+                            "canonical": "muhanadrasheed",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/muhanadrasheed/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "8fd5f9c2fdc0f177f40c6c9d77acef78c43b6cf7"
+                        },
+                        {
+                            "uri": "/tags/mennoeuwe",
+                            "name": "Menno Euwe",
+                            "tag": "Menno Euwe",
+                            "canonical": "mennoeuwe",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mennoeuwe/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "5c428e37de1a5976ebdb7ae13d870dcc9c998024"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 519
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/87934029/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/87934029/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/87934029/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "pictures": {
+                                "uri": "/videos/87934029/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/87934029/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/25387665",
+                        "name": "Point Taken",
+                        "link": "https://vimeo.com/pointtaken",
+                        "location": "Netherlands",
+                        "bio": "Media Fonds and the Fonds Podiumkunsten, in collaboration with NTR and Cinedans present:\nPOINT TAKEN\nwww.pointtaken.nl",
+                        "created_time": "2014-02-23T23:49:37+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/25387665/pictures/7208586",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "91bf8a46fa27cd19a8bddf2f02df4afd743465ea"
+                        },
+                        "websites": [
+                            {
+                                "name": "Point Taken Official",
+                                "link": "http://www.pointtaken.nl/",
+                                "description": "Point Taken | Media Fonds"
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/25387665/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/25387665/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "appearances": {
+                                    "uri": "/users/25387665/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/25387665/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/25387665/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/25387665/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/25387665/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 113
+                                },
+                                "following": {
+                                    "uri": "/users/25387665/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/25387665/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/25387665/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/25387665/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/25387665/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/25387665/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 32
+                                },
+                                "watchlater": {
+                                    "uri": "/users/25387665/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/25387665/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/25387665/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "0bdc30c166c0e9d27fda1589dc40f3e20934e22c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231674101?s=87934029_1473803811_cc7e30019d35c6fd1cbf8ae037e1b38b&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T15:31:04+00:00",
+                            "fps": 25,
+                            "size": 249585009,
+                            "md5": "14f3f3cb41c06c6e155d9c1eada7e19d"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231674093?s=87934029_1473803811_de94dbf661cce34b10cb1b0908189886&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T15:31:04+00:00",
+                            "fps": 25,
+                            "size": 72680270,
+                            "md5": "e291b7b40b4259bdc384e96468e8fb3a"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231674101,231674093/hls?s=87934029_1473800211_76b7617ebead8703841382918a2a60f0&oauth2_token_id=903107513",
+                            "created_time": "2014-03-01T15:31:04+00:00",
+                            "fps": 25,
+                            "size": 249585009,
+                            "md5": "14f3f3cb41c06c6e155d9c1eada7e19d",
+                            "link_secure": "https://player.vimeo.com/play/231674101,231674093/hls?s=87934029_1473800211_76b7617ebead8703841382918a2a60f0&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231674101?s=87934029_2947596822_6b27aacef7fec67258d7d446250e0ae7&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hypnagogia%253A%2BA%2Bborderland%2Bstate113.mp4",
+                            "created_time": "2014-03-01T15:31:04+00:00",
+                            "fps": 25,
+                            "size": 249585009,
+                            "md5": "14f3f3cb41c06c6e155d9c1eada7e19d"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/231674093?s=87934029_2947596822_ba9253061c8caeec74daa41b8280208f&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hypnagogia%253A%2BA%2Bborderland%2Bstate112.mp4",
+                            "created_time": "2014-03-01T15:31:04+00:00",
+                            "fps": 25,
+                            "size": 72680270,
+                            "md5": "e291b7b40b4259bdc384e96468e8fb3a"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "632c477dac45f423e93577bd31539aaac7f261d2",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/89203159",
+                    "name": "Hypnagogia: A borderline state - Making of",
+                    "description": "HYPNAGOGIA: A BORDERLINE STATE - MAKING OF \nPoint Taken 2\n\nNederlands 2011\nMeer informatie: http://www.mediafonds.nl/toekenning/85304/point-taken-hypnagogia",
+                    "link": "https://vimeo.com/89203159",
+                    "duration": 299,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/89203159?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Hypnagogia: A borderline state - Making of\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2014-03-15T22:30:49+00:00",
+                    "modified_time": "2016-08-19T10:12:26+00:00",
+                    "release_time": "2014-03-15T22:30:49+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": "by",
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "whitelist",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/89203159/pictures/467865924",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/467865924_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/467865924_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/467865924_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/467865924_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/467865924_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/467865924_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/467865924_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "aae2ceefa4c813b686659f6702e52e42cafa2c54"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/pointtaken",
+                            "name": "Point Taken",
+                            "tag": "Point Taken",
+                            "canonical": "pointtaken",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pointtaken/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 23
+                                    }
+                                }
+                            },
+                            "resource_key": "de3d1e127b0f50d845dfc7c404c446684a553e1c"
+                        },
+                        {
+                            "uri": "/tags/2",
+                            "name": "2",
+                            "tag": "2",
+                            "canonical": "2",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/2/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 22658
+                                    }
+                                }
+                            },
+                            "resource_key": "0f95f67415229c86ea6be6179d0605f3eb2e5bf5"
+                        },
+                        {
+                            "uri": "/tags/mediafonds",
+                            "name": "Media Fonds",
+                            "tag": "Media Fonds",
+                            "canonical": "mediafonds",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mediafonds/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 73
+                                    }
+                                }
+                            },
+                            "resource_key": "7693e9e36b295b28605156e0e4df84e3f2423515"
+                        },
+                        {
+                            "uri": "/tags/fondspodiumkunsten",
+                            "name": "Fonds Podiumkunsten",
+                            "tag": "Fonds Podiumkunsten",
+                            "canonical": "fondspodiumkunsten",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fondspodiumkunsten/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 30
+                                    }
+                                }
+                            },
+                            "resource_key": "5b6f117b19acdbc07b60ae5b3ff491816aadcee3"
+                        },
+                        {
+                            "uri": "/tags/ntr",
+                            "name": "NTR",
+                            "tag": "NTR",
+                            "canonical": "ntr",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ntr/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 501
+                                    }
+                                }
+                            },
+                            "resource_key": "b7894e7429030b8e94c89a91e8cce06ff825df4a"
+                        },
+                        {
+                            "uri": "/tags/cinedans",
+                            "name": "Cinedans",
+                            "tag": "Cinedans",
+                            "canonical": "cinedans",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cinedans/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 134
+                                    }
+                                }
+                            },
+                            "resource_key": "270bd4084587b7b1dbe858fad4d26fa7af4be46e"
+                        },
+                        {
+                            "uri": "/tags/hypnagogia",
+                            "name": "Hypnagogia",
+                            "tag": "Hypnagogia",
+                            "canonical": "hypnagogia",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hypnagogia/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 94
+                                    }
+                                }
+                            },
+                            "resource_key": "cd76138fd87eb6d37ea31effae37b5225bd5acbe"
+                        },
+                        {
+                            "uri": "/tags/familyaffairfilms",
+                            "name": "Family Affair Films",
+                            "tag": "Family Affair Films",
+                            "canonical": "familyaffairfilms",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/familyaffairfilms/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 12
+                                    }
+                                }
+                            },
+                            "resource_key": "b2e537f418ea1f42eb306d0ece5f56c1325ad879"
+                        },
+                        {
+                            "uri": "/tags/frankscheffer",
+                            "name": "Frank Scheffer",
+                            "tag": "Frank Scheffer",
+                            "canonical": "frankscheffer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/frankscheffer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7
+                                    }
+                                }
+                            },
+                            "resource_key": "3fa8ca0447807d5914ab8055e3981f036f1119c7"
+                        },
+                        {
+                            "uri": "/tags/mellevanessen",
+                            "name": "Melle van Essen",
+                            "tag": "Melle van Essen",
+                            "canonical": "mellevanessen",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mellevanessen/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 10
+                                    }
+                                }
+                            },
+                            "resource_key": "dc242461b73a0632612c9211a6acf3c1b8441fb7"
+                        },
+                        {
+                            "uri": "/tags/riekjeziengs",
+                            "name": "Riekje Ziengs",
+                            "tag": "Riekje Ziengs",
+                            "canonical": "riekjeziengs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/riekjeziengs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3
+                                    }
+                                }
+                            },
+                            "resource_key": "5a7130eb4d0c8fac13b6b9b8cc14427f8c6236b2"
+                        },
+                        {
+                            "uri": "/tags/muhanadrasheed",
+                            "name": "Muhanad Rasheed",
+                            "tag": "Muhanad Rasheed",
+                            "canonical": "muhanadrasheed",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/muhanadrasheed/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4
+                                    }
+                                }
+                            },
+                            "resource_key": "8c1919cebe6f8165a210190389ef12575b75f843"
+                        },
+                        {
+                            "uri": "/tags/mennoeuwe",
+                            "name": "Menno Euwe",
+                            "tag": "Menno Euwe",
+                            "canonical": "mennoeuwe",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mennoeuwe/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "c905235048513aaa7866160f103e5f09ed91c065"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 186
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/89203159/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/89203159/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/89203159/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/89203159/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/89203159/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/25387665",
+                        "name": "Point Taken",
+                        "link": "https://vimeo.com/pointtaken",
+                        "location": "Netherlands",
+                        "bio": "Media Fonds and the Fonds Podiumkunsten, in collaboration with NTR and Cinedans present:\nPOINT TAKEN\nwww.pointtaken.nl",
+                        "created_time": "2014-02-23T23:49:37+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/25387665/pictures/7208586",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/7208586_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "91bf8a46fa27cd19a8bddf2f02df4afd743465ea"
+                        },
+                        "websites": [
+                            {
+                                "name": "Point Taken Official",
+                                "link": "http://www.pointtaken.nl/",
+                                "description": "Point Taken | Media Fonds"
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/25387665/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/25387665/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "appearances": {
+                                    "uri": "/users/25387665/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/25387665/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/25387665/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/25387665/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/25387665/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 113
+                                },
+                                "following": {
+                                    "uri": "/users/25387665/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/25387665/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/25387665/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/25387665/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/25387665/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/25387665/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 32
+                                },
+                                "watchlater": {
+                                    "uri": "/users/25387665/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/25387665/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/25387665/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "0bdc30c166c0e9d27fda1589dc40f3e20934e22c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/235620621?s=89203159_1473803811_895052b9d07b8dd78cd908bbbb112e7f&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-16T00:25:20+00:00",
+                            "fps": 25,
+                            "size": 74242287,
+                            "md5": "00d51f62f4d5b8e93c8133f53f85163d"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/235620620?s=89203159_1473803811_62758d34ff18098b4246a61bf8c77420&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2014-03-16T00:25:20+00:00",
+                            "fps": 25,
+                            "size": 21680202,
+                            "md5": "6ba97f7cb69b6549207c2d730558722e"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/235620621,235620620/hls?s=89203159_1473800211_38f65a474302a428bf133e29d01c1465&oauth2_token_id=903107513",
+                            "created_time": "2014-03-16T00:25:20+00:00",
+                            "fps": 25,
+                            "size": 74242287,
+                            "md5": "00d51f62f4d5b8e93c8133f53f85163d",
+                            "link_secure": "https://player.vimeo.com/play/235620621,235620620/hls?s=89203159_1473800211_38f65a474302a428bf133e29d01c1465&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/235620621?s=89203159_2947596822_7966b72878acee41a8250fa9fd79116f&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hypnagogia%253A%2BA%2Bborderline%2Bstate%2B-%2BMaking%2Bof113.mp4",
+                            "created_time": "2014-03-16T00:25:20+00:00",
+                            "fps": 25,
+                            "size": 74242287,
+                            "md5": "00d51f62f4d5b8e93c8133f53f85163d"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/235620620?s=89203159_2947596822_3ab284eb70155f94610761d061b6c94d&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Hypnagogia%253A%2BA%2Bborderline%2Bstate%2B-%2BMaking%2Bof112.mp4",
+                            "created_time": "2014-03-16T00:25:20+00:00",
+                            "fps": 25,
+                            "size": 21680202,
+                            "md5": "6ba97f7cb69b6549207c2d730558722e"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "70a786d7436d64d463119076e18a021398cae042",
+                    "embed_presets": null
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/narrative/subcategories/drama/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 7279
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/narrative/subcategories/drama",
+                "name": "Drama",
+                "link": "https://vimeo.com/categories/narrative/drama/videos",
+                "top_level": false,
+                "pictures": {
+                    "uri": "/videos/182556168/pictures/591498077",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/591498077_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591498077_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/591498077_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591498077_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/591498077_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591498077_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 270,
+                            "link": "https://i.vimeocdn.com/video/591498077_640x270.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591498077_640x270.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 405,
+                            "link": "https://i.vimeocdn.com/video/591498077_960x405.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591498077_960x405.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "6ee98e84f77c9a0af7315c34427e0a4aa6ce26d8"
+                },
+                "last_video_featured_time": null,
+                "parent": {
+                    "uri": "/categories/narrative",
+                    "name": "Narrative",
+                    "link": "https://vimeo.com/categories/narrative"
+                },
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/narrative/subcategories/drama/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 2
+                        },
+                        "groups": {
+                            "uri": "/categories/narrative/subcategories/drama/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 1
+                        },
+                        "users": {
+                            "uri": "/categories/narrative/subcategories/drama/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 57
+                        },
+                        "videos": {
+                            "uri": "/categories/narrative/subcategories/drama/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 7279
+                        }
+                    }
+                },
+                "resource_key": "27f95812efa999d7a87a97cee46724e8347c69b4"
+            }
+        },
+        {
+            "uri": "/categories/sports",
+            "name": "Sports",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/1491494",
+                    "name": "Mt Tremblant with COMSCC - Les driving my Miata",
+                    "description": "Mt Tremblant - August 5, 2008\nLes driving my Miata during open practice the morning of time trials.",
+                    "link": "https://vimeo.com/1491494",
+                    "duration": 586,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1491494?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Mt Tremblant with COMSCC - Les driving my Miata\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-08-08T14:06:35+00:00",
+                    "modified_time": "2016-09-13T11:10:58+00:00",
+                    "release_time": "2008-08-08T14:06:35+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1491494/pictures/59272798",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/59272798_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/59272798_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/59272798_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/59272798_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/59272798_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/59272798_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59272798_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "e515243f54ab87f0c6c2d92a8b7af28401eff280"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/comscc",
+                            "name": "COMSCC",
+                            "tag": "COMSCC",
+                            "canonical": "comscc",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/comscc/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 56
+                                    }
+                                }
+                            },
+                            "resource_key": "e3e3dd239fb2c2181bccae8e2c2703b9f987030a"
+                        },
+                        {
+                            "uri": "/tags/mttremblant",
+                            "name": "Mt Tremblant",
+                            "tag": "Mt Tremblant",
+                            "canonical": "mttremblant",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mttremblant/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8
+                                    }
+                                }
+                            },
+                            "resource_key": "2de822a4be04916240f91ac7176588471e3269bd"
+                        },
+                        {
+                            "uri": "/tags/miata",
+                            "name": "Miata",
+                            "tag": "Miata",
+                            "canonical": "miata",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/miata/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1863
+                                    }
+                                }
+                            },
+                            "resource_key": "ab5e6dd699686939f838254110fb5f3e809292d7"
+                        },
+                        {
+                            "uri": "/tags/timetrial",
+                            "name": "Time Trial",
+                            "tag": "Time Trial",
+                            "canonical": "timetrial",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/timetrial/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 527
+                                    }
+                                }
+                            },
+                            "resource_key": "1c0ebb56b362bf77c7ab3fe69be83f859d371a0d"
+                        },
+                        {
+                            "uri": "/tags/track",
+                            "name": "Track",
+                            "tag": "Track",
+                            "canonical": "track",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/track/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 15912
+                                    }
+                                }
+                            },
+                            "resource_key": "4a8a82d9cf0a94bf5fb37108e478e8817574a2fe"
+                        },
+                        {
+                            "uri": "/tags/hpde",
+                            "name": "HPDE",
+                            "tag": "HPDE",
+                            "canonical": "hpde",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hpde/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 957
+                                    }
+                                }
+                            },
+                            "resource_key": "dfd6d8da03f2f80743a1285a79ad0564a631d36d"
+                        },
+                        {
+                            "uri": "/tags/comsportscarclub",
+                            "name": "COM Sports Car Club",
+                            "tag": "COM Sports Car Club",
+                            "canonical": "comsportscarclub",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/comsportscarclub/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 19
+                                    }
+                                }
+                            },
+                            "resource_key": "3fb2717a21b4d9805525e4e439db0c44da406af4"
+                        },
+                        {
+                            "uri": "/tags/2008",
+                            "name": "2008",
+                            "tag": "2008",
+                            "canonical": "2008",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/2008/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 28467
+                                    }
+                                }
+                            },
+                            "resource_key": "74904dd7bffc2aab0972af1110f0059452392cde"
+                        },
+                        {
+                            "uri": "/tags/lecircuitmonttremblant",
+                            "name": "Le Circuit Mont Tremblant",
+                            "tag": "Le Circuit Mont Tremblant",
+                            "canonical": "lecircuitmonttremblant",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/lecircuitmonttremblant/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3
+                                    }
+                                }
+                            },
+                            "resource_key": "f08414c8ac4320b1b47e4ce1651752b4371d7c3b"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 1973
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1491494/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1491494/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1491494/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 3
+                            },
+                            "pictures": {
+                                "uri": "/videos/1491494/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1491494/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/499605",
+                        "name": "WillM",
+                        "link": "https://vimeo.com/user499605",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-05-24T03:15:52+00:00",
+                        "account": "plus",
+                        "pictures": null,
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/499605/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/499605/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/499605/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/499605/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/499605/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/499605/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/499605/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 4
+                                },
+                                "following": {
+                                    "uri": "/users/499605/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/499605/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/499605/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/499605/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/499605/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/499605/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 30
+                                },
+                                "watchlater": {
+                                    "uri": "/users/499605/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/499605/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/499605/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 0
+                                }
+                            }
+                        },
+                        "resource_key": "f435aa22b91e2209d49dfa5926545ae2334662c9",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452670929?s=1491494_1473803811_cab7ffed013a61cb2975da70e97fa69a&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T00:37:55+00:00",
+                            "fps": 24,
+                            "size": 193383533,
+                            "md5": "787ca6092e546015404b98f57a1b1cc7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452670926?s=1491494_1473803811_ff14c61493665dc723e3e7ae8c070db6&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T00:37:55+00:00",
+                            "fps": 24,
+                            "size": 62652573,
+                            "md5": "0a8a20a5003b6e371813d03901f1362f"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452670929,452670926/hls?s=1491494_1473800211_9630453355afa375955dd05de7206a85&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T00:37:55+00:00",
+                            "fps": 24,
+                            "size": 193383533,
+                            "md5": "787ca6092e546015404b98f57a1b1cc7",
+                            "link_secure": "https://player.vimeo.com/play/452670929,452670926/hls?s=1491494_1473800211_9630453355afa375955dd05de7206a85&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452670929?s=1491494_2947596822_032d457b2e03bb58b2bb0c5d24afa26c&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Mt%2BTremblant%2Bwith%2BCOMSCC%2B-%2BLes%2Bdriving%2Bmy%2BMiata113.mp4",
+                            "created_time": "2015-12-13T00:37:55+00:00",
+                            "fps": 24,
+                            "size": 193383533,
+                            "md5": "787ca6092e546015404b98f57a1b1cc7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452670926?s=1491494_2947596822_a66131316134c837dcdb5f21a35a61a8&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Mt%2BTremblant%2Bwith%2BCOMSCC%2B-%2BLes%2Bdriving%2Bmy%2BMiata112.mp4",
+                            "created_time": "2015-12-13T00:37:55+00:00",
+                            "fps": 24,
+                            "size": 62652573,
+                            "md5": "0a8a20a5003b6e371813d03901f1362f"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "6d9829c6bdb7fbe58889f660249eb4b81fdccef2",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/1494904",
+                    "name": "COM at tremblant 8/4/08 group 1 drivers",
+                    "description": null,
+                    "link": "https://vimeo.com/1494904",
+                    "duration": 194,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1494904?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"COM at tremblant 8/4/08 group 1 drivers\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-08-09T01:06:33+00:00",
+                    "modified_time": "2016-09-13T02:09:55+00:00",
+                    "release_time": "2008-08-09T01:06:33+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1494904/pictures/59297590",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/59297590_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/59297590_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/59297590_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/59297590_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/59297590_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/59297590_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59297590_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "667d57a3ca64bfc7f15c62fc2a75472febb723ed"
+                    },
+                    "tags": [],
+                    "stats": {
+                        "plays": 784
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1494904/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1494904/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1494904/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 3
+                            },
+                            "pictures": {
+                                "uri": "/videos/1494904/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1494904/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/526388",
+                        "name": "ted d",
+                        "link": "https://vimeo.com/nhsilversti",
+                        "location": "southern, NH",
+                        "bio": null,
+                        "created_time": "2008-06-07T22:55:35+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/526388/pictures/1071348",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "794f3c7d3f33c775153e1b0eece8b2d0da5d5c9b"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/526388/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/526388/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/526388/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/526388/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/526388/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/526388/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/526388/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "following": {
+                                    "uri": "/users/526388/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "groups": {
+                                    "uri": "/users/526388/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/526388/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/526388/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/526388/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/526388/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "watchlater": {
+                                    "uri": "/users/526388/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/526388/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/526388/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "83867e0b90a4c965f9ec6dd58029c644556f849c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452681795?s=1494904_1473803811_23495af9aaa5659633e545858bc00c69&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T01:33:10+00:00",
+                            "fps": 24,
+                            "size": 20719059,
+                            "md5": "9c48b2eeda160671c13059646b0ac146"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452681791?s=1494904_1473803811_9e1019cc873d7ef8fd1d616f54466c32&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T01:33:09+00:00",
+                            "fps": 24,
+                            "size": 64229045,
+                            "md5": "4406c64264b5c0098fe3c7aa110d8d44"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452681795,452681791/hls?s=1494904_1473800211_136a8612520b42fa10b3f55da5bc11ec&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T01:33:10+00:00",
+                            "fps": 24,
+                            "size": 20719059,
+                            "md5": "9c48b2eeda160671c13059646b0ac146",
+                            "link_secure": "https://player.vimeo.com/play/452681795,452681791/hls?s=1494904_1473800211_136a8612520b42fa10b3f55da5bc11ec&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452681795?s=1494904_2947596822_7f1476cd6e619dcc6de21e5a3bdb5733&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=COM%2Bat%2Btremblant%2B8%252F4%252F08%2Bgroup%2B1%2Bdrivers112.mp4",
+                            "created_time": "2015-12-13T01:33:10+00:00",
+                            "fps": 24,
+                            "size": 20719059,
+                            "md5": "9c48b2eeda160671c13059646b0ac146"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/452681791?s=1494904_2947596822_cf30449d7132f5418bb0b481ddeeec2d&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=COM%2Bat%2Btremblant%2B8%252F4%252F08%2Bgroup%2B1%2Bdrivers113.mp4",
+                            "created_time": "2015-12-13T01:33:09+00:00",
+                            "fps": 24,
+                            "size": 64229045,
+                            "md5": "4406c64264b5c0098fe3c7aa110d8d44"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "575ff453428612231486c16a1dddf1c02d06ae07",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/1741892",
+                    "name": "mosport time trial laps with COM scc",
+                    "description": "2006 subaru wrx sti time trial laps from mosport.  \nlap 1 is warm up lap\nlap 2 is 1st hot lap, 1:36.828\nlap 3 is 2nd hot lap, 1:36.016\nlap 4 is the final hot lap 1:35.485 which set the class (SPB) track record.\nlap 5 is a cooldown lap\ninfo about these time trails/track days can be found here\nwww.comscc.org",
+                    "link": "https://vimeo.com/1741892",
+                    "duration": 547,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1741892?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"mosport time trial laps with COM scc\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-09-16T02:03:41+00:00",
+                    "modified_time": "2016-09-13T02:12:00+00:00",
+                    "release_time": "2008-09-16T02:03:41+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1741892/pictures/62854815",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/62854815_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/62854815_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/62854815_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/62854815_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/62854815_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/62854815_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/62854815_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "01ae9fd6d6c1deac2a9463699b295f1d779f6bc6"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/com",
+                            "name": "COM",
+                            "tag": "COM",
+                            "canonical": "com",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/com/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2287
+                                    }
+                                }
+                            },
+                            "resource_key": "8063e9542064ad6f8c72c1150d16b7ef8db97e11"
+                        },
+                        {
+                            "uri": "/tags/timetrails",
+                            "name": "time trails",
+                            "tag": "time trails",
+                            "canonical": "timetrails",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/timetrails/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11
+                                    }
+                                }
+                            },
+                            "resource_key": "f10597960fb955aa08c5905647d57ccce1f41ea3"
+                        },
+                        {
+                            "uri": "/tags/subaru",
+                            "name": "subaru",
+                            "tag": "subaru",
+                            "canonical": "subaru",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/subaru/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8999
+                                    }
+                                }
+                            },
+                            "resource_key": "8038145606b0cf6729b1426fe755357f19cf6b34"
+                        },
+                        {
+                            "uri": "/tags/trackdays",
+                            "name": "track days",
+                            "tag": "track days",
+                            "canonical": "trackdays",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/trackdays/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 300
+                                    }
+                                }
+                            },
+                            "resource_key": "b095761b89d0407799b96d6ab0cf3da8b089209b"
+                        },
+                        {
+                            "uri": "/tags/hpde",
+                            "name": "hpde",
+                            "tag": "hpde",
+                            "canonical": "hpde",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hpde/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 957
+                                    }
+                                }
+                            },
+                            "resource_key": "193df07a44a558532fc86c90c3a49e38cdc3b64d"
+                        },
+                        {
+                            "uri": "/tags/driving",
+                            "name": "driving",
+                            "tag": "driving",
+                            "canonical": "driving",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/driving/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17792
+                                    }
+                                }
+                            },
+                            "resource_key": "57bb5632ebd8ab85d74373050caebcf935cc81d8"
+                        },
+                        {
+                            "uri": "/tags/sti",
+                            "name": "sti",
+                            "tag": "sti",
+                            "canonical": "sti",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sti/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2404
+                                    }
+                                }
+                            },
+                            "resource_key": "fc79972d0d32b63c832d349d123cc480c4f23634"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 1052
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1741892/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1741892/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1741892/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/1741892/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1741892/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/526388",
+                        "name": "ted d",
+                        "link": "https://vimeo.com/nhsilversti",
+                        "location": "southern, NH",
+                        "bio": null,
+                        "created_time": "2008-06-07T22:55:35+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/526388/pictures/1071348",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1071348_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "794f3c7d3f33c775153e1b0eece8b2d0da5d5c9b"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/526388/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/526388/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/526388/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/526388/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/526388/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/526388/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/526388/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "following": {
+                                    "uri": "/users/526388/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "groups": {
+                                    "uri": "/users/526388/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/526388/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/526388/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/526388/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/526388/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "watchlater": {
+                                    "uri": "/users/526388/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/526388/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/526388/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "83867e0b90a4c965f9ec6dd58029c644556f849c",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/454167880?s=1741892_1473803811_2619f5fc6402c29663ee30875a0b86df&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-16T06:57:10+00:00",
+                            "fps": 24,
+                            "size": 58329430,
+                            "md5": "eb6a47b3883b3b37394615ff949d688c"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/454167879?s=1741892_1473803811_7318371744e3de71fdcf98f9c603dcdf&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-16T06:57:10+00:00",
+                            "fps": 24,
+                            "size": 181283182,
+                            "md5": "497538f7dfcfc10f604483d7ecf4c4ea"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/454167880,454167879/hls?s=1741892_1473800211_ef9b93367d4739efa8f6f7e116120c2c&oauth2_token_id=903107513",
+                            "created_time": "2015-12-16T06:57:10+00:00",
+                            "fps": 24,
+                            "size": 58329430,
+                            "md5": "eb6a47b3883b3b37394615ff949d688c",
+                            "link_secure": "https://player.vimeo.com/play/454167880,454167879/hls?s=1741892_1473800211_ef9b93367d4739efa8f6f7e116120c2c&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/454167880?s=1741892_2947596822_1c39d83fb213e90e6e3ef1818b7e40ac&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=mosport%2Btime%2Btrial%2Blaps%2Bwith%2BCOM%2Bscc112.mp4",
+                            "created_time": "2015-12-16T06:57:10+00:00",
+                            "fps": 24,
+                            "size": 58329430,
+                            "md5": "eb6a47b3883b3b37394615ff949d688c"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/454167879?s=1741892_2947596822_c953682a2243df8869cc59d54a40b0f0&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=mosport%2Btime%2Btrial%2Blaps%2Bwith%2BCOM%2Bscc113.mp4",
+                            "created_time": "2015-12-16T06:57:10+00:00",
+                            "fps": 24,
+                            "size": 181283182,
+                            "md5": "497538f7dfcfc10f604483d7ecf4c4ea"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "b896d69dcfb147a5fe7c10a9bd89a71021184911",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/2172459",
+                    "name": "COM Time Trials @ NHMS 11/2/08",
+                    "description": "1991 Honda Civic Standard w/b16a swap, Koni SPSS/GC suspension, Wilwood front brakes/rear drums, Rosner Engineering full cage.  Kumho V710 205/50/15s on Enkei wheels.  Driver: Sandy Clam.  Class: SPC.  Finishing position: 3rd, 8/10ths of a second behind an E30 M3 and 2.2 seconds behind an S2000.  Outer CV breaks shortly into the 3rd lap...",
+                    "link": "https://vimeo.com/2172459",
+                    "duration": 275,
+                    "width": 504,
+                    "language": null,
+                    "height": 380,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/2172459?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"504\" height=\"380\" frameborder=\"0\" title=\"COM Time Trials @ NHMS 11/2/08\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-11-06T18:36:55+00:00",
+                    "modified_time": "2016-09-12T15:07:56+00:00",
+                    "release_time": "2008-11-06T18:36:55+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/2172459/pictures/86247920",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/86247920_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86247920_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/86247920_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86247920_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/86247920_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86247920_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 483,
+                                "link": "https://i.vimeocdn.com/video/86247920_640x483.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86247920_640x483.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 725,
+                                "link": "https://i.vimeocdn.com/video/86247920_960x725.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86247920_960x725.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "d80425ac1d3cb6635f80186d35b646b598806cb3"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/com",
+                            "name": "COM",
+                            "tag": "COM",
+                            "canonical": "com",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/com/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2287
+                                    }
+                                }
+                            },
+                            "resource_key": "c0148ae1c92fe1f451ea9af561d8a84a6298c786"
+                        },
+                        {
+                            "uri": "/tags/nhms",
+                            "name": "NHMS",
+                            "tag": "NHMS",
+                            "canonical": "nhms",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/nhms/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 196
+                                    }
+                                }
+                            },
+                            "resource_key": "a8eb45722322d026df02ab38dcac7c7cd342d199"
+                        },
+                        {
+                            "uri": "/tags/honda",
+                            "name": "Honda",
+                            "tag": "Honda",
+                            "canonical": "honda",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/honda/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 29780
+                                    }
+                                }
+                            },
+                            "resource_key": "e635b0cbf0183805cc5e7af03441fe5921d0ef6f"
+                        },
+                        {
+                            "uri": "/tags/timetrials",
+                            "name": "Time Trials",
+                            "tag": "Time Trials",
+                            "canonical": "timetrials",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/timetrials/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 146
+                                    }
+                                }
+                            },
+                            "resource_key": "5a7635de32b22cdd1baee786888b76b37d4aef14"
+                        },
+                        {
+                            "uri": "/tags/motorsports",
+                            "name": "Motor Sports",
+                            "tag": "Motor Sports",
+                            "canonical": "motorsports",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/motorsports/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3111
+                                    }
+                                }
+                            },
+                            "resource_key": "b9f0e7fae5a37215704572913235a725de67675e"
+                        },
+                        {
+                            "uri": "/tags/ef",
+                            "name": "ef",
+                            "tag": "ef",
+                            "canonical": "ef",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ef/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2003
+                                    }
+                                }
+                            },
+                            "resource_key": "5fb7d29a442a17550c5257bbeefc911d7bf72efb"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 885
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/2172459/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/2172459/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/2172459/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "pictures": {
+                                "uri": "/videos/2172459/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/2172459/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/909511",
+                        "name": "Ryan C",
+                        "link": "https://vimeo.com/user909511",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-11-06T18:35:24+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/909511/pictures/1173666",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1173666_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1173666_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1173666_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1173666_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "d175d948f2292b283d20b83c43366206a23324ce"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/909511/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/909511/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/909511/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/909511/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/909511/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/909511/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/909511/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 4
+                                },
+                                "following": {
+                                    "uri": "/users/909511/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/909511/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/909511/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/909511/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/909511/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/909511/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "watchlater": {
+                                    "uri": "/users/909511/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/909511/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/909511/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "1c165a11ab3b7a052242ed35ae89961f6b82438a",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/456685750?s=2172459_1473803811_45917676d21bdd67af7a90818c68b171&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-22T02:12:58+00:00",
+                            "fps": 30,
+                            "size": 29439028,
+                            "md5": "d91b64940c1001e8dd992d6d43622df0"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/456685750/hls?s=2172459_1473800211_3e06ccc2830d1b20483e53ce1606625f&oauth2_token_id=903107513",
+                            "created_time": "2015-12-22T02:12:58+00:00",
+                            "fps": 30,
+                            "size": 29439028,
+                            "md5": "d91b64940c1001e8dd992d6d43622df0",
+                            "link_secure": "https://player.vimeo.com/play/456685750/hls?s=2172459_1473800211_3e06ccc2830d1b20483e53ce1606625f&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/456685750?s=2172459_2947596822_11bbff06418a2f3722b71af66cbc534c&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=COM%2BTime%2BTrials%2B%2540%2BNHMS%2B11%252F2%252F08112.mp4",
+                            "created_time": "2015-12-22T02:12:58+00:00",
+                            "fps": 30,
+                            "size": 29439028,
+                            "md5": "d91b64940c1001e8dd992d6d43622df0"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "e3bb4e4b49d84469cc66ca6f3183500172b65b10",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/3512763",
+                    "name": "Setting the SSGT Lap Record at NHMS",
+                    "description": null,
+                    "link": "https://vimeo.com/3512763",
+                    "duration": 144,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/3512763?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Setting the SSGT Lap Record at NHMS\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-03-07T12:39:49+00:00",
+                    "modified_time": "2016-09-12T11:11:18+00:00",
+                    "release_time": "2009-03-07T12:39:49+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/3512763/pictures/3753848",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/3753848_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/3753848_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/3753848_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/3753848_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/3753848_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/3753848_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/3753848_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "091dc0c4530c77c3d0c37a26dbb3ab1a2edcb018"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/subaru",
+                            "name": "Subaru",
+                            "tag": "Subaru",
+                            "canonical": "subaru",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/subaru/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8999
+                                    }
+                                }
+                            },
+                            "resource_key": "f0026340b1f8953f7fb467ff6aaa34ca19da4069"
+                        },
+                        {
+                            "uri": "/tags/sti",
+                            "name": "STi",
+                            "tag": "STi",
+                            "canonical": "sti",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sti/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2404
+                                    }
+                                }
+                            },
+                            "resource_key": "a17890cac8e0b4fbdbd5806be3085cb730f7b77a"
+                        },
+                        {
+                            "uri": "/tags/ssgt",
+                            "name": "SSGT",
+                            "tag": "SSGT",
+                            "canonical": "ssgt",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ssgt/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11
+                                    }
+                                }
+                            },
+                            "resource_key": "8a9c5309f128370b9403efcbf925d8d72d636f4f"
+                        },
+                        {
+                            "uri": "/tags/nhms",
+                            "name": "NHMS",
+                            "tag": "NHMS",
+                            "canonical": "nhms",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/nhms/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 196
+                                    }
+                                }
+                            },
+                            "resource_key": "ecd0f97149ad4b22a1b6a23908f5d3e19acb34bc"
+                        },
+                        {
+                            "uri": "/tags/comscc",
+                            "name": "COMSCC",
+                            "tag": "COMSCC",
+                            "canonical": "comscc",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/comscc/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 56
+                                    }
+                                }
+                            },
+                            "resource_key": "269ae5eee587efdc7693bc18b0b8867d14c8a756"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 1592
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/3512763/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "credits": {
+                                "uri": "/videos/3512763/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/3512763/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/3512763/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/3512763/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/526518",
+                        "name": "MikeM",
+                        "link": "https://vimeo.com/user526518",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-06-08T00:55:24+00:00",
+                        "account": "basic",
+                        "pictures": null,
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/526518/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/526518/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/526518/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/526518/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/526518/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/526518/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/526518/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "following": {
+                                    "uri": "/users/526518/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/526518/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/526518/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/526518/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/526518/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/526518/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 7
+                                },
+                                "watchlater": {
+                                    "uri": "/users/526518/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/526518/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/526518/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 0
+                                }
+                            }
+                        },
+                        "resource_key": "4fc5c85899d4f9ec1216804283cd7692b99290ae",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/459271703?s=3512763_1473803811_e5585d0b60936cf9a71961f9341cdb37&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-29T14:51:11+00:00",
+                            "fps": 25,
+                            "size": 47593517,
+                            "md5": "252088fa91d840d0f57a5ec3492e8080"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/459271695?s=3512763_1473803811_42d479235144f86ff9e125040f278d33&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-29T14:51:11+00:00",
+                            "fps": 25,
+                            "size": 15342668,
+                            "md5": "2585b8adf1b8925544f7140ba165f4c7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/749079?s=3512763_1473803811_0556f5bdba0087c5b990273ba61efebc&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-03-07T13:10:15+00:00",
+                            "fps": 29.97,
+                            "size": 13574343,
+                            "md5": "3dcee2cc1b76f2d05a374d3765917501"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/459271703,459271695,749079/hls?s=3512763_1473800211_89ad8ac421575dd2eeaed8e874e7d06d&oauth2_token_id=903107513",
+                            "created_time": "2015-12-29T14:51:11+00:00",
+                            "fps": 25,
+                            "size": 47593517,
+                            "md5": "252088fa91d840d0f57a5ec3492e8080",
+                            "link_secure": "https://player.vimeo.com/play/459271703,459271695,749079/hls?s=3512763_1473800211_89ad8ac421575dd2eeaed8e874e7d06d&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/459271703?s=3512763_2947596822_7158f6ffad6fd9c6ebc11c5f734169a6&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Setting%2Bthe%2BSSGT%2BLap%2BRecord%2Bat%2BNHMS113.mp4",
+                            "created_time": "2015-12-29T14:51:11+00:00",
+                            "fps": 25,
+                            "size": 47593517,
+                            "md5": "252088fa91d840d0f57a5ec3492e8080"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/459271695?s=3512763_2947596822_365b9ab44af49136c7dcf6cb1c772cc1&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Setting%2Bthe%2BSSGT%2BLap%2BRecord%2Bat%2BNHMS112.mp4",
+                            "created_time": "2015-12-29T14:51:11+00:00",
+                            "fps": 25,
+                            "size": 15342668,
+                            "md5": "2585b8adf1b8925544f7140ba165f4c7"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/749079?s=3512763_2947596822_485b9e28e151b64fa36a51d3fec6807c&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Setting%2Bthe%2BSSGT%2BLap%2BRecord%2Bat%2BNHMS107.mp4",
+                            "created_time": "2009-03-07T13:10:15+00:00",
+                            "fps": 29.97,
+                            "size": 13574343,
+                            "md5": "3dcee2cc1b76f2d05a374d3765917501"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "99a77f6a67514063f95c2cf391cc5fbd30260512",
+                    "embed_presets": null
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/sports/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 229605
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/sports",
+                "name": "Sports",
+                "link": "https://vimeo.com/categories/sports",
+                "top_level": true,
+                "pictures": {
+                    "uri": "/videos/152865687/pictures/552973002",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/552973002_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/552973002_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/552973002_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/552973002_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/552973002_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/552973002_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 360,
+                            "link": "https://i.vimeocdn.com/video/552973002_640x360.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/552973002_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 540,
+                            "link": "https://i.vimeocdn.com/video/552973002_960x540.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/552973002_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "edc8730cb61ccdc91eeb35ca1021e1de091072ed"
+                },
+                "last_video_featured_time": null,
+                "parent": null,
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/sports/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 33577
+                        },
+                        "groups": {
+                            "uri": "/categories/sports/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 9670
+                        },
+                        "users": {
+                            "uri": "/categories/sports/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 3681
+                        },
+                        "videos": {
+                            "uri": "/categories/sports/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 229605
+                        }
+                    }
+                },
+                "subcategories": [
+                    {
+                        "uri": "/categories/sports/subcategories/bikes",
+                        "name": "Bikes",
+                        "link": "https://vimeo.com/categories/sports/bikes/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/everythingelse",
+                        "name": "Everything Else",
+                        "link": "https://vimeo.com/categories/sports/everythingelse/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/outdoorsports",
+                        "name": "Outdoor Sports",
+                        "link": "https://vimeo.com/categories/sports/outdoorsports/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/skate",
+                        "name": "Skate",
+                        "link": "https://vimeo.com/categories/sports/skate/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/sky",
+                        "name": "Sky",
+                        "link": "https://vimeo.com/categories/sports/sky/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/snow",
+                        "name": "Snow",
+                        "link": "https://vimeo.com/categories/sports/snow/videos"
+                    },
+                    {
+                        "uri": "/categories/sports/subcategories/surf",
+                        "name": "Surf",
+                        "link": "https://vimeo.com/categories/sports/surf/videos"
+                    }
+                ],
+                "resource_key": "24145eed0412385437c5a34fa732d3f90dd1dd3a"
+            }
+        },
+        {
+            "uri": "/categories/comedy",
+            "name": "Comedy",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/4924321",
+                    "name": "Cuba Suckumentary",
+                    "description": "For Yr 10 World Issues Class",
+                    "link": "https://vimeo.com/4924321",
+                    "duration": 642,
+                    "width": 640,
+                    "language": null,
+                    "height": 368,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/4924321?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"640\" height=\"368\" frameborder=\"0\" title=\"Cuba Suckumentary\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-05-31T07:50:27+00:00",
+                    "modified_time": "2016-09-13T17:16:44+00:00",
+                    "release_time": "2009-05-31T07:50:27+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/4924321/pictures/14060707",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/14060707_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14060707_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/14060707_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14060707_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/14060707_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14060707_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/14060707_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14060707_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/14060707_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14060707_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "c77b429fa850c3673af33fc53a83be139d1616be"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/cuba",
+                            "name": "Cuba",
+                            "tag": "Cuba",
+                            "canonical": "cuba",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cuba/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 13962
+                                    }
+                                }
+                            },
+                            "resource_key": "0064542251683064d7e4d72b31e39f9e83e1fb2d"
+                        },
+                        {
+                            "uri": "/tags/globalization",
+                            "name": "Globalization",
+                            "tag": "Globalization",
+                            "canonical": "globalization",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/globalization/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2062
+                                    }
+                                }
+                            },
+                            "resource_key": "2c3e213557c9d7f063986fb90d98c490e8e6474d"
+                        },
+                        {
+                            "uri": "/tags/telecommunications",
+                            "name": "Telecommunications",
+                            "tag": "Telecommunications",
+                            "canonical": "telecommunications",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/telecommunications/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1619
+                                    }
+                                }
+                            },
+                            "resource_key": "96070de287736c94bf8542851e604ea90716a5e9"
+                        },
+                        {
+                            "uri": "/tags/sarah",
+                            "name": "Sarah",
+                            "tag": "Sarah",
+                            "canonical": "sarah",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sarah/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 6876
+                                    }
+                                }
+                            },
+                            "resource_key": "4562fc5ce6cdf000d57b465be0a6e0d045bd44dc"
+                        },
+                        {
+                            "uri": "/tags/courtney",
+                            "name": "Courtney",
+                            "tag": "Courtney",
+                            "canonical": "courtney",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/courtney/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1331
+                                    }
+                                }
+                            },
+                            "resource_key": "9f3eba44714a5058b31ccc85fe867a5f69b14088"
+                        },
+                        {
+                            "uri": "/tags/peri",
+                            "name": "Peri",
+                            "tag": "Peri",
+                            "canonical": "peri",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/peri/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 274
+                                    }
+                                }
+                            },
+                            "resource_key": "633ce93adb70f3a280b0df72e77033e68a85d486"
+                        },
+                        {
+                            "uri": "/tags/humor",
+                            "name": "Humor",
+                            "tag": "Humor",
+                            "canonical": "humor",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/humor/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 94390
+                                    }
+                                }
+                            },
+                            "resource_key": "be56d71d65c43b1243f5c611fd1211131840f3ce"
+                        },
+                        {
+                            "uri": "/tags/travis",
+                            "name": "Travis",
+                            "tag": "Travis",
+                            "canonical": "travis",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/travis/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2624
+                                    }
+                                }
+                            },
+                            "resource_key": "8514527eba82fbaa85f57857bbffb3ac782014b4"
+                        },
+                        {
+                            "uri": "/tags/daddyyankee",
+                            "name": "Daddy Yankee",
+                            "tag": "Daddy Yankee",
+                            "canonical": "daddyyankee",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/daddyyankee/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 763
+                                    }
+                                }
+                            },
+                            "resource_key": "17c4049ea44b8193f4b889c522dd4f4435fbe13b"
+                        },
+                        {
+                            "uri": "/tags/america",
+                            "name": "America",
+                            "tag": "America",
+                            "canonical": "america",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/america/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 25295
+                                    }
+                                }
+                            },
+                            "resource_key": "a06874e1b761351738084c12fb0496a83534e214"
+                        },
+                        {
+                            "uri": "/tags/obama",
+                            "name": "Obama",
+                            "tag": "Obama",
+                            "canonical": "obama",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/obama/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17600
+                                    }
+                                }
+                            },
+                            "resource_key": "0c34346d863f18d3997ac893cd8fdb0c0aa1370e"
+                        },
+                        {
+                            "uri": "/tags/castro",
+                            "name": "Castro",
+                            "tag": "Castro",
+                            "canonical": "castro",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/castro/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2688
+                                    }
+                                }
+                            },
+                            "resource_key": "e6be7e6987439535c355f2bff396ce1cf077f916"
+                        },
+                        {
+                            "uri": "/tags/communism",
+                            "name": "Communism",
+                            "tag": "Communism",
+                            "canonical": "communism",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/communism/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2185
+                                    }
+                                }
+                            },
+                            "resource_key": "0210df567d8af663718bd2765db4088ce1cace20"
+                        },
+                        {
+                            "uri": "/tags/capitalism",
+                            "name": "Capitalism",
+                            "tag": "Capitalism",
+                            "canonical": "capitalism",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/capitalism/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2863
+                                    }
+                                }
+                            },
+                            "resource_key": "3cdd03164de8ad17a2e36f2bf75739d07bf8a5fd"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 98581
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/4924321/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "credits": {
+                                "uri": "/videos/4924321/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/4924321/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 14
+                            },
+                            "pictures": {
+                                "uri": "/videos/4924321/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/4924321/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/1832268",
+                        "name": "Sarah Gottlieb",
+                        "link": "https://vimeo.com/user1832268",
+                        "location": "The Biggest Hole in Australia",
+                        "bio": "oh, you know, just your average loser.",
+                        "created_time": "2009-05-31T07:26:28+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/1832268/pictures/964630",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/964630_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/964630_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/964630_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/964630_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "232ae9488911c72baea7a05dbc9d7032c795b4fb"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "http://myspace.com/o0MusicxSaves0o",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/1832268/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/1832268/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/1832268/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/1832268/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/1832268/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/1832268/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/1832268/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "following": {
+                                    "uri": "/users/1832268/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/1832268/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/1832268/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/1832268/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/1832268/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/1832268/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "watchlater": {
+                                    "uri": "/users/1832268/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/1832268/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/1832268/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "67755cddec0493a1a6379b43c015c6e9401c3c55",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3216815?s=4924321_1473803811_98c6306b2bb02e2569109311f193df23&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-05-31T09:39:46+00:00",
+                            "fps": 25,
+                            "size": 57413179,
+                            "md5": "85830ddafe3e4d133058ff907363f04e"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3216815/hls?s=4924321_1473800211_d032b27b7bdbcebb95e8f4eb3254640e&oauth2_token_id=903107513",
+                            "created_time": "2009-05-31T09:39:46+00:00",
+                            "fps": 25,
+                            "size": 57413179,
+                            "md5": "85830ddafe3e4d133058ff907363f04e",
+                            "link_secure": "https://player.vimeo.com/play/3216815/hls?s=4924321_1473800211_d032b27b7bdbcebb95e8f4eb3254640e&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3216815?s=4924321_2947596822_2e29019659b478f6fb48242897138d84&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Cuba%2BSuckumentary107.mp4",
+                            "created_time": "2009-05-31T09:39:46+00:00",
+                            "fps": 25,
+                            "size": 57413179,
+                            "md5": "85830ddafe3e4d133058ff907363f04e"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "4dcbd8771d948f10df036e1bdd80f62bf7026ba1",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/4990476",
+                    "name": "Billy Mays Spoof: \"The Man Purse\"",
+                    "description": "Billy Mays (as played by Stephen T. Veach) pitches another corny product that solves a manly problem in this Billy Mays Spoof.",
+                    "link": "https://vimeo.com/4990476",
+                    "duration": 135,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/4990476?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Billy Mays Spoof: &quot;The Man Purse&quot;\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-06-03T23:53:40+00:00",
+                    "modified_time": "2016-09-13T14:12:22+00:00",
+                    "release_time": "2009-06-03T23:53:40+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/4990476/pictures/14533408",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/14533408_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/14533408_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/14533408_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/14533408_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/14533408_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/14533408_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14533408_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "b53f52747740f862bb5abe8030b4b328d9319caa"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/anthonysullivan",
+                            "name": "anthony sullivan",
+                            "tag": "anthony sullivan",
+                            "canonical": "anthonysullivan",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/anthonysullivan/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 14
+                                    }
+                                }
+                            },
+                            "resource_key": "0a3d1557b2f4721ba0bdf005e531c60e3aab3376"
+                        },
+                        {
+                            "uri": "/tags/billymays",
+                            "name": "billy mays",
+                            "tag": "billy mays",
+                            "canonical": "billymays",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/billymays/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 102
+                                    }
+                                }
+                            },
+                            "resource_key": "c87854e943b4d2ab8ec19645389a9cc80ca73f09"
+                        },
+                        {
+                            "uri": "/tags/parody",
+                            "name": "parody",
+                            "tag": "parody",
+                            "canonical": "parody",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/parody/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 21914
+                                    }
+                                }
+                            },
+                            "resource_key": "a08fc63866ecf3edacf45b3747bbf24e4b0351e1"
+                        },
+                        {
+                            "uri": "/tags/spoof",
+                            "name": "spoof",
+                            "tag": "spoof",
+                            "canonical": "spoof",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/spoof/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 10273
+                                    }
+                                }
+                            },
+                            "resource_key": "a4178d702a6cd5290dccd2a965835cdaa06163db"
+                        },
+                        {
+                            "uri": "/tags/manpurse",
+                            "name": "man purse",
+                            "tag": "man purse",
+                            "canonical": "manpurse",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/manpurse/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8
+                                    }
+                                }
+                            },
+                            "resource_key": "c49ac743861dee1c029bc0e26070a993a240e2cb"
+                        },
+                        {
+                            "uri": "/tags/ytp",
+                            "name": "ytp",
+                            "tag": "ytp",
+                            "canonical": "ytp",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ytp/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 230
+                                    }
+                                }
+                            },
+                            "resource_key": "db216972c0b79328e6f9e8210ab6ad7eb9b64353"
+                        },
+                        {
+                            "uri": "/tags/infomercial",
+                            "name": "infomercial",
+                            "tag": "infomercial",
+                            "canonical": "infomercial",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/infomercial/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3259
+                                    }
+                                }
+                            },
+                            "resource_key": "a29b6a71575bd26232bf4948d3861a1bdd639934"
+                        },
+                        {
+                            "uri": "/tags/commercial",
+                            "name": "commercial",
+                            "tag": "commercial",
+                            "canonical": "commercial",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/commercial/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 195965
+                                    }
+                                }
+                            },
+                            "resource_key": "9f8ae479baf2f0ebe35f8a7795d76e96f43aca6c"
+                        },
+                        {
+                            "uri": "/tags/purses",
+                            "name": "purses",
+                            "tag": "purses",
+                            "canonical": "purses",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/purses/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 328
+                                    }
+                                }
+                            },
+                            "resource_key": "d2d1395e92fd5487926919cfc799bb00682e479b"
+                        },
+                        {
+                            "uri": "/tags/props",
+                            "name": "props",
+                            "tag": "props",
+                            "canonical": "props",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/props/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1966
+                                    }
+                                }
+                            },
+                            "resource_key": "8bca478bdefaec7d1156dd4d3a819500d4c43855"
+                        },
+                        {
+                            "uri": "/tags/eyepatch",
+                            "name": "eye patch",
+                            "tag": "eye patch",
+                            "canonical": "eyepatch",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/eyepatch/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 103
+                                    }
+                                }
+                            },
+                            "resource_key": "7cbdb0da071edc517600c6db88ecc20644624569"
+                        },
+                        {
+                            "uri": "/tags/billymayssucks",
+                            "name": "billy mays sucks",
+                            "tag": "billy mays sucks",
+                            "canonical": "billymayssucks",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/billymayssucks/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "2e984f394007bda2a86742af7ef5dea038898057"
+                        },
+                        {
+                            "uri": "/tags/billymaysrocks",
+                            "name": "billy mays rocks",
+                            "tag": "billy mays rocks",
+                            "canonical": "billymaysrocks",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/billymaysrocks/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "9f0d1a93903c7e0c920fd4efc90acf0286c92391"
+                        },
+                        {
+                            "uri": "/tags/asseenontv",
+                            "name": "as seen on tv",
+                            "tag": "as seen on tv",
+                            "canonical": "asseenontv",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/asseenontv/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 208
+                                    }
+                                }
+                            },
+                            "resource_key": "d745fde51a859c9ce92561572fcd32d729a20465"
+                        },
+                        {
+                            "uri": "/tags/billymaysrules",
+                            "name": "billy mays rules",
+                            "tag": "billy mays rules",
+                            "canonical": "billymaysrules",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/billymaysrules/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "0ca3067c0b3d81a340e0f726d991f78ba1342e81"
+                        },
+                        {
+                            "uri": "/tags/billymaysistheman",
+                            "name": "billy mays is the man",
+                            "tag": "billy mays is the man",
+                            "canonical": "billymaysistheman",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/billymaysistheman/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "c4b6ed28d313eff1ef434f1bc571008c48f2f0db"
+                        },
+                        {
+                            "uri": "/tags/robertveach",
+                            "name": "robert veach",
+                            "tag": "robert veach",
+                            "canonical": "robertveach",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/robertveach/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 39
+                                    }
+                                }
+                            },
+                            "resource_key": "02e4c64fc465fa673d38b3274eac11b399ae68bd"
+                        },
+                        {
+                            "uri": "/tags/stephenveach",
+                            "name": "stephen veach",
+                            "tag": "stephen veach",
+                            "canonical": "stephenveach",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/stephenveach/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3
+                                    }
+                                }
+                            },
+                            "resource_key": "96d895c0adc1f3a26da9e496d428d5c937661175"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 17307
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/4990476/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 4
+                            },
+                            "credits": {
+                                "uri": "/videos/4990476/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/4990476/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 7
+                            },
+                            "pictures": {
+                                "uri": "/videos/4990476/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/4990476/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/910632",
+                        "name": "robert veach",
+                        "link": "https://vimeo.com/user910632",
+                        "location": "yorkville Il.",
+                        "bio": "Special effects/animatronics/prop builder. Company called Chicago Animatronics Inc.. 630-553-8697.",
+                        "created_time": "2008-11-07T01:14:41+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/910632/pictures/1179219",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1179219_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1179219_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1179219_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1179219_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "4ce3cd1fbd981c1e94b999db59056bc7167fa0c1"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/910632/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/910632/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/910632/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/910632/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/910632/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "feed": {
+                                    "uri": "/users/910632/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/910632/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 15
+                                },
+                                "following": {
+                                    "uri": "/users/910632/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 20
+                                },
+                                "groups": {
+                                    "uri": "/users/910632/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 5
+                                },
+                                "likes": {
+                                    "uri": "/users/910632/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 13
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/910632/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/910632/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/910632/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 63
+                                },
+                                "watchlater": {
+                                    "uri": "/users/910632/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "shared": {
+                                    "uri": "/users/910632/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 8
+                                },
+                                "pictures": {
+                                    "uri": "/users/910632/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "3bb88c81ebf44af817ef84ad746e86481f25779b",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3333169?s=4990476_1473803811_560f0ef3d1c9726ed990aee441a1fbb1&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-06-04T01:43:50+00:00",
+                            "fps": 30,
+                            "size": 12073591,
+                            "md5": "a7f260c5218883923adf554e988fd1f3"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3333021?s=4990476_1473803811_6ca9c81059ce914bb794b3a1a87a2bf9&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-06-04T01:37:19+00:00",
+                            "fps": 30,
+                            "size": 32420225,
+                            "md5": "8240e5f43c4e60eb6940fef5f752e911"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3333169,3333021/hls?s=4990476_1473800211_504c86bf0db51e67533fd2aa8d4f1ce9&oauth2_token_id=903107513",
+                            "created_time": "2009-06-04T01:43:50+00:00",
+                            "fps": 30,
+                            "size": 12073591,
+                            "md5": "a7f260c5218883923adf554e988fd1f3",
+                            "link_secure": "https://player.vimeo.com/play/3333169,3333021/hls?s=4990476_1473800211_504c86bf0db51e67533fd2aa8d4f1ce9&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 368,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3333169?s=4990476_2947596822_ee62424448cddf07e28ced88ae1966ad&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Billy%2BMays%2BSpoof%253A%2B%2522The%2BMan%2BPurse%2522107.mp4",
+                            "created_time": "2009-06-04T01:43:50+00:00",
+                            "fps": 30,
+                            "size": 12073591,
+                            "md5": "a7f260c5218883923adf554e988fd1f3"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3333021?s=4990476_2947596822_12d0dc3d6bda09a97acafb42bd6dc0a5&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Billy%2BMays%2BSpoof%253A%2B%2522The%2BMan%2BPurse%2522113.mp4",
+                            "created_time": "2009-06-04T01:37:19+00:00",
+                            "fps": 30,
+                            "size": 32420225,
+                            "md5": "8240e5f43c4e60eb6940fef5f752e911"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "771ac38319a9cc0f8ff63b70708be794c2bfe4ae",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/4889165",
+                    "name": "Battery [Test Trailer]",
+                    "description": "\"A man wakes up in an alley with superhuman powers at his finger tips.\"\n\nStaring: Ben Brady\n\n© 2009 Media Storm",
+                    "link": "https://vimeo.com/4889165",
+                    "duration": 69,
+                    "width": 640,
+                    "language": null,
+                    "height": 432,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/4889165?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"640\" height=\"432\" frameborder=\"0\" title=\"Battery [Test Trailer]\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-05-28T19:58:31+00:00",
+                    "modified_time": "2016-09-13T14:17:21+00:00",
+                    "release_time": "2009-05-28T19:58:31+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/4889165/pictures/13825530",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/13825530_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/13825530_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/13825530_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/13825530_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/13825530_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/13825530_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 427,
+                                "link": "https://i.vimeocdn.com/video/13825530_640x427.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/13825530_640x427.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 641,
+                                "link": "https://i.vimeocdn.com/video/13825530_960x641.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/13825530_960x641.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "237f777695539b0ed98ceba9ddf697d507d4647c"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/ehtermotionpictures",
+                            "name": "ehter motion pictures",
+                            "tag": "ehter motion pictures",
+                            "canonical": "ehtermotionpictures",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/ehtermotionpictures/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "e27ebf8f2e5e042f17b5da08efcab8f593bae85c"
+                        },
+                        {
+                            "uri": "/tags/schroeder",
+                            "name": "schroeder",
+                            "tag": "schroeder",
+                            "canonical": "schroeder",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/schroeder/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 580
+                                    }
+                                }
+                            },
+                            "resource_key": "fbd11e74be3c35784f155a88008d79cfdc222d2a"
+                        },
+                        {
+                            "uri": "/tags/brady",
+                            "name": "brady",
+                            "tag": "brady",
+                            "canonical": "brady",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/brady/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1299
+                                    }
+                                }
+                            },
+                            "resource_key": "33f672e9266c64d1edee13a77f82642f3f6c54b6"
+                        },
+                        {
+                            "uri": "/tags/trailer",
+                            "name": "trailer",
+                            "tag": "trailer",
+                            "canonical": "trailer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/trailer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 213480
+                                    }
+                                }
+                            },
+                            "resource_key": "7205718fc6aecd44ddf4446b296495371748982f"
+                        },
+                        {
+                            "uri": "/tags/battery",
+                            "name": "battery",
+                            "tag": "battery",
+                            "canonical": "battery",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/battery/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3042
+                                    }
+                                }
+                            },
+                            "resource_key": "628286d2f6331de5429d0afa79fe82f2f34c745b"
+                        },
+                        {
+                            "uri": "/tags/superhero",
+                            "name": "superhero",
+                            "tag": "superhero",
+                            "canonical": "superhero",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/superhero/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 6792
+                                    }
+                                }
+                            },
+                            "resource_key": "90eab1c62c3056d8f7b4994f36bc49961b567d92"
+                        },
+                        {
+                            "uri": "/tags/film",
+                            "name": "film",
+                            "tag": "film",
+                            "canonical": "film",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/film/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 456012
+                                    }
+                                }
+                            },
+                            "resource_key": "1eea022367106c5292d19527b6dd9042ea26b47d"
+                        },
+                        {
+                            "uri": "/tags/college",
+                            "name": "college",
+                            "tag": "college",
+                            "canonical": "college",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/college/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 61539
+                                    }
+                                }
+                            },
+                            "resource_key": "48521b060bee1daf741abf4a5f0a39a426696683"
+                        },
+                        {
+                            "uri": "/tags/teaser",
+                            "name": "teaser",
+                            "tag": "teaser",
+                            "canonical": "teaser",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/teaser/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 83188
+                                    }
+                                }
+                            },
+                            "resource_key": "9ee8a3e638d535699a31335c8efdc734d75b86ad"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 14001
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/4889165/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/4889165/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/4889165/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 5
+                            },
+                            "pictures": {
+                                "uri": "/videos/4889165/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/4889165/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/1518162",
+                        "name": "Old Abbot",
+                        "link": "https://vimeo.com/oldabbot",
+                        "location": "Minneapolis, MN",
+                        "bio": "A commercial and philanthropic production company with the purpose of compellingly and effectually crafting new media in the era of Digital Film and Internet Television.",
+                        "created_time": "2009-03-31T22:55:55+00:00",
+                        "account": "pro",
+                        "pictures": {
+                            "uri": "/users/1518162/pictures/2677622",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/2677622_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/2677622_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/2677622_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/2677622_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "35ca7718626eb88c6b6c088d7ea5ec745a44cc2c"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "OldAbbot.com",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/1518162/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/1518162/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/1518162/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "categories": {
+                                    "uri": "/users/1518162/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/1518162/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/1518162/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/1518162/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 20
+                                },
+                                "following": {
+                                    "uri": "/users/1518162/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 29
+                                },
+                                "groups": {
+                                    "uri": "/users/1518162/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/1518162/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/1518162/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/1518162/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/1518162/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 105
+                                },
+                                "watchlater": {
+                                    "uri": "/users/1518162/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/1518162/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 5
+                                },
+                                "pictures": {
+                                    "uri": "/users/1518162/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "3ef13fcbcf63320a160c9a5c49d3464b27360b62",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/28308232?s=4889165_1473803811_f014e82193b970466e35235757d9d03c&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2010-09-15T07:05:09+00:00",
+                            "fps": 29.97,
+                            "size": 3641281,
+                            "md5": "be668497393ae74141850678fcb2801f"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 432,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3151849?s=4889165_1473803811_b9c8a41b4f63fe49f75a3096bd085be4&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2009-05-28T20:54:55+00:00",
+                            "fps": 29.97,
+                            "size": 6105112,
+                            "md5": "2ef525878e74a225d07ac3309d0ef991"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/28308232,3151849/hls?s=4889165_1473800211_9c5eb2cba8470bf37913b39d0190c520&oauth2_token_id=903107513",
+                            "created_time": "2010-09-15T07:05:09+00:00",
+                            "fps": 29.97,
+                            "size": 3641281,
+                            "md5": "be668497393ae74141850678fcb2801f",
+                            "link_secure": "https://player.vimeo.com/play/28308232,3151849/hls?s=4889165_1473800211_9c5eb2cba8470bf37913b39d0190c520&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 320,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/28308232?s=4889165_2947596822_4582c3682edf1182e487ee9e23f2012f&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Battery%2B%255BTest%2BTrailer%255D116.mp4",
+                            "created_time": "2010-09-15T07:05:09+00:00",
+                            "fps": 29.97,
+                            "size": 3641281,
+                            "md5": "be668497393ae74141850678fcb2801f"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 432,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/3151849?s=4889165_2947596822_c8639f1d870ef72b50f6556c088e6e58&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Battery%2B%255BTest%2BTrailer%255D107.mp4",
+                            "created_time": "2009-05-28T20:54:55+00:00",
+                            "fps": 29.97,
+                            "size": 6105112,
+                            "md5": "2ef525878e74a225d07ac3309d0ef991"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "80d509301575436b7b1f866ab399fba5a44199ab",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/2286192",
+                    "name": "Campionat de PRO de Sueca TV. (6) Espanya - Brasil",
+                    "description": "Campionat per parelles de Pro Evolution organitzat per Sueca Televisió. Este és el sisé partit (2ona Semifinal) i enfronta al Espanya (Angel i Saül) i al Brasil (Dani i Dani). A més està comentat pel Sr. Senheisser, Msr. Gresca i Dr Camansos (Grans col·laboradors del Maemeua)",
+                    "link": "https://vimeo.com/2286192",
+                    "duration": 1226,
+                    "width": 504,
+                    "language": null,
+                    "height": 380,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/2286192?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"504\" height=\"380\" frameborder=\"0\" title=\"Campionat de PRO de Sueca TV. (6) Espanya - Brasil\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-11-19T12:01:58+00:00",
+                    "modified_time": "2016-09-13T14:06:17+00:00",
+                    "release_time": "2008-11-19T12:01:58+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/2286192/pictures/86646834",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/86646834_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86646834_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/86646834_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86646834_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/86646834_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86646834_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 483,
+                                "link": "https://i.vimeocdn.com/video/86646834_640x483.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86646834_640x483.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 725,
+                                "link": "https://i.vimeocdn.com/video/86646834_960x725.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86646834_960x725.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "e1bd7766fa4008928ee0ab4a0197908e8db57c13"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/pro",
+                            "name": "pro",
+                            "tag": "pro",
+                            "canonical": "pro",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pro/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 25283
+                                    }
+                                }
+                            },
+                            "resource_key": "39d6b983b82ce01b9de962e4ac39db09716b4e9c"
+                        },
+                        {
+                            "uri": "/tags/evolution",
+                            "name": "evolution",
+                            "tag": "evolution",
+                            "canonical": "evolution",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/evolution/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11461
+                                    }
+                                }
+                            },
+                            "resource_key": "6a428bc280c622a8ce4e01f8222a5ebf97b69015"
+                        },
+                        {
+                            "uri": "/tags/soccer",
+                            "name": "soccer",
+                            "tag": "soccer",
+                            "canonical": "soccer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/soccer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 43518
+                                    }
+                                }
+                            },
+                            "resource_key": "ffdd55164f2574b19a190c2f6517013265dac6d6"
+                        },
+                        {
+                            "uri": "/tags/sueca",
+                            "name": "sueca",
+                            "tag": "sueca",
+                            "canonical": "sueca",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sueca/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2249
+                                    }
+                                }
+                            },
+                            "resource_key": "c278425fd16dad54503c9dfee0f38418a092c7a4"
+                        },
+                        {
+                            "uri": "/tags/tv",
+                            "name": "tv",
+                            "tag": "tv",
+                            "canonical": "tv",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/tv/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 165923
+                                    }
+                                }
+                            },
+                            "resource_key": "6b6301872340646525f0bf68186a54865ede5835"
+                        },
+                        {
+                            "uri": "/tags/maemeua",
+                            "name": "maemeua",
+                            "tag": "maemeua",
+                            "canonical": "maemeua",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/maemeua/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 39
+                                    }
+                                }
+                            },
+                            "resource_key": "2d2b3972a1e307fd2cfa243deeffe6ccd1c65f94"
+                        },
+                        {
+                            "uri": "/tags/televisi",
+                            "name": "televisió",
+                            "tag": "televisió",
+                            "canonical": "televisi",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/televisi/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 60
+                                    }
+                                }
+                            },
+                            "resource_key": "4d90c01f8c0b1eb7825b751a8dd3b9acb00b36d1"
+                        },
+                        {
+                            "uri": "/tags/local",
+                            "name": "local",
+                            "tag": "local",
+                            "canonical": "local",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/local/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 19967
+                                    }
+                                }
+                            },
+                            "resource_key": "53700adf936c757d0d5062e554edee9de2a92cdd"
+                        },
+                        {
+                            "uri": "/tags/humor",
+                            "name": "humor",
+                            "tag": "humor",
+                            "canonical": "humor",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/humor/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 94390
+                                    }
+                                }
+                            },
+                            "resource_key": "ed94b1f677d630ab487e443f513b3a4facd19e56"
+                        },
+                        {
+                            "uri": "/tags/risa",
+                            "name": "risa",
+                            "tag": "risa",
+                            "canonical": "risa",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/risa/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1040
+                                    }
+                                }
+                            },
+                            "resource_key": "6576fb2a305676d6608e3abfd37586f7dc1397fe"
+                        },
+                        {
+                            "uri": "/tags/riff",
+                            "name": "riff",
+                            "tag": "riff",
+                            "canonical": "riff",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/riff/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 785
+                                    }
+                                }
+                            },
+                            "resource_key": "ef2df5ff940be0b8a841d5fdc8f864da889a195e"
+                        },
+                        {
+                            "uri": "/tags/playstation",
+                            "name": "playstation",
+                            "tag": "playstation",
+                            "canonical": "playstation",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/playstation/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5726
+                                    }
+                                }
+                            },
+                            "resource_key": "f77101d1118b979a4d13f5db75c1485a4b0872ad"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 6555
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/2286192/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/2286192/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/2286192/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 5
+                            },
+                            "pictures": {
+                                "uri": "/videos/2286192/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/2286192/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/840077",
+                        "name": "Sueca Televisió",
+                        "link": "https://vimeo.com/suecatv",
+                        "location": "Sueca",
+                        "bio": null,
+                        "created_time": "2008-10-15T08:31:26+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/840077/pictures/1038970",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1038970_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1038970_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1038970_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1038970_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "6e33e9a6a456652b659ecd8b379088ef5b9d0a57"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "http://www.suecatv.com/",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/840077/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/840077/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/840077/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/840077/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/840077/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 8
+                                },
+                                "feed": {
+                                    "uri": "/users/840077/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/840077/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 29
+                                },
+                                "following": {
+                                    "uri": "/users/840077/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/840077/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/840077/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 26
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/840077/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "portfolios": {
+                                    "uri": "/users/840077/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/840077/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2274
+                                },
+                                "watchlater": {
+                                    "uri": "/users/840077/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "shared": {
+                                    "uri": "/users/840077/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "pictures": {
+                                    "uri": "/users/840077/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "d6f77ddd1821e8d8b4297b806153d185479429f5",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/457414896?s=2286192_1473803811_453aa93fe6c85256b8e87eef62e15713&sid=6d2c98a0ff99a499da9e68b7270808fe735fa3571473793011&oauth2_token_id=903107513",
+                            "created_time": "2015-12-23T16:31:01+00:00",
+                            "fps": 25,
+                            "size": 130782261,
+                            "md5": "1c36c5266badfc63e822c24c52e50951"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/457414896/hls?s=2286192_1473800211_b1dbf486c057c4761640a08382ab0205&oauth2_token_id=903107513",
+                            "created_time": "2015-12-23T16:31:01+00:00",
+                            "fps": 25,
+                            "size": 130782261,
+                            "md5": "1c36c5266badfc63e822c24c52e50951",
+                            "link_secure": "https://player.vimeo.com/play/457414896/hls?s=2286192_1473800211_b1dbf486c057c4761640a08382ab0205&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:51+00:00",
+                            "link": "https://player.vimeo.com/play/457414896?s=2286192_2947596822_430cc8cf4faac32cf59efabef1f222e9&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Campionat%2Bde%2BPRO%2Bde%2BSueca%2BTV.%2B%25286%2529%2BEspanya%2B-%2BBrasil112.mp4",
+                            "created_time": "2015-12-23T16:31:01+00:00",
+                            "fps": 25,
+                            "size": 130782261,
+                            "md5": "1c36c5266badfc63e822c24c52e50951"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "d8c6e69581c0d8d213c667fddd5af0f49a9d6ea6",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/4941834",
+                    "name": "Senator Scammer Interview #3 with LetsVentAmerica.com",
+                    "description": "In another of the ongoing series, Senator Scammer discussed Nancy Peliso, Anderson Cooper, Glenn Beck, and answers questions about contributions, the federal budget, scandals, and congressional travel.",
+                    "link": "https://vimeo.com/4941834",
+                    "duration": 301,
+                    "width": 320,
+                    "language": null,
+                    "height": 240,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/4941834?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"320\" height=\"240\" frameborder=\"0\" title=\"Senator Scammer Interview #3 with LetsVentAmerica.com\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2009-06-01T11:41:22+00:00",
+                    "modified_time": "2016-09-13T14:18:23+00:00",
+                    "release_time": "2009-06-01T11:41:22+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/4941834/pictures/14189537",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/14189537_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14189537_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/14189537_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14189537_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/14189537_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14189537_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/14189537_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14189537_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/14189537_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/14189537_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "7864983fa656b37991c8e29ab64cdaaed544de7c"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/senatorscammer",
+                            "name": "Senator Scammer",
+                            "tag": "Senator Scammer",
+                            "canonical": "senatorscammer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/senatorscammer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "43d96928865aa1965b53b0f9901d9bd5126a3817"
+                        },
+                        {
+                            "uri": "/tags/senator",
+                            "name": "Senator",
+                            "tag": "Senator",
+                            "canonical": "senator",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/senator/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 963
+                                    }
+                                }
+                            },
+                            "resource_key": "1676d4d42bdb1ea88bf05d53f0079d77e32ebb2f"
+                        },
+                        {
+                            "uri": "/tags/scammer",
+                            "name": "Scammer",
+                            "tag": "Scammer",
+                            "canonical": "scammer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/scammer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 70
+                                    }
+                                }
+                            },
+                            "resource_key": "b5b69e84ab5d9952d9e29baefcd2518ae96dc2fa"
+                        },
+                        {
+                            "uri": "/tags/letsventamerica",
+                            "name": "LetsVentAmerica",
+                            "tag": "LetsVentAmerica",
+                            "canonical": "letsventamerica",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/letsventamerica/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2
+                                    }
+                                }
+                            },
+                            "resource_key": "9657b138d93a01cd96ad4b20b051beadd71b1084"
+                        },
+                        {
+                            "uri": "/tags/letsventamericadotcom",
+                            "name": "letsventamerica.com",
+                            "tag": "letsventamerica.com",
+                            "canonical": "letsventamericadotcom",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/letsventamericadotcom/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "2d82d7f3f428b64b6c446e64205579aece440a9b"
+                        },
+                        {
+                            "uri": "/tags/interview",
+                            "name": "interview",
+                            "tag": "interview",
+                            "canonical": "interview",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/interview/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 111510
+                                    }
+                                }
+                            },
+                            "resource_key": "684ee6f70b62e24862b1ec4b9b6cce5fb1d31c3c"
+                        },
+                        {
+                            "uri": "/tags/nancypelosi",
+                            "name": "Nancy Pelosi",
+                            "tag": "Nancy Pelosi",
+                            "canonical": "nancypelosi",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/nancypelosi/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 143
+                                    }
+                                }
+                            },
+                            "resource_key": "e850d0385ca3dd6bb401e5a3686d4cd4622ef275"
+                        },
+                        {
+                            "uri": "/tags/andersoncooper",
+                            "name": "Anderson Cooper",
+                            "tag": "Anderson Cooper",
+                            "canonical": "andersoncooper",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/andersoncooper/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 177
+                                    }
+                                }
+                            },
+                            "resource_key": "88ac7af3f12eb67d5b8f5b8242b38e5afaaafd3a"
+                        },
+                        {
+                            "uri": "/tags/glennbeck",
+                            "name": "Glenn Beck",
+                            "tag": "Glenn Beck",
+                            "canonical": "glennbeck",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/glennbeck/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 378
+                                    }
+                                }
+                            },
+                            "resource_key": "2487887d32593b95f19797020ad07d5f05bdf819"
+                        },
+                        {
+                            "uri": "/tags/humor",
+                            "name": "humor",
+                            "tag": "humor",
+                            "canonical": "humor",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/humor/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 94390
+                                    }
+                                }
+                            },
+                            "resource_key": "6a40da846ab06d7279752cf50851c2270ad13ce7"
+                        },
+                        {
+                            "uri": "/tags/youtube",
+                            "name": "YouTube",
+                            "tag": "YouTube",
+                            "canonical": "youtube",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/youtube/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 93326
+                                    }
+                                }
+                            },
+                            "resource_key": "5645a2c65026d1ca078698be0151def03076186e"
+                        },
+                        {
+                            "uri": "/tags/politicalcontributions",
+                            "name": "political contributions",
+                            "tag": "political contributions",
+                            "canonical": "politicalcontributions",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/politicalcontributions/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8
+                                    }
+                                }
+                            },
+                            "resource_key": "9be04e50385bd726552d4a186223c382f65f1db2"
+                        },
+                        {
+                            "uri": "/tags/congressionaltravel",
+                            "name": "congressional travel",
+                            "tag": "congressional travel",
+                            "canonical": "congressionaltravel",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/congressionaltravel/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "f140e4e38a9d5c42e8f5840080c97fc488034336"
+                        },
+                        {
+                            "uri": "/tags/washingtonscandals",
+                            "name": "washington scandals",
+                            "tag": "washington scandals",
+                            "canonical": "washingtonscandals",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/washingtonscandals/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "4f3b8d8e337312b108b97a1ce70d6216d0dc11f8"
+                        },
+                        {
+                            "uri": "/tags/politics",
+                            "name": "politics",
+                            "tag": "politics",
+                            "canonical": "politics",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/politics/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 32682
+                                    }
+                                }
+                            },
+                            "resource_key": "72a58ebc3ea994b28ff7bb0b3cea2d636be48911"
+                        },
+                        {
+                            "uri": "/tags/thecapital",
+                            "name": "the capital",
+                            "tag": "the capital",
+                            "canonical": "thecapital",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/thecapital/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 26
+                                    }
+                                }
+                            },
+                            "resource_key": "9462414999f12c838ae211df70dce83dee4e9d15"
+                        },
+                        {
+                            "uri": "/tags/insidethebeltway",
+                            "name": "inside the beltway",
+                            "tag": "inside the beltway",
+                            "canonical": "insidethebeltway",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/insidethebeltway/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "d5742fde3a0c5faea948078899a1aa01fbed8e71"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 10989
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/4941834/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/4941834/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/4941834/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "pictures": {
+                                "uri": "/videos/4941834/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/4941834/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/1646863",
+                        "name": "LetsVentAmerica",
+                        "link": "https://vimeo.com/user1646863",
+                        "location": null,
+                        "bio": "http://www.letsventamerica.com",
+                        "created_time": "2009-04-24T17:25:14+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/1646863/pictures/1148435",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1148435_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1148435_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1148435_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1148435_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "a479ae448a22c190edadb6471a23b5aff8352f48"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/1646863/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/1646863/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/1646863/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/1646863/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/1646863/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/1646863/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/1646863/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "following": {
+                                    "uri": "/users/1646863/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/1646863/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/1646863/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/1646863/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/1646863/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/1646863/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "watchlater": {
+                                    "uri": "/users/1646863/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/1646863/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/1646863/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "ec2a2f2413a1494d48f98642811848d661ec9b57",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 320,
+                            "height": 240,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/3245881?s=4941834_1473803812_8c4e1e0045a12016b4eabad477739f58&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2009-06-01T11:49:33+00:00",
+                            "fps": 25,
+                            "size": 11728572,
+                            "md5": "de215c532917dad4a4571c523d4f9a73"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/3245881/hls?s=4941834_1473800212_c936940f939ae71a8fde4c4ff4067e66&oauth2_token_id=903107513",
+                            "created_time": "2009-06-01T11:49:33+00:00",
+                            "fps": 25,
+                            "size": 11728572,
+                            "md5": "de215c532917dad4a4571c523d4f9a73",
+                            "link_secure": "https://player.vimeo.com/play/3245881/hls?s=4941834_1473800212_c936940f939ae71a8fde4c4ff4067e66&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 320,
+                            "height": 240,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/3245881?s=4941834_2947596824_a815d3445eddc84d82526220b0098f41&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Senator%2BScammer%2BInterview%2B%25233%2Bwith%2BLetsVentAmerica.com107.mp4",
+                            "created_time": "2009-06-01T11:49:33+00:00",
+                            "fps": 25,
+                            "size": 11728572,
+                            "md5": "de215c532917dad4a4571c523d4f9a73"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "75f82f399f5ecf3cbf6e50c348b18a51fb2c5b7a",
+                    "embed_presets": null
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/comedy/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 32314
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/comedy",
+                "name": "Comedy",
+                "link": "https://vimeo.com/categories/comedy",
+                "top_level": true,
+                "pictures": {
+                    "uri": "/videos/182412385/pictures/591335615",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/591335615_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591335615_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/591335615_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591335615_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/591335615_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591335615_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 360,
+                            "link": "https://i.vimeocdn.com/video/591335615_640x360.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591335615_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 540,
+                            "link": "https://i.vimeocdn.com/video/591335615_960x540.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591335615_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "8664a46ba4e89f71cdeeb996693fdeb579a95b06"
+                },
+                "last_video_featured_time": null,
+                "parent": null,
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/comedy/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 14100
+                        },
+                        "groups": {
+                            "uri": "/categories/comedy/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 2001
+                        },
+                        "users": {
+                            "uri": "/categories/comedy/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 632
+                        },
+                        "videos": {
+                            "uri": "/categories/comedy/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 32314
+                        }
+                    }
+                },
+                "subcategories": [
+                    {
+                        "uri": "/categories/comedy/subcategories/standup",
+                        "name": "Stand Up",
+                        "link": "https://vimeo.com/categories/comedy/standup/videos"
+                    },
+                    {
+                        "uri": "/categories/comedy/subcategories/comicnarrative",
+                        "name": "Narrative",
+                        "link": "https://vimeo.com/categories/comedy/comicnarrative/videos"
+                    }
+                ],
+                "resource_key": "41d4652c5951de4808745714f7659bee396325d3"
+            }
+        },
+        {
+            "uri": "/categories/animation",
+            "name": "Animation",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/191736",
+                    "name": "mask pixelation test",
+                    "description": "etiology: http://flickr.com/photos/forresto/501759955/",
+                    "link": "https://vimeo.com/191736",
+                    "duration": 9,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/191736?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"mask pixelation test\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-05-17T04:22:07+00:00",
+                    "modified_time": "2016-09-13T18:07:28+00:00",
+                    "release_time": "2007-05-17T04:22:07+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/191736/pictures/47742335",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/47742335_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/47742335_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/47742335_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/47742335_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/47742335_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/47742335_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/47742335_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "659ebdc98a94f238219f75792911c3d1fce84690"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/me",
+                            "name": "me",
+                            "tag": "me",
+                            "canonical": "me",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/me/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17271
+                                    }
+                                }
+                            },
+                            "resource_key": "13e10afe7140035e1e3dfbf2854e6523bdd7e7be"
+                        },
+                        {
+                            "uri": "/tags/forrest",
+                            "name": "forrest",
+                            "tag": "forrest",
+                            "canonical": "forrest",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/forrest/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2033
+                                    }
+                                }
+                            },
+                            "resource_key": "2a5d5b2aa7f540f9f73c927f05994e7d4f79af85"
+                        },
+                        {
+                            "uri": "/tags/mask",
+                            "name": "mask",
+                            "tag": "mask",
+                            "canonical": "mask",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/mask/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7039
+                                    }
+                                }
+                            },
+                            "resource_key": "8d96ec808d154b2d244d79e772ed6a2aac38b04b"
+                        },
+                        {
+                            "uri": "/tags/pixelation",
+                            "name": "pixelation",
+                            "tag": "pixelation",
+                            "canonical": "pixelation",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/pixelation/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1283
+                                    }
+                                }
+                            },
+                            "resource_key": "ca206f6612a4bc25b2ac064403770410cd9b4e0e"
+                        },
+                        {
+                            "uri": "/tags/animation",
+                            "name": "animation",
+                            "tag": "animation",
+                            "canonical": "animation",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/animation/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 794949
+                                    }
+                                }
+                            },
+                            "resource_key": "3a90395289791c2f487e243ddddf1d9bed22f7de"
+                        },
+                        {
+                            "uri": "/tags/longexposure",
+                            "name": "longexposure",
+                            "tag": "longexposure",
+                            "canonical": "longexposure",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/longexposure/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1729
+                                    }
+                                }
+                            },
+                            "resource_key": "3514c000962bb78c77fb0f2cca84ef2c0ba7f8b9"
+                        },
+                        {
+                            "uri": "/tags/led",
+                            "name": "led",
+                            "tag": "led",
+                            "canonical": "led",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/led/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 22214
+                                    }
+                                }
+                            },
+                            "resource_key": "cc70054e54f0240da4be0068d9b4253825b4fc3f"
+                        },
+                        {
+                            "uri": "/tags/looped",
+                            "name": "looped",
+                            "tag": "looped",
+                            "canonical": "looped",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/looped/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 196
+                                    }
+                                }
+                            },
+                            "resource_key": "7262255f63bf905b889bb52c392bc8fa35b835b8"
+                        },
+                        {
+                            "uri": "/tags/hd",
+                            "name": "hd",
+                            "tag": "hd",
+                            "canonical": "hd",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hd/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 217925
+                                    }
+                                }
+                            },
+                            "resource_key": "eee058280104a3085c45b814fcb1798ae24c4880"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 7457
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/191736/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "credits": {
+                                "uri": "/videos/191736/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/191736/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 8
+                            },
+                            "pictures": {
+                                "uri": "/videos/191736/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/191736/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/172",
+                        "name": "Forrest O.",
+                        "link": "https://vimeo.com/forresto",
+                        "location": "Carrboro, NC",
+                        "bio": "dance, craft, paper, animation, web apps",
+                        "created_time": "2005-03-30T12:47:54+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/172/pictures/803424",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/803424_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/803424_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/803424_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/803424_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "62bb9dc96288ca8722abb0bc712338a51a3a0e7e"
+                        },
+                        "websites": [
+                            {
+                                "name": "forresto.com",
+                                "link": "http://forresto.com",
+                                "description": "personal"
+                            },
+                            {
+                                "name": "meemoo.org",
+                                "link": "http://meemoo.org/",
+                                "description": "hackable creative apps"
+                            },
+                            {
+                                "name": "flowhub.io",
+                                "link": "http://flowhub.io/",
+                                "description": "more visual programming"
+                            },
+                            {
+                                "name": "thegrid.io/#8",
+                                "link": "https://thegrid.io/#8",
+                                "description": "ai-designed websites"
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/172/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/172/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 4
+                                },
+                                "appearances": {
+                                    "uri": "/users/172/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "categories": {
+                                    "uri": "/users/172/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/172/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 14
+                                },
+                                "feed": {
+                                    "uri": "/users/172/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/172/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 84
+                                },
+                                "following": {
+                                    "uri": "/users/172/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 34
+                                },
+                                "groups": {
+                                    "uri": "/users/172/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 12
+                                },
+                                "likes": {
+                                    "uri": "/users/172/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 165
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/172/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "portfolios": {
+                                    "uri": "/users/172/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/172/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 59
+                                },
+                                "watchlater": {
+                                    "uri": "/users/172/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "shared": {
+                                    "uri": "/users/172/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 36
+                                },
+                                "pictures": {
+                                    "uri": "/users/172/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "dbb41f99770bbf0959d394a37aa013060648d4ec",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/445983298?s=191736_1473803812_0670028e6e14a15a6beb34e5ecc6d606&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-11-28T21:35:40+00:00",
+                            "fps": 24,
+                            "size": 2799473,
+                            "md5": "a78f28bd43ed9c43975d76de89b72a34"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/445983293?s=191736_1473803812_5ba77461b37f318e9db4166afbe9eb46&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-11-28T21:35:40+00:00",
+                            "fps": 24,
+                            "size": 815622,
+                            "md5": "0b7c868988ff2c1c594ec2d14236c20a"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/445983298,445983293/hls?s=191736_1473800212_43e29ffe0cf4f74e7d6091af7e54d302&oauth2_token_id=903107513",
+                            "created_time": "2015-11-28T21:35:40+00:00",
+                            "fps": 24,
+                            "size": 2799473,
+                            "md5": "a78f28bd43ed9c43975d76de89b72a34",
+                            "link_secure": "https://player.vimeo.com/play/445983298,445983293/hls?s=191736_1473800212_43e29ffe0cf4f74e7d6091af7e54d302&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/445983298?s=191736_2947596824_fde332c1fa5f4e7b01c992f7c5f0d41a&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=mask%2Bpixelation%2Btest113.mp4",
+                            "created_time": "2015-11-28T21:35:40+00:00",
+                            "fps": 24,
+                            "size": 2799473,
+                            "md5": "a78f28bd43ed9c43975d76de89b72a34"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/445983293?s=191736_2947596824_2079cb7def65515149013333bb24f583&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=mask%2Bpixelation%2Btest112.mp4",
+                            "created_time": "2015-11-28T21:35:40+00:00",
+                            "fps": 24,
+                            "size": 815622,
+                            "md5": "0b7c868988ff2c1c594ec2d14236c20a"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "15b8c8efffb33b5b16ecde0b82521c049e8241aa",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/253454",
+                    "name": "Cubes explosion 02",
+                    "description": "Made with Vision Factory. The parameters are real-time driven by Javascript.\nhttp://v3ga.net/blog/2007/02/vision-factory-registration/",
+                    "link": "https://vimeo.com/253454",
+                    "duration": 10,
+                    "width": 462,
+                    "language": null,
+                    "height": 346,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/253454?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"462\" height=\"346\" frameborder=\"0\" title=\"Cubes explosion 02\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-07-27T16:36:23+00:00",
+                    "modified_time": "2016-09-13T18:08:04+00:00",
+                    "release_time": "2007-07-27T16:36:23+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/253454/pictures/48334340",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/48334340_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/48334340_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/48334340_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/48334340_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/48334340_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/48334340_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/48334340_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/48334340_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/48334340_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/48334340_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "22a46ea9edb451ad46b3b7b419d926f71fedcf06"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/vision",
+                            "name": "vision",
+                            "tag": "vision",
+                            "canonical": "vision",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/vision/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 18222
+                                    }
+                                }
+                            },
+                            "resource_key": "1e673a7f72c22c7a5c41c0cc3bc29d701fdf7ea3"
+                        },
+                        {
+                            "uri": "/tags/factory",
+                            "name": "factory",
+                            "tag": "factory",
+                            "canonical": "factory",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/factory/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 8914
+                                    }
+                                }
+                            },
+                            "resource_key": "9ece2179e8c08efc87c64c6c22c95f100be3f38e"
+                        },
+                        {
+                            "uri": "/tags/lines",
+                            "name": "lines",
+                            "tag": "lines",
+                            "canonical": "lines",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/lines/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 4898
+                                    }
+                                }
+                            },
+                            "resource_key": "db963c4f99b9188820deda8783c18c34bd6e5ea4"
+                        },
+                        {
+                            "uri": "/tags/cubes",
+                            "name": "cubes",
+                            "tag": "cubes",
+                            "canonical": "cubes",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cubes/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1596
+                                    }
+                                }
+                            },
+                            "resource_key": "b7486d4d6258281ab76ce7d72565473f8664a9d6"
+                        },
+                        {
+                            "uri": "/tags/explosion",
+                            "name": "explosion",
+                            "tag": "explosion",
+                            "canonical": "explosion",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/explosion/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 12568
+                                    }
+                                }
+                            },
+                            "resource_key": "b8fb0e397448cd89e4a28cff747baa0a402788f3"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 7874
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/253454/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 4
+                            },
+                            "credits": {
+                                "uri": "/videos/253454/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/253454/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 17
+                            },
+                            "pictures": {
+                                "uri": "/videos/253454/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/253454/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/144138",
+                        "name": "v3ga",
+                        "link": "https://vimeo.com/v3ga",
+                        "location": "Bordeaux, France.",
+                        "bio": "http://www.v3ga.net\n",
+                        "created_time": "2006-11-17T17:07:38+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/144138/pictures/1032263",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1032263_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1032263_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1032263_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1032263_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "0129cfc84bc6f79b2047811960de361cabccf614"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "http://www.v3ga.net",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/144138/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/144138/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/144138/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "categories": {
+                                    "uri": "/users/144138/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/144138/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "feed": {
+                                    "uri": "/users/144138/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/144138/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 224
+                                },
+                                "following": {
+                                    "uri": "/users/144138/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 42
+                                },
+                                "groups": {
+                                    "uri": "/users/144138/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/144138/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 215
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/144138/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/144138/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/144138/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 25
+                                },
+                                "watchlater": {
+                                    "uri": "/users/144138/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/144138/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 155
+                                },
+                                "pictures": {
+                                    "uri": "/users/144138/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "a1e631266637a27b269ba8275e035df732a06953",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 462,
+                            "height": 346,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446135400?s=253454_1473803812_caf94b8a0ea918f26011d81b7917ca6e&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-11-29T12:34:10+00:00",
+                            "fps": 30,
+                            "size": 835790,
+                            "md5": "765b5ac01ce9b69f47f60d0a524ff3ad"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446135400/hls?s=253454_1473800212_eef9432716582e88ce7e2cc370296400&oauth2_token_id=903107513",
+                            "created_time": "2015-11-29T12:34:10+00:00",
+                            "fps": 30,
+                            "size": 835790,
+                            "md5": "765b5ac01ce9b69f47f60d0a524ff3ad",
+                            "link_secure": "https://player.vimeo.com/play/446135400/hls?s=253454_1473800212_eef9432716582e88ce7e2cc370296400&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 462,
+                            "height": 346,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446135400?s=253454_2947596824_37e00b28d71c3358cf37cb8de74ffa5e&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Cubes%2Bexplosion%2B02112.mp4",
+                            "created_time": "2015-11-29T12:34:10+00:00",
+                            "fps": 30,
+                            "size": 835790,
+                            "md5": "765b5ac01ce9b69f47f60d0a524ff3ad"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "36551bc2fa71c7532fc09bc2a26c2256465d72a3",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/358450",
+                    "name": "newbox",
+                    "description": "music: squarepusher / cronecker king",
+                    "link": "https://vimeo.com/358450",
+                    "duration": 39,
+                    "width": 400,
+                    "language": null,
+                    "height": 300,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/358450?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"400\" height=\"300\" frameborder=\"0\" title=\"newbox\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-10-26T13:34:11+00:00",
+                    "modified_time": "2016-09-13T18:08:39+00:00",
+                    "release_time": "2007-10-26T13:34:11+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/358450/pictures/49413285",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/49413285_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49413285_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/49413285_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49413285_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/49413285_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49413285_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/49413285_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49413285_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/49413285_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49413285_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "2bf73c4505c16269b03a92fe0e7213f78ac70db0"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/generative",
+                            "name": "generative",
+                            "tag": "generative",
+                            "canonical": "generative",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/generative/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7052
+                                    }
+                                }
+                            },
+                            "resource_key": "bbb6d039cae2d2c311b57ce3a38e50b88da707f5"
+                        },
+                        {
+                            "uri": "/tags/box",
+                            "name": "box",
+                            "tag": "box",
+                            "canonical": "box",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/box/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 14166
+                                    }
+                                }
+                            },
+                            "resource_key": "dacf4eb5fc881147658e19aecaf01bb6d4a60c4d"
+                        },
+                        {
+                            "uri": "/tags/vvvv",
+                            "name": "vvvv",
+                            "tag": "vvvv",
+                            "canonical": "vvvv",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/vvvv/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3941
+                                    }
+                                }
+                            },
+                            "resource_key": "6c14a2e2e1f265b1f78f14e6fdaf9bc04ab3b4c0"
+                        },
+                        {
+                            "uri": "/tags/fft",
+                            "name": "fft",
+                            "tag": "fft",
+                            "canonical": "fft",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/fft/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 559
+                                    }
+                                }
+                            },
+                            "resource_key": "8c9d69f88e895cfc60dae61c2fda1d8ecaad3f5a"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 7087
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/358450/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 6
+                            },
+                            "credits": {
+                                "uri": "/videos/358450/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/358450/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 10
+                            },
+                            "pictures": {
+                                "uri": "/videos/358450/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/358450/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/165657",
+                        "name": "Daniel Kauer",
+                        "link": "https://vimeo.com/memalloc",
+                        "location": "vienna, austria",
+                        "bio": null,
+                        "created_time": "2007-03-08T10:25:50+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/165657/pictures/848690",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/848690_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/848690_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/848690_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/848690_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "5fb36bc8dd3d4154c73f4294e4bdd9b674393534"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "http://www.danielkauer.at",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/165657/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/165657/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/165657/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/165657/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/165657/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 6
+                                },
+                                "feed": {
+                                    "uri": "/users/165657/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/165657/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 54
+                                },
+                                "following": {
+                                    "uri": "/users/165657/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 52
+                                },
+                                "groups": {
+                                    "uri": "/users/165657/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "likes": {
+                                    "uri": "/users/165657/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 124
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/165657/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/165657/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/165657/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 22
+                                },
+                                "watchlater": {
+                                    "uri": "/users/165657/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "shared": {
+                                    "uri": "/users/165657/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 42
+                                },
+                                "pictures": {
+                                    "uri": "/users/165657/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "ecdea811903f31bc8a6fadbd1f7f93581360685d",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 400,
+                            "height": 300,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446538538?s=358450_1473803812_38bdb7ef0f80f847945908b979c19d06&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-11-30T13:24:26+00:00",
+                            "fps": 30,
+                            "size": 3346090,
+                            "md5": "896c2781230d90a116fb6f94ed86a883"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446538538/hls?s=358450_1473800212_095b65377e6afdd0bf7405d2d06f523b&oauth2_token_id=903107513",
+                            "created_time": "2015-11-30T13:24:26+00:00",
+                            "fps": 30,
+                            "size": 3346090,
+                            "md5": "896c2781230d90a116fb6f94ed86a883",
+                            "link_secure": "https://player.vimeo.com/play/446538538/hls?s=358450_1473800212_095b65377e6afdd0bf7405d2d06f523b&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 400,
+                            "height": 300,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446538538?s=358450_2947596824_faa5decfb8aaeba08eb6fac6be397665&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=newbox112.mp4",
+                            "created_time": "2015-11-30T13:24:26+00:00",
+                            "fps": 30,
+                            "size": 3346090,
+                            "md5": "896c2781230d90a116fb6f94ed86a883"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "93f566f97c160a4f6de5aebb4e86103e331a73c4",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/366217",
+                    "name": "experimental seating accomodation - muffathalle / ampere club",
+                    "description": "programming/design for peter haimerl,\n\nthe development of a sculptural seating accomadation\nfor the muffathalle / ampere club in munich.\nthe mold is made of laser-cut steel-plates and\nfilled with special glass-foam-concrete.\n\n(project and realisation: peter haimerl)\n\nrendered in povray (www.povray.org)",
+                    "link": "https://vimeo.com/366217",
+                    "duration": 60,
+                    "width": 480,
+                    "language": null,
+                    "height": 360,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/366217?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"480\" height=\"360\" frameborder=\"0\" title=\"experimental seating accomodation - muffathalle / ampere club\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-11-01T12:09:36+00:00",
+                    "modified_time": "2016-09-13T18:08:49+00:00",
+                    "release_time": "2007-11-01T12:09:36+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/366217/pictures/49503581",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/49503581_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49503581_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/49503581_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49503581_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/49503581_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49503581_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/49503581_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49503581_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/49503581_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49503581_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "78450430e65d14b8f3d9bf44594bde57abc7a8bc"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/povray",
+                            "name": "povray",
+                            "tag": "povray",
+                            "canonical": "povray",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/povray/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 141
+                                    }
+                                }
+                            },
+                            "resource_key": "71798002df74b810f49ef441ab33799b31a71ad8"
+                        },
+                        {
+                            "uri": "/tags/processing",
+                            "name": "processing",
+                            "tag": "processing",
+                            "canonical": "processing",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/processing/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 22403
+                                    }
+                                }
+                            },
+                            "resource_key": "cf98fd0e9d602a9907938a0262e8758345708013"
+                        },
+                        {
+                            "uri": "/tags/algorithmic",
+                            "name": "algorithmic",
+                            "tag": "algorithmic",
+                            "canonical": "algorithmic",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/algorithmic/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 644
+                                    }
+                                }
+                            },
+                            "resource_key": "e9b639d735df661c9a511c1725928e2b4dbce2bf"
+                        },
+                        {
+                            "uri": "/tags/computational",
+                            "name": "computational",
+                            "tag": "computational",
+                            "canonical": "computational",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/computational/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 305
+                                    }
+                                }
+                            },
+                            "resource_key": "a2c6356a5f5711250d4f5bc4a70905ad2824982e"
+                        },
+                        {
+                            "uri": "/tags/generative",
+                            "name": "generative",
+                            "tag": "generative",
+                            "canonical": "generative",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/generative/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7052
+                                    }
+                                }
+                            },
+                            "resource_key": "56c68fb7a7225d591f2f377d7f39698292c30d0e"
+                        },
+                        {
+                            "uri": "/tags/code",
+                            "name": "code",
+                            "tag": "code",
+                            "canonical": "code",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/code/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 10939
+                                    }
+                                }
+                            },
+                            "resource_key": "dcf7a65c06ac1d0d3f8d74ab4a9358ef2892ae4b"
+                        },
+                        {
+                            "uri": "/tags/design",
+                            "name": "design",
+                            "tag": "design",
+                            "canonical": "design",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/design/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 259133
+                                    }
+                                }
+                            },
+                            "resource_key": "2ed53ba869c4e5b2c67ddc3b480854ffce44be93"
+                        },
+                        {
+                            "uri": "/tags/cube",
+                            "name": "cube",
+                            "tag": "cube",
+                            "canonical": "cube",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cube/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7091
+                                    }
+                                }
+                            },
+                            "resource_key": "1e87b3a003611dedd626d053474752429479cd07"
+                        },
+                        {
+                            "uri": "/tags/environmental",
+                            "name": "environmental",
+                            "tag": "environmental",
+                            "canonical": "environmental",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/environmental/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5630
+                                    }
+                                }
+                            },
+                            "resource_key": "1367c2819382c0b4cbd847d0268bd220cb03a523"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 3398
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/366217/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "credits": {
+                                "uri": "/videos/366217/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/366217/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 4
+                            },
+                            "pictures": {
+                                "uri": "/videos/366217/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/366217/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/286790",
+                        "name": "gero wortmann",
+                        "link": "https://vimeo.com/user286790",
+                        "location": "munich, germany",
+                        "bio": "images can be seen at:\nwww.flickr.com/photos/gerowortmann\n",
+                        "created_time": "2007-11-01T10:35:34+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/286790/pictures/966147",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/966147_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/966147_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/966147_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/966147_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "ae3aed2a948c179f5d37276bc07f3d36b57aef51"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "www.gerowortmann.com",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/286790/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/286790/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/286790/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/286790/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/286790/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 5
+                                },
+                                "feed": {
+                                    "uri": "/users/286790/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/286790/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 38
+                                },
+                                "following": {
+                                    "uri": "/users/286790/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 21
+                                },
+                                "groups": {
+                                    "uri": "/users/286790/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "likes": {
+                                    "uri": "/users/286790/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 75
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/286790/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/286790/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/286790/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 4
+                                },
+                                "watchlater": {
+                                    "uri": "/users/286790/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/286790/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 73
+                                },
+                                "pictures": {
+                                    "uri": "/users/286790/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "37fc7f5d7c0a4b5e2b08968e828412a771751c70",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446624618?s=366217_1473803812_d80944e2f9a543b4b6f50f88e484e92c&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-11-30T16:14:40+00:00",
+                            "fps": 30,
+                            "size": 3940106,
+                            "md5": "9e2dc8eb7619239e6833a91d82f1ac4e"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446624618/hls?s=366217_1473800212_c142c22d9b8098e9e9b914129d8f486e&oauth2_token_id=903107513",
+                            "created_time": "2015-11-30T16:14:40+00:00",
+                            "fps": 30,
+                            "size": 3940106,
+                            "md5": "9e2dc8eb7619239e6833a91d82f1ac4e",
+                            "link_secure": "https://player.vimeo.com/play/446624618/hls?s=366217_1473800212_c142c22d9b8098e9e9b914129d8f486e&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/446624618?s=366217_2947596824_90413cdb513360dd3934dcb4f49d3d62&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=experimental%2Bseating%2Baccomodation%2B-%2Bmuffathalle%2B%252F%2Bampere%2Bclub112.mp4",
+                            "created_time": "2015-11-30T16:14:40+00:00",
+                            "fps": 30,
+                            "size": 3940106,
+                            "md5": "9e2dc8eb7619239e6833a91d82f1ac4e"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "2a730b4c63af8c99bea8a8726e5b9301216c057e",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/409875",
+                    "name": "videokubism",
+                    "description": "small demo of my submission - an interactive videoinstallation - for the open call exhibition @ röda sten, gothenburg",
+                    "link": "https://vimeo.com/409875",
+                    "duration": 95,
+                    "width": 508,
+                    "language": null,
+                    "height": 406,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/409875?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"508\" height=\"406\" frameborder=\"0\" title=\"videokubism\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2007-11-30T12:44:58+00:00",
+                    "modified_time": "2016-09-13T13:12:42+00:00",
+                    "release_time": "2007-11-30T12:44:58+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/409875/pictures/49996312",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/49996312_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49996312_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/49996312_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49996312_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/49996312_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49996312_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 512,
+                                "link": "https://i.vimeocdn.com/video/49996312_640x512.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49996312_640x512.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 768,
+                                "link": "https://i.vimeocdn.com/video/49996312_960x768.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/49996312_960x768.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "4b2d623c7d34eab905831c4ee4a3a7aba77c4178"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/audiovisual",
+                            "name": "audiovisual",
+                            "tag": "audiovisual",
+                            "canonical": "audiovisual",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/audiovisual/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 26828
+                                    }
+                                }
+                            },
+                            "resource_key": "f39d8d7d24740f7e31065a0a05a2e859296dfae7"
+                        },
+                        {
+                            "uri": "/tags/visualization",
+                            "name": "visualization",
+                            "tag": "visualization",
+                            "canonical": "visualization",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/visualization/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11774
+                                    }
+                                }
+                            },
+                            "resource_key": "f18eee4560fd68128606fce23e4991b2b6ada7a3"
+                        },
+                        {
+                            "uri": "/tags/video",
+                            "name": "video",
+                            "tag": "video",
+                            "canonical": "video",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/video/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 657927
+                                    }
+                                }
+                            },
+                            "resource_key": "118a8f1bb8ebb23ef0833de0275f2f15ce5ba4a4"
+                        },
+                        {
+                            "uri": "/tags/webcam",
+                            "name": "webcam",
+                            "tag": "webcam",
+                            "canonical": "webcam",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/webcam/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 6689
+                                    }
+                                }
+                            },
+                            "resource_key": "597f6b5d4c19a96047e36bac48748845e50a87d4"
+                        },
+                        {
+                            "uri": "/tags/house",
+                            "name": "house",
+                            "tag": "house",
+                            "canonical": "house",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/house/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 76524
+                                    }
+                                }
+                            },
+                            "resource_key": "26544bfc798556534b3dd547cdbf3d6759631267"
+                        },
+                        {
+                            "uri": "/tags/cubes",
+                            "name": "cubes",
+                            "tag": "cubes",
+                            "canonical": "cubes",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cubes/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1596
+                                    }
+                                }
+                            },
+                            "resource_key": "c6158b107b52bde67fdd02eff21f4eef270691be"
+                        },
+                        {
+                            "uri": "/tags/computerizedart",
+                            "name": "computerized art",
+                            "tag": "computerized art",
+                            "canonical": "computerizedart",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/computerizedart/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "bc79e51b9b34950632ceb95ec155c13100aa009d"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 2283
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/409875/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/409875/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/409875/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 3
+                            },
+                            "pictures": {
+                                "uri": "/videos/409875/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/409875/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/302384",
+                        "name": "markus hamburger",
+                        "link": "https://vimeo.com/rudebox",
+                        "location": null,
+                        "bio": "interaction designer/vj/rasterdisaster from gothenburg sweden.. \nfeel free to contact me if:\n\n* you want to collaborate\n* you want to employ me\n* you just want to say hi",
+                        "created_time": "2007-11-23T14:51:25+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/302384/pictures/803492",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/803492_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/803492_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/803492_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/803492_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "1406b68896e2fa758c23708029b4999d0550d016"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "http://markushamburger.se/",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/302384/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/302384/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/302384/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/302384/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/302384/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "feed": {
+                                    "uri": "/users/302384/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/302384/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 40
+                                },
+                                "following": {
+                                    "uri": "/users/302384/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 38
+                                },
+                                "groups": {
+                                    "uri": "/users/302384/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "likes": {
+                                    "uri": "/users/302384/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 47
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/302384/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "portfolios": {
+                                    "uri": "/users/302384/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/302384/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 31
+                                },
+                                "watchlater": {
+                                    "uri": "/users/302384/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/302384/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 84
+                                },
+                                "pictures": {
+                                    "uri": "/users/302384/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "52150d6ebc4aa41ef078438d855282b85cc3515a",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 508,
+                            "height": 406,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/447022885?s=409875_1473803812_2b98a5f565b5dd32916c3340b956fa77&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-01T07:49:55+00:00",
+                            "fps": 30,
+                            "size": 8754252,
+                            "md5": "85751f37e8b615fb457907e8eb8614af"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/447022885/hls?s=409875_1473800212_2f0aaa06c8c0e822e6fe31a91cd98e83&oauth2_token_id=903107513",
+                            "created_time": "2015-12-01T07:49:55+00:00",
+                            "fps": 30,
+                            "size": 8754252,
+                            "md5": "85751f37e8b615fb457907e8eb8614af",
+                            "link_secure": "https://player.vimeo.com/play/447022885/hls?s=409875_1473800212_2f0aaa06c8c0e822e6fe31a91cd98e83&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 508,
+                            "height": 406,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/447022885?s=409875_2947596824_6ddbf627b9cc4541b6ae2d230cea690e&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=videokubism112.mp4",
+                            "created_time": "2015-12-01T07:49:55+00:00",
+                            "fps": 30,
+                            "size": 8754252,
+                            "md5": "85751f37e8b615fb457907e8eb8614af"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "3e07a9a430a84f371be1804c8c2eb6e8b76cfac3",
+                    "embed_presets": null
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/animation/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 409405
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/animation",
+                "name": "Animation",
+                "link": "https://vimeo.com/categories/animation",
+                "top_level": true,
+                "pictures": {
+                    "uri": "/videos/180222262/pictures/588383651",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/588383651_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/588383651_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/588383651_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/588383651_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/588383651_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/588383651_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 356,
+                            "link": "https://i.vimeocdn.com/video/588383651_640x356.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/588383651_640x356.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 534,
+                            "link": "https://i.vimeocdn.com/video/588383651_960x534.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/588383651_960x534.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "db9dc53e196af5362cfb0f363e6ac01f6a3a0830"
+                },
+                "last_video_featured_time": null,
+                "parent": null,
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/animation/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 33140
+                        },
+                        "groups": {
+                            "uri": "/categories/animation/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 8430
+                        },
+                        "users": {
+                            "uri": "/categories/animation/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 1806
+                        },
+                        "videos": {
+                            "uri": "/categories/animation/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 409405
+                        }
+                    }
+                },
+                "subcategories": [
+                    {
+                        "uri": "/categories/animation/subcategories/2d",
+                        "name": "2D",
+                        "link": "https://vimeo.com/categories/animation/2d/videos"
+                    },
+                    {
+                        "uri": "/categories/animation/subcategories/3d",
+                        "name": "3D/CG",
+                        "link": "https://vimeo.com/categories/animation/3d/videos"
+                    },
+                    {
+                        "uri": "/categories/animation/subcategories/mograph",
+                        "name": "Mograph",
+                        "link": "https://vimeo.com/categories/animation/mograph/videos"
+                    },
+                    {
+                        "uri": "/categories/animation/subcategories/projectionmapping",
+                        "name": "Projection Mapping",
+                        "link": "https://vimeo.com/categories/animation/projectionmapping/videos"
+                    },
+                    {
+                        "uri": "/categories/animation/subcategories/stopmotion",
+                        "name": "Stop Frame",
+                        "link": "https://vimeo.com/categories/animation/stopmotion/videos"
+                    },
+                    {
+                        "uri": "/categories/animation/subcategories/vfx",
+                        "name": "VFX",
+                        "link": "https://vimeo.com/categories/animation/vfx/videos"
+                    }
+                ],
+                "resource_key": "a622babbdfc1bd91a993b011a47b5a02330f5812"
+            }
+        },
+        {
+            "uri": "/categories/documentary",
+            "name": "Documentary",
+            "type": "category",
+            "content": [
+                {
+                    "uri": "/videos/1226296",
+                    "name": "Copenhagen Film Festival - sweetie",
+                    "description": null,
+                    "link": "https://vimeo.com/1226296",
+                    "duration": 30,
+                    "width": 504,
+                    "language": null,
+                    "height": 380,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1226296?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"504\" height=\"380\" frameborder=\"0\" title=\"Copenhagen Film Festival - sweetie\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-06-24T17:17:27+00:00",
+                    "modified_time": "2016-09-13T16:09:03+00:00",
+                    "release_time": "2008-06-24T17:17:27+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1226296/pictures/57036609",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/57036609_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57036609_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/57036609_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57036609_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/57036609_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57036609_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 483,
+                                "link": "https://i.vimeocdn.com/video/57036609_640x483.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57036609_640x483.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 725,
+                                "link": "https://i.vimeocdn.com/video/57036609_960x725.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/57036609_960x725.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "b26e73166ec9a0727b60888f2a64c398e01baf94"
+                    },
+                    "tags": [],
+                    "stats": {
+                        "plays": 1902
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1226296/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/1226296/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1226296/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 4
+                            },
+                            "pictures": {
+                                "uri": "/videos/1226296/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1226296/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/556282",
+                        "name": "Peter Farver",
+                        "link": "https://vimeo.com/user556282",
+                        "location": "Currently: Copenhagen, Denmark",
+                        "bio": null,
+                        "created_time": "2008-06-23T14:59:31+00:00",
+                        "account": "basic",
+                        "pictures": null,
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "peterfarver.wordpress.com",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/556282/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/556282/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/556282/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/556282/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/556282/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/556282/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/556282/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "following": {
+                                    "uri": "/users/556282/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/556282/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/556282/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 2
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/556282/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/556282/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/556282/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 21
+                                },
+                                "watchlater": {
+                                    "uri": "/users/556282/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "shared": {
+                                    "uri": "/users/556282/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/556282/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 0
+                                }
+                            }
+                        },
+                        "resource_key": "a9fd8d54c302e02f6b32725a41864de56567b0fe",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/450964961?s=1226296_1473803812_1112e2a3681e2d5d9968cf64dc7ec252&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-09T09:17:29+00:00",
+                            "fps": 25,
+                            "size": 3172835,
+                            "md5": "243d85c2ff7e129fa700cff727472304"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/450964961/hls?s=1226296_1473800212_f59f36c3d95e51be0a1cf3e4eea20fbb&oauth2_token_id=903107513",
+                            "created_time": "2015-12-09T09:17:29+00:00",
+                            "fps": 25,
+                            "size": 3172835,
+                            "md5": "243d85c2ff7e129fa700cff727472304",
+                            "link_secure": "https://player.vimeo.com/play/450964961/hls?s=1226296_1473800212_f59f36c3d95e51be0a1cf3e4eea20fbb&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/450964961?s=1226296_2947596824_eeefe9eab5a45c0751c428f95588c9b8&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Copenhagen%2BFilm%2BFestival%2B-%2Bsweetie112.mp4",
+                            "created_time": "2015-12-09T09:17:29+00:00",
+                            "fps": 25,
+                            "size": 3172835,
+                            "md5": "243d85c2ff7e129fa700cff727472304"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "166b260fc84f9d7bad1eef256e641263eef146ac",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/964198",
+                    "name": "Filmmaking Tip #6: How To Be A Producer",
+                    "description": "Want to make movies? Want to be a rich, famous, award-winning Producer?\n\nDov S-S Simens shows you how!",
+                    "link": "https://vimeo.com/964198",
+                    "duration": 477,
+                    "width": 320,
+                    "language": null,
+                    "height": 240,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/964198?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"320\" height=\"240\" frameborder=\"0\" title=\"Filmmaking Tip #6: How To Be A Producer\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-05-01T20:54:18+00:00",
+                    "modified_time": "2016-09-13T16:17:41+00:00",
+                    "release_time": "2008-05-01T20:54:18+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": true,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/964198/pictures/54134524",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/54134524_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/54134524_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/54134524_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/54134524_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/54134524_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/54134524_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 480,
+                                "link": "https://i.vimeocdn.com/video/54134524_640x480.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/54134524_640x480.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/54134524_960x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/54134524_960x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "ea4b2a81f6df6a91e38163c564cfd66f2b84da02"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/filmschool",
+                            "name": "FILM SCHOOL",
+                            "tag": "FILM SCHOOL",
+                            "canonical": "filmschool",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/filmschool/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5969
+                                    }
+                                }
+                            },
+                            "resource_key": "20cea04026dfa46735937b71fe6c8b18dbd03897"
+                        },
+                        {
+                            "uri": "/tags/dovsimens",
+                            "name": "DOV SIMENS",
+                            "tag": "DOV SIMENS",
+                            "canonical": "dovsimens",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/dovsimens/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 35
+                                    }
+                                }
+                            },
+                            "resource_key": "37ffa6229f688733151d5d8f810f17cf383555ab"
+                        },
+                        {
+                            "uri": "/tags/filmmaker",
+                            "name": "FILMMAKER",
+                            "tag": "FILMMAKER",
+                            "canonical": "filmmaker",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/filmmaker/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 23003
+                                    }
+                                }
+                            },
+                            "resource_key": "c4ec7461dcda915246701ddc3defe67b253000f8"
+                        },
+                        {
+                            "uri": "/tags/moviemaker",
+                            "name": "MOVIEMAKER",
+                            "tag": "MOVIEMAKER",
+                            "canonical": "moviemaker",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/moviemaker/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1145
+                                    }
+                                }
+                            },
+                            "resource_key": "3f0f31b2b234373d74dd8df7a6b297764712eb68"
+                        },
+                        {
+                            "uri": "/tags/stevenspielberg",
+                            "name": "STEVEN SPIELBERG",
+                            "tag": "STEVEN SPIELBERG",
+                            "canonical": "stevenspielberg",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/stevenspielberg/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1013
+                                    }
+                                }
+                            },
+                            "resource_key": "69348529b2b917d4994d8cc3c4db30ac279f7b80"
+                        },
+                        {
+                            "uri": "/tags/georgelucas",
+                            "name": "GEORGE LUCAS",
+                            "tag": "GEORGE LUCAS",
+                            "canonical": "georgelucas",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/georgelucas/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 702
+                                    }
+                                }
+                            },
+                            "resource_key": "3c72b9551ce78e645dd6557987ffa9c27ee86f45"
+                        },
+                        {
+                            "uri": "/tags/hollywood",
+                            "name": "HOLLYWOOD",
+                            "tag": "HOLLYWOOD",
+                            "canonical": "hollywood",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hollywood/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 27726
+                                    }
+                                }
+                            },
+                            "resource_key": "9e87fa8098af69c6bbcae132cdd1b0e8be639ef0"
+                        },
+                        {
+                            "uri": "/tags/bollywood",
+                            "name": "BOLLYWOOD",
+                            "tag": "BOLLYWOOD",
+                            "canonical": "bollywood",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/bollywood/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 7913
+                                    }
+                                }
+                            },
+                            "resource_key": "63351aabc6220845a7178850ea9e436672ef8500"
+                        },
+                        {
+                            "uri": "/tags/independentfilmmaking",
+                            "name": "INDEPENDENT FILMMAKING",
+                            "tag": "INDEPENDENT FILMMAKING",
+                            "canonical": "independentfilmmaking",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/independentfilmmaking/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 571
+                                    }
+                                }
+                            },
+                            "resource_key": "eb90bed8e02ec9b6b1f3d78ec7bf7a19c8d1b195"
+                        },
+                        {
+                            "uri": "/tags/digitalfilm",
+                            "name": "DIGITAL FILM",
+                            "tag": "DIGITAL FILM",
+                            "canonical": "digitalfilm",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/digitalfilm/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 696
+                                    }
+                                }
+                            },
+                            "resource_key": "e78724bad724a9609797eb4cb180da7c177d8848"
+                        },
+                        {
+                            "uri": "/tags/hd",
+                            "name": "HD",
+                            "tag": "HD",
+                            "canonical": "hd",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hd/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 217925
+                                    }
+                                }
+                            },
+                            "resource_key": "cf970111950f35ba4bfc936efd2722716e571896"
+                        },
+                        {
+                            "uri": "/tags/hdv",
+                            "name": "HDV",
+                            "tag": "HDV",
+                            "canonical": "hdv",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/hdv/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5605
+                                    }
+                                }
+                            },
+                            "resource_key": "920731c5d2fa4912f90bc292e025887190155736"
+                        },
+                        {
+                            "uri": "/tags/minidv",
+                            "name": "MINI-DV",
+                            "tag": "MINI-DV",
+                            "canonical": "minidv",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/minidv/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1260
+                                    }
+                                }
+                            },
+                            "resource_key": "fa0836ce0ec61550b9ebc6b185769700b3c89bf3"
+                        },
+                        {
+                            "uri": "/tags/oscars",
+                            "name": "OSCARS",
+                            "tag": "OSCARS",
+                            "canonical": "oscars",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/oscars/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 2555
+                                    }
+                                }
+                            },
+                            "resource_key": "f21e87bc87fe2d3557bf15aa946564291d773e63"
+                        },
+                        {
+                            "uri": "/tags/emmys",
+                            "name": "EMMYS",
+                            "tag": "EMMYS",
+                            "canonical": "emmys",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/emmys/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 348
+                                    }
+                                }
+                            },
+                            "resource_key": "90fe4193a624c6f1a5027e99dd1db472556cdaa7"
+                        },
+                        {
+                            "uri": "/tags/sundance",
+                            "name": "SUNDANCE",
+                            "tag": "SUNDANCE",
+                            "canonical": "sundance",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sundance/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3524
+                                    }
+                                }
+                            },
+                            "resource_key": "78c323a127dc9ec0572a7f1367c60d0ac2fae7fd"
+                        },
+                        {
+                            "uri": "/tags/cannes",
+                            "name": "CANNES",
+                            "tag": "CANNES",
+                            "canonical": "cannes",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cannes/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 9348
+                                    }
+                                }
+                            },
+                            "resource_key": "21e435d7a59073d2e61bb502cda0f22c71fa16ba"
+                        },
+                        {
+                            "uri": "/tags/quentintarrantino",
+                            "name": "QUENTIN TARRANTINO",
+                            "tag": "QUENTIN TARRANTINO",
+                            "canonical": "quentintarrantino",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/quentintarrantino/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 29
+                                    }
+                                }
+                            },
+                            "resource_key": "3ce7ceecf48c4719d17dc2ccfa93fd57e22d528a"
+                        },
+                        {
+                            "uri": "/tags/spikelee",
+                            "name": "SPIKE LEE",
+                            "tag": "SPIKE LEE",
+                            "canonical": "spikelee",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/spikelee/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 752
+                                    }
+                                }
+                            },
+                            "resource_key": "9ec03e6948e6e5d127485821841249b7f49a899c"
+                        },
+                        {
+                            "uri": "/tags/robertrodriquez",
+                            "name": "ROBERT RODRIQUEZ",
+                            "tag": "ROBERT RODRIQUEZ",
+                            "canonical": "robertrodriquez",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/robertrodriquez/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 24
+                                    }
+                                }
+                            },
+                            "resource_key": "fdb08eafd7cf6a25ce39a687575c37df7b9abf7f"
+                        },
+                        {
+                            "uri": "/tags/dvdfilmschool",
+                            "name": "DVD FILM SCHOOL",
+                            "tag": "DVD FILM SCHOOL",
+                            "canonical": "dvdfilmschool",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/dvdfilmschool/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 31
+                                    }
+                                }
+                            },
+                            "resource_key": "653cd35a27492a4bae102201d751277fef7658aa"
+                        },
+                        {
+                            "uri": "/tags/webfilmschool",
+                            "name": "WEB FILM SCHOOL",
+                            "tag": "WEB FILM SCHOOL",
+                            "canonical": "webfilmschool",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/webfilmschool/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 31
+                                    }
+                                }
+                            },
+                            "resource_key": "ec839b2fce38ee6e74302c640aaa0fa1c7faa81a"
+                        },
+                        {
+                            "uri": "/tags/sony",
+                            "name": "SONY",
+                            "tag": "SONY",
+                            "canonical": "sony",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/sony/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 72546
+                                    }
+                                }
+                            },
+                            "resource_key": "f646eed00e26333ccf7b50aaf93b1c6b681932e7"
+                        },
+                        {
+                            "uri": "/tags/canon",
+                            "name": "CANON",
+                            "tag": "CANON",
+                            "canonical": "canon",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/canon/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 270156
+                                    }
+                                }
+                            },
+                            "resource_key": "021a94bcfa552fe87c74ab460aee5d723f8c2478"
+                        },
+                        {
+                            "uri": "/tags/uclauscnyufilmschool",
+                            "name": "UCLA USC NYU FILM SCHOOL",
+                            "tag": "UCLA USC NYU FILM SCHOOL",
+                            "canonical": "uclauscnyufilmschool",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/uclauscnyufilmschool/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 31
+                                    }
+                                }
+                            },
+                            "resource_key": "dec43dbdd13937b1769ccb3a52493814672861e2"
+                        },
+                        {
+                            "uri": "/tags/newyorkfilmacademy",
+                            "name": "NEW YORK FILM ACADEMY",
+                            "tag": "NEW YORK FILM ACADEMY",
+                            "canonical": "newyorkfilmacademy",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/newyorkfilmacademy/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1375
+                                    }
+                                }
+                            },
+                            "resource_key": "9c197989ef397a5607db44e2fee9e55e9955fedf"
+                        },
+                        {
+                            "uri": "/tags/movieschool",
+                            "name": "MOVIE SCHOOL",
+                            "tag": "MOVIE SCHOOL",
+                            "canonical": "movieschool",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/movieschool/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 32
+                                    }
+                                }
+                            },
+                            "resource_key": "b0bb4e8894a60026d5d81bb1ed79880fd2036689"
+                        },
+                        {
+                            "uri": "/tags/producer",
+                            "name": "PRODUCER",
+                            "tag": "PRODUCER",
+                            "canonical": "producer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/producer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 25069
+                                    }
+                                }
+                            },
+                            "resource_key": "b1fd97fe8930c864db34dc50c1f61920286fe481"
+                        },
+                        {
+                            "uri": "/tags/director",
+                            "name": "DIRECTOR",
+                            "tag": "DIRECTOR",
+                            "canonical": "director",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/director/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 70555
+                                    }
+                                }
+                            },
+                            "resource_key": "5507af4df6922bc7a124bf4db1546e9cfe18652f"
+                        },
+                        {
+                            "uri": "/tags/actor",
+                            "name": "ACTOR",
+                            "tag": "ACTOR",
+                            "canonical": "actor",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/actor/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 47648
+                                    }
+                                }
+                            },
+                            "resource_key": "3b963fa165aa28a30399c42baf80d25cf0606d17"
+                        },
+                        {
+                            "uri": "/tags/actress",
+                            "name": "ACTRESS",
+                            "tag": "ACTRESS",
+                            "canonical": "actress",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/actress/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 21951
+                                    }
+                                }
+                            },
+                            "resource_key": "afea80a6e244b994c5f1cbd2c831877f02d8e32a"
+                        },
+                        {
+                            "uri": "/tags/cinematographer",
+                            "name": "CINEMATOGRAPHER",
+                            "tag": "CINEMATOGRAPHER",
+                            "canonical": "cinematographer",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/cinematographer/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 24114
+                                    }
+                                }
+                            },
+                            "resource_key": "67a379bf3029d2283e6cc10108b09057d0b2c632"
+                        },
+                        {
+                            "uri": "/tags/clinteastwood",
+                            "name": "CLINT EASTWOOD",
+                            "tag": "CLINT EASTWOOD",
+                            "canonical": "clinteastwood",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/clinteastwood/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 911
+                                    }
+                                }
+                            },
+                            "resource_key": "a27c31d1f417f9bb43787d4dd67f84be55b32914"
+                        },
+                        {
+                            "uri": "/tags/wanttodirect",
+                            "name": "WANT TO DIRECT",
+                            "tag": "WANT TO DIRECT",
+                            "canonical": "wanttodirect",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/wanttodirect/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 31
+                                    }
+                                }
+                            },
+                            "resource_key": "a11c25392bb24d114f35ac075776d13cd0f72fb8"
+                        },
+                        {
+                            "uri": "/tags/script",
+                            "name": "SCRIPT",
+                            "tag": "SCRIPT",
+                            "canonical": "script",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/script/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5922
+                                    }
+                                }
+                            },
+                            "resource_key": "9ae817993b59b875c8702a92b0202366bf823973"
+                        },
+                        {
+                            "uri": "/tags/screenplay",
+                            "name": "SCREENPLAY",
+                            "tag": "SCREENPLAY",
+                            "canonical": "screenplay",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/screenplay/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1164
+                                    }
+                                }
+                            },
+                            "resource_key": "28fd0ca19fe20d1a919423f268c1871e4903b355"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 3145
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/964198/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/964198/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/964198/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 3
+                            },
+                            "pictures": {
+                                "uri": "/videos/964198/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/964198/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/140718",
+                        "name": "FilmSchool",
+                        "link": "https://vimeo.com/user140718",
+                        "location": "Santa Monica, CA",
+                        "bio": null,
+                        "created_time": "2006-10-25T22:02:00+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/140718/pictures/1012237",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/1012237_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/1012237_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/1012237_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/1012237_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "5c190505e0a151bab3dc5897a67679d3d9e6fdc5"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/140718/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/140718/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/140718/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/140718/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/140718/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/140718/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/140718/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 28
+                                },
+                                "following": {
+                                    "uri": "/users/140718/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "groups": {
+                                    "uri": "/users/140718/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/140718/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/140718/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/140718/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/140718/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 10
+                                },
+                                "watchlater": {
+                                    "uri": "/users/140718/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/140718/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 29
+                                },
+                                "pictures": {
+                                    "uri": "/users/140718/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "2894d6e54b6ea9b17eb884e7e822019e238f1319",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 320,
+                            "height": 240,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/449610386?s=964198_1473803812_f77df4dc7675eb77597c1ccaa006a751&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-06T08:27:10+00:00",
+                            "fps": 24,
+                            "size": 50778812,
+                            "md5": "923b8440db3bc9cbf831a3180c17a870"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/449610386/hls?s=964198_1473800212_fac25292cd73a6bc4365b9bb01ea4ab0&oauth2_token_id=903107513",
+                            "created_time": "2015-12-06T08:27:10+00:00",
+                            "fps": 24,
+                            "size": 50778812,
+                            "md5": "923b8440db3bc9cbf831a3180c17a870",
+                            "link_secure": "https://player.vimeo.com/play/449610386/hls?s=964198_1473800212_fac25292cd73a6bc4365b9bb01ea4ab0&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 320,
+                            "height": 240,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/449610386?s=964198_2947596824_1568ac95e74a34a0072cd0ff3c6c1ebe&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Filmmaking%2BTip%2B%25236%253A%2BHow%2BTo%2BBe%2BA%2BProducer112.mp4",
+                            "created_time": "2015-12-06T08:27:10+00:00",
+                            "fps": 24,
+                            "size": 50778812,
+                            "md5": "923b8440db3bc9cbf831a3180c17a870"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "6ea90504408daba8834e2d5f9156e3ea05330c8f",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/1515009",
+                    "name": "Alice's Place",
+                    "description": "Documentation of an artist's space. \nRachel Riggs is an artist who works with devised objects and puppet theatre (with DNA and independently). Fascinated by the notion that objects can be imbued with metaphoric life for the purposes of story telling, I decided to visually list Rachel's work surroundings and the references that contextualise her practice.\n\"I found myself looking at things quite calmly, like Alice as she fell down the rabbit hole... cupboard, photos, books, groups of little broken dolls...\"\n\nMusic: Celestial Aeon Project, Track: Masquerade from Album: Aeon 3",
+                    "link": "https://vimeo.com/1515009",
+                    "duration": 136,
+                    "width": 504,
+                    "language": null,
+                    "height": 380,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/1515009?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"504\" height=\"380\" frameborder=\"0\" title=\"Alice&#039;s Place\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-08-12T10:30:19+00:00",
+                    "modified_time": "2016-09-13T03:09:16+00:00",
+                    "release_time": "2008-08-12T10:30:19+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": "by",
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/1515009/pictures/59400169",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/59400169_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59400169_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/59400169_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59400169_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/59400169_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59400169_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 483,
+                                "link": "https://i.vimeocdn.com/video/59400169_640x483.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59400169_640x483.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 725,
+                                "link": "https://i.vimeocdn.com/video/59400169_960x725.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/59400169_960x725.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "38ada79d5cf75d1a6e53925c918ea2e759042543"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/art",
+                            "name": "art",
+                            "tag": "art",
+                            "canonical": "art",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/art/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 446584
+                                    }
+                                }
+                            },
+                            "resource_key": "901d24441d2e8e5202e3820f4ad9cb62ad58ff66"
+                        },
+                        {
+                            "uri": "/tags/diary",
+                            "name": "diary",
+                            "tag": "diary",
+                            "canonical": "diary",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/diary/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 5455
+                                    }
+                                }
+                            },
+                            "resource_key": "c90cdaf0856509e050865e6638713a9928aa2295"
+                        },
+                        {
+                            "uri": "/tags/womenscreativity",
+                            "name": "women's creativity",
+                            "tag": "women's creativity",
+                            "canonical": "womenscreativity",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/womenscreativity/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "ed174dfb5cf64c9ce69906e7623ed4779f10458f"
+                        },
+                        {
+                            "uri": "/tags/chantaloakes",
+                            "name": "Chantal Oakes",
+                            "tag": "Chantal Oakes",
+                            "canonical": "chantaloakes",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/chantaloakes/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 31
+                                    }
+                                }
+                            },
+                            "resource_key": "155dd4f9049035a8591124782f7efe4b79d33584"
+                        },
+                        {
+                            "uri": "/tags/celestialaeonproject",
+                            "name": "Celestial Aeon Project",
+                            "tag": "Celestial Aeon Project",
+                            "canonical": "celestialaeonproject",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/celestialaeonproject/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 34
+                                    }
+                                }
+                            },
+                            "resource_key": "07fb67bd6b7cabc08c915e480267d91e3f491543"
+                        },
+                        {
+                            "uri": "/tags/rachelriggs",
+                            "name": "Rachel Riggs",
+                            "tag": "Rachel Riggs",
+                            "canonical": "rachelriggs",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/rachelriggs/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11
+                                    }
+                                }
+                            },
+                            "resource_key": "bd8fd9bb5ee2b40bdc5d9e35295f8629567e1936"
+                        },
+                        {
+                            "uri": "/tags/dynamicnewanimation",
+                            "name": "Dynamic New Animation",
+                            "tag": "Dynamic New Animation",
+                            "canonical": "dynamicnewanimation",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/dynamicnewanimation/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "c7237c5c7eeedceb66b34ecbce8893070f66a203"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 1035
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/1515009/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 2
+                            },
+                            "credits": {
+                                "uri": "/videos/1515009/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/1515009/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 1
+                            },
+                            "pictures": {
+                                "uri": "/videos/1515009/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/1515009/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/635446",
+                        "name": "Chantal Oakes 2005-2011",
+                        "link": "https://vimeo.com/chantaloakes",
+                        "location": "UK",
+                        "bio": "Working in multimedia, creating installation pieces using moving image, text and live performance.",
+                        "created_time": "2008-07-27T19:03:19+00:00",
+                        "account": "basic",
+                        "pictures": {
+                            "uri": "/users/635446/pictures/9678469",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/9678469_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/9678469_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/9678469_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/9678469_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "300fceb125ce140529730513f5780619068e6f65"
+                        },
+                        "websites": [],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/635446/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/635446/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "appearances": {
+                                    "uri": "/users/635446/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/635446/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/635446/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 5
+                                },
+                                "feed": {
+                                    "uri": "/users/635446/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/635446/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 85
+                                },
+                                "following": {
+                                    "uri": "/users/635446/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 72
+                                },
+                                "groups": {
+                                    "uri": "/users/635446/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 19
+                                },
+                                "likes": {
+                                    "uri": "/users/635446/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 138
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/635446/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "portfolios": {
+                                    "uri": "/users/635446/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/635446/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 69
+                                },
+                                "watchlater": {
+                                    "uri": "/users/635446/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "shared": {
+                                    "uri": "/users/635446/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 249
+                                },
+                                "pictures": {
+                                    "uri": "/users/635446/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "6a5720fd075c422addf4b20b105e6c511aff79df",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/452734222?s=1515009_1473803812_27c978dafde6f6c050a8e2a9d7cca771&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T06:38:09+00:00",
+                            "fps": 30,
+                            "size": 14276194,
+                            "md5": "b96b7975fcce431d1da351566521cdb8"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/452734222/hls?s=1515009_1473800212_8cb5da9b5568af9a8def3c397dd9874a&oauth2_token_id=903107513",
+                            "created_time": "2015-12-13T06:38:09+00:00",
+                            "fps": 30,
+                            "size": 14276194,
+                            "md5": "b96b7975fcce431d1da351566521cdb8",
+                            "link_secure": "https://player.vimeo.com/play/452734222/hls?s=1515009_1473800212_8cb5da9b5568af9a8def3c397dd9874a&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 504,
+                            "height": 380,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/452734222?s=1515009_2947596824_7de4ceb82f16a13860dfd83add7eeb1d&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Alice%2527s%2BPlace112.mp4",
+                            "created_time": "2015-12-13T06:38:09+00:00",
+                            "fps": 30,
+                            "size": 14276194,
+                            "md5": "b96b7975fcce431d1da351566521cdb8"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "af1ed3dbf087761c3083b8e808fbfa5abaf493f9",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/2172629",
+                    "name": "LoveStory_2008",
+                    "description": "Canon XH A1",
+                    "link": "https://vimeo.com/2172629",
+                    "duration": 292,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/2172629?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"LoveStory_2008\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2008-11-06T18:59:05+00:00",
+                    "modified_time": "2016-09-13T18:07:17+00:00",
+                    "release_time": "2008-11-06T18:59:05+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/2172629/pictures/86258568",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/86258568_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/86258568_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/86258568_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/86258568_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/86258568_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/86258568_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/86258568_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "5269dd1137b3915320aaf35df37caccf047a4582"
+                    },
+                    "tags": [
+                        {
+                            "uri": "/tags/rostov-on-don",
+                            "name": "Rostov-on-Don",
+                            "tag": "Rostov-on-Don",
+                            "canonical": "rostov-on-don",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/rostov-on-don/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 171
+                                    }
+                                }
+                            },
+                            "resource_key": "1e67a919761a84b572b3b498b2c55637f6e018f0"
+                        },
+                        {
+                            "uri": "/tags/Ростов-на-Дону",
+                            "name": "Ростов-на-Дону",
+                            "tag": "Ростов-на-Дону",
+                            "canonical": "Ростов-на-Дону",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/Ростов-на-Дону/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 331
+                                    }
+                                }
+                            },
+                            "resource_key": "b0109eb0990888082be484ec80467d7d0e349ba9"
+                        },
+                        {
+                            "uri": "/tags/Свадьбы",
+                            "name": "Свадьбы",
+                            "tag": "Свадьбы",
+                            "canonical": "Свадьбы",
+                            "metadata": {
+                                "connections": {
+                                    "videos": {
+                                        "uri": "/tags/Свадьбы/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 120
+                                    }
+                                }
+                            },
+                            "resource_key": "76331f6dd9a5cfb259753c5fc5a2df0092353136"
+                        }
+                    ],
+                    "stats": {
+                        "plays": 6968
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/2172629/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 18
+                            },
+                            "credits": {
+                                "uri": "/videos/2172629/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/2172629/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 11
+                            },
+                            "pictures": {
+                                "uri": "/videos/2172629/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/2172629/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/878443",
+                        "name": "VideoMaster st. AUGUST",
+                        "link": "https://vimeo.com/user878443",
+                        "location": null,
+                        "bio": null,
+                        "created_time": "2008-10-27T20:25:14+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/878443/pictures/970857",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/970857_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/970857_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/970857_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/970857_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "f685d09caff636e17aa40c158ce5b106e3330332"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "AUGUST_Video_Studo",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/878443/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/878443/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "appearances": {
+                                    "uri": "/users/878443/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "categories": {
+                                    "uri": "/users/878443/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/878443/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "feed": {
+                                    "uri": "/users/878443/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/878443/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 158
+                                },
+                                "following": {
+                                    "uri": "/users/878443/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 9
+                                },
+                                "groups": {
+                                    "uri": "/users/878443/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "likes": {
+                                    "uri": "/users/878443/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 290
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/878443/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "portfolios": {
+                                    "uri": "/users/878443/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/878443/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 97
+                                },
+                                "watchlater": {
+                                    "uri": "/users/878443/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "shared": {
+                                    "uri": "/users/878443/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 369
+                                },
+                                "pictures": {
+                                    "uri": "/users/878443/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "6476d117da914a3a2dfa957de5b2d06a8aaf43c6",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/456686425?s=2172629_1473803812_241b9fc25bcca1038e24a063686ad4e6&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-22T02:15:56+00:00",
+                            "fps": 24,
+                            "size": 30399131,
+                            "md5": "720d14fc6ba47d6a4b48fee61867ae15"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/456686421?s=2172629_1473803812_dd4e50de673a5d06574674f924d3a1ee&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2015-12-22T02:15:56+00:00",
+                            "fps": 24,
+                            "size": 96179255,
+                            "md5": "940445e344280f4a802a9a3168fef67e"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/456686425,456686421/hls?s=2172629_1473800212_1c33ff50ff0776c4d0b2acbdd52b958d&oauth2_token_id=903107513",
+                            "created_time": "2015-12-22T02:15:56+00:00",
+                            "fps": 24,
+                            "size": 30399131,
+                            "md5": "720d14fc6ba47d6a4b48fee61867ae15",
+                            "link_secure": "https://player.vimeo.com/play/456686425,456686421/hls?s=2172629_1473800212_1c33ff50ff0776c4d0b2acbdd52b958d&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/456686425?s=2172629_2947596824_c024bdbf6d3ea08e5a0aa56b771fd116&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=LoveStory_2008112.mp4",
+                            "created_time": "2015-12-22T02:15:56+00:00",
+                            "fps": 24,
+                            "size": 30399131,
+                            "md5": "720d14fc6ba47d6a4b48fee61867ae15"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/456686421?s=2172629_2947596824_83a1b272e920ca497d7cc8d30df918f8&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=LoveStory_2008113.mp4",
+                            "created_time": "2015-12-22T02:15:56+00:00",
+                            "fps": 24,
+                            "size": 96179255,
+                            "md5": "940445e344280f4a802a9a3168fef67e"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "aa22071de76ba2712f29705f07259d12bc6f66c9",
+                    "embed_presets": null
+                },
+                {
+                    "uri": "/videos/32845061",
+                    "name": "Desafio Levantemos Chile, en que estamos hoy",
+                    "description": "Video realizado por Caja de Compensación Los Héroes, en el marco de su programa \"Héroes destacados 2011\"",
+                    "link": "https://vimeo.com/desafiotv/desafio2011",
+                    "duration": 113,
+                    "width": 1280,
+                    "language": null,
+                    "height": 720,
+                    "embed": {
+                        "html": "<iframe src=\"https://player.vimeo.com/video/32845061?title=0&byline=0&portrait=0&badge=0&autopause=0&player_id=0\" width=\"1280\" height=\"720\" frameborder=\"0\" title=\"Desafio Levantemos Chile, en que estamos hoy\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+                    },
+                    "created_time": "2011-11-29T13:43:51+00:00",
+                    "modified_time": "2016-09-13T18:12:01+00:00",
+                    "release_time": "2011-11-29T13:43:51+00:00",
+                    "content_rating": [
+                        "unrated"
+                    ],
+                    "license": null,
+                    "privacy": {
+                        "view": "anybody",
+                        "embed": "public",
+                        "download": false,
+                        "add": true,
+                        "comments": "anybody"
+                    },
+                    "pictures": {
+                        "uri": "/videos/32845061/pictures/222495722",
+                        "active": true,
+                        "type": "custom",
+                        "sizes": [
+                            {
+                                "width": 100,
+                                "height": 75,
+                                "link": "https://i.vimeocdn.com/video/222495722_100x75.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 200,
+                                "height": 150,
+                                "link": "https://i.vimeocdn.com/video/222495722_200x150.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 295,
+                                "height": 166,
+                                "link": "https://i.vimeocdn.com/video/222495722_295x166.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 640,
+                                "height": 360,
+                                "link": "https://i.vimeocdn.com/video/222495722_640x360.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 960,
+                                "height": 540,
+                                "link": "https://i.vimeocdn.com/video/222495722_960x540.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            },
+                            {
+                                "width": 1280,
+                                "height": 720,
+                                "link": "https://i.vimeocdn.com/video/222495722_1280x720.jpg?r=pad",
+                                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/222495722_1280x720.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                            }
+                        ],
+                        "resource_key": "82f49fa46fcea42496b5d552efa1ea372a4a0ddf"
+                    },
+                    "tags": [],
+                    "stats": {
+                        "plays": null
+                    },
+                    "metadata": {
+                        "connections": {
+                            "comments": {
+                                "uri": "/videos/32845061/comments",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "credits": {
+                                "uri": "/videos/32845061/credits",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "likes": {
+                                "uri": "/videos/32845061/likes",
+                                "options": [
+                                    "GET"
+                                ],
+                                "total": 0
+                            },
+                            "pictures": {
+                                "uri": "/videos/32845061/pictures",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 1
+                            },
+                            "texttracks": {
+                                "uri": "/videos/32845061/texttracks",
+                                "options": [
+                                    "GET",
+                                    "POST"
+                                ],
+                                "total": 0
+                            },
+                            "related": null
+                        }
+                    },
+                    "user": {
+                        "uri": "/users/9451748",
+                        "name": "Desafío Levantemos Chile",
+                        "link": "https://vimeo.com/desafiotv",
+                        "location": "Chile",
+                        "bio": "DesafíoTV es el equipo audiovisual de Desafío Levantemos Chile. Buscamos, por medio del audiovisual, extender puentes entre las necesidades y quienes pueden satisfacerlas. Aquí podrás encontrar videos de los proyectos, programas, campañas y todo lo relacionado con nuestra fundación.",
+                        "created_time": "2011-11-29T13:06:39+00:00",
+                        "account": "plus",
+                        "pictures": {
+                            "uri": "/users/9451748/pictures/2873059",
+                            "active": true,
+                            "type": "custom",
+                            "sizes": [
+                                {
+                                    "width": 30,
+                                    "height": 30,
+                                    "link": "https://i.vimeocdn.com/portrait/2873059_30x30?r=pad"
+                                },
+                                {
+                                    "width": 75,
+                                    "height": 75,
+                                    "link": "https://i.vimeocdn.com/portrait/2873059_75x75?r=pad"
+                                },
+                                {
+                                    "width": 100,
+                                    "height": 100,
+                                    "link": "https://i.vimeocdn.com/portrait/2873059_100x100?r=pad"
+                                },
+                                {
+                                    "width": 300,
+                                    "height": 300,
+                                    "link": "https://i.vimeocdn.com/portrait/2873059_300x300?r=pad"
+                                }
+                            ],
+                            "resource_key": "0e531fb12e63b06e3807547d1f2129b9c3fcb3b4"
+                        },
+                        "websites": [
+                            {
+                                "name": null,
+                                "link": "www.desafiolevantemoschile.cl",
+                                "description": null
+                            }
+                        ],
+                        "metadata": {
+                            "connections": {
+                                "activities": {
+                                    "uri": "/users/9451748/activities",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "albums": {
+                                    "uri": "/users/9451748/albums",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 11
+                                },
+                                "appearances": {
+                                    "uri": "/users/9451748/appearances",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "categories": {
+                                    "uri": "/users/9451748/categories",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "channels": {
+                                    "uri": "/users/9451748/channels",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "feed": {
+                                    "uri": "/users/9451748/feed",
+                                    "options": [
+                                        "GET"
+                                    ]
+                                },
+                                "followers": {
+                                    "uri": "/users/9451748/followers",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 79
+                                },
+                                "following": {
+                                    "uri": "/users/9451748/following",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 19
+                                },
+                                "groups": {
+                                    "uri": "/users/9451748/groups",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "likes": {
+                                    "uri": "/users/9451748/likes",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 17
+                                },
+                                "moderated_channels": {
+                                    "uri": "/users/9451748/channels?filter=moderated",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 1
+                                },
+                                "portfolios": {
+                                    "uri": "/users/9451748/portfolios",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "videos": {
+                                    "uri": "/users/9451748/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 365
+                                },
+                                "watchlater": {
+                                    "uri": "/users/9451748/watchlater",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 3
+                                },
+                                "shared": {
+                                    "uri": "/users/9451748/shared/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 0
+                                },
+                                "pictures": {
+                                    "uri": "/users/9451748/pictures",
+                                    "options": [
+                                        "GET",
+                                        "POST"
+                                    ],
+                                    "total": 1
+                                }
+                            }
+                        },
+                        "resource_key": "c0f528dc708975e83f3bc0f32cd8fcadeeeeff9f",
+                        "preferences": {
+                            "videos": {
+                                "privacy": null
+                            }
+                        }
+                    },
+                    "files": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 270,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/78268529?s=32845061_1473803812_edc9b3fa93700adf3d3cb21a963246a5&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2011-12-29T17:28:10+00:00",
+                            "fps": 23.98,
+                            "size": 5615614,
+                            "md5": "45c0b79461edb2013f449b0b41f30987"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/74562251?s=32845061_1473803812_5eac74072c36f80c2728d19c1bc7bb4a&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2011-11-29T14:23:57+00:00",
+                            "fps": 23.98,
+                            "size": 37387400,
+                            "md5": "28ca27f190e4feca06eb1fbd7a50f77a"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/74562052?s=32845061_1473803812_e98bfc09cc260b8820025170352fa89c&sid=9e840d1266546b95d7f7b2075ee9029c01cd012c1473793012&oauth2_token_id=903107513",
+                            "created_time": "2011-11-29T14:22:10+00:00",
+                            "fps": 23.98,
+                            "size": 10015220,
+                            "md5": "f25e12e726f73a4ca7c1bbb7e7e8049b"
+                        },
+                        {
+                            "quality": "hls",
+                            "type": "video/mp4",
+                            "expires": "2016-09-13T20:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/78268529,74562251,74562052/hls?s=32845061_1473800212_33e70430b4ee40911ac84f4fec85841c&oauth2_token_id=903107513",
+                            "created_time": "2011-12-29T17:28:10+00:00",
+                            "fps": 23.98,
+                            "size": 5615614,
+                            "md5": "45c0b79461edb2013f449b0b41f30987",
+                            "link_secure": "https://player.vimeo.com/play/78268529,74562251,74562052/hls?s=32845061_1473800212_33e70430b4ee40911ac84f4fec85841c&oauth2_token_id=903107513"
+                        }
+                    ],
+                    "download": [
+                        {
+                            "quality": "mobile",
+                            "type": "video/mp4",
+                            "width": 480,
+                            "height": 270,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/78268529?s=32845061_2947596824_af0468a61efbba820c88e3d8295445a5&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Desafio%2BLevantemos%2BChile%252C%2Ben%2Bque%2Bestamos%2Bhoy116.mp4",
+                            "created_time": "2011-12-29T17:28:10+00:00",
+                            "fps": 23.98,
+                            "size": 5615614,
+                            "md5": "45c0b79461edb2013f449b0b41f30987"
+                        },
+                        {
+                            "quality": "hd",
+                            "type": "video/mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/74562251?s=32845061_2947596824_de6ec4d61f60f9b230efac27459e5a55&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Desafio%2BLevantemos%2BChile%252C%2Ben%2Bque%2Bestamos%2Bhoy113.mp4",
+                            "created_time": "2011-11-29T14:23:57+00:00",
+                            "fps": 23.98,
+                            "size": 37387400,
+                            "md5": "28ca27f190e4feca06eb1fbd7a50f77a"
+                        },
+                        {
+                            "quality": "sd",
+                            "type": "video/mp4",
+                            "width": 640,
+                            "height": 360,
+                            "expires": "2016-09-13T21:56:52+00:00",
+                            "link": "https://player.vimeo.com/play/74562052?s=32845061_2947596824_76a7d16983f32bfd008f1b3b75a50333&loc=external&context=Vimeo%5CController%5CApi%5CResources%5CProgrammed%5CCinemaController.&download=1&filename=Desafio%2BLevantemos%2BChile%252C%2Ben%2Bque%2Bestamos%2Bhoy107.mp4",
+                            "created_time": "2011-11-29T14:22:10+00:00",
+                            "fps": 23.98,
+                            "size": 10015220,
+                            "md5": "f25e12e726f73a4ca7c1bbb7e7e8049b"
+                        }
+                    ],
+                    "app": null,
+                    "status": "available",
+                    "resource_key": "058e4eaaf8cde44883b64db403178d7f4b94609e",
+                    "embed_presets": {
+                        "uri": "/presets/329222",
+                        "name": "Incrustación de Canal",
+                        "settings": {
+                            "buttons": {
+                                "like": true,
+                                "watchlater": true,
+                                "share": true,
+                                "embed": true,
+                                "vote": false,
+                                "hd": false
+                            },
+                            "logos": {
+                                "vimeo": true,
+                                "custom": false,
+                                "sticky_custom": false
+                            },
+                            "outro": "link",
+                            "portrait": "show",
+                            "title": "show",
+                            "byline": "show",
+                            "badge": false,
+                            "byline_badge": false,
+                            "collections_button": false,
+                            "playbar": true,
+                            "volume": true,
+                            "fullscreen_button": true,
+                            "scaling_button": true,
+                            "autoplay": false,
+                            "autopause": true,
+                            "loop": false,
+                            "color": "ff9933",
+                            "link": true,
+                            "overlay_email_capture": -1,
+                            "overlay_email_capture_text": "Like what you see? Let’s stay in touch.",
+                            "overlay_email_capture_confirmation": "Thanks! We’ll be in touch."
+                        },
+                        "metadata": {
+                            "connections": {
+                                "videos": {
+                                    "uri": "/presets/329222/videos",
+                                    "options": [
+                                        "GET"
+                                    ],
+                                    "total": 416
+                                }
+                            }
+                        },
+                        "user": {
+                            "uri": "/users/9451748",
+                            "name": "Desafío Levantemos Chile",
+                            "link": "https://vimeo.com/desafiotv",
+                            "location": "Chile",
+                            "bio": "DesafíoTV es el equipo audiovisual de Desafío Levantemos Chile. Buscamos, por medio del audiovisual, extender puentes entre las necesidades y quienes pueden satisfacerlas. Aquí podrás encontrar videos de los proyectos, programas, campañas y todo lo relacionado con nuestra fundación.",
+                            "created_time": "2011-11-29T13:06:39+00:00",
+                            "account": "plus",
+                            "pictures": {
+                                "uri": "/users/9451748/pictures/2873059",
+                                "active": true,
+                                "type": "custom",
+                                "sizes": [
+                                    {
+                                        "width": 30,
+                                        "height": 30,
+                                        "link": "https://i.vimeocdn.com/portrait/2873059_30x30?r=pad"
+                                    },
+                                    {
+                                        "width": 75,
+                                        "height": 75,
+                                        "link": "https://i.vimeocdn.com/portrait/2873059_75x75?r=pad"
+                                    },
+                                    {
+                                        "width": 100,
+                                        "height": 100,
+                                        "link": "https://i.vimeocdn.com/portrait/2873059_100x100?r=pad"
+                                    },
+                                    {
+                                        "width": 300,
+                                        "height": 300,
+                                        "link": "https://i.vimeocdn.com/portrait/2873059_300x300?r=pad"
+                                    }
+                                ],
+                                "resource_key": "0e531fb12e63b06e3807547d1f2129b9c3fcb3b4"
+                            },
+                            "websites": [
+                                {
+                                    "name": null,
+                                    "link": "www.desafiolevantemoschile.cl",
+                                    "description": null
+                                }
+                            ],
+                            "metadata": {
+                                "connections": {
+                                    "activities": {
+                                        "uri": "/users/9451748/activities",
+                                        "options": [
+                                            "GET"
+                                        ]
+                                    },
+                                    "albums": {
+                                        "uri": "/users/9451748/albums",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 11
+                                    },
+                                    "appearances": {
+                                        "uri": "/users/9451748/appearances",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 0
+                                    },
+                                    "categories": {
+                                        "uri": "/users/9451748/categories",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 0
+                                    },
+                                    "channels": {
+                                        "uri": "/users/9451748/channels",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    },
+                                    "feed": {
+                                        "uri": "/users/9451748/feed",
+                                        "options": [
+                                            "GET"
+                                        ]
+                                    },
+                                    "followers": {
+                                        "uri": "/users/9451748/followers",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 79
+                                    },
+                                    "following": {
+                                        "uri": "/users/9451748/following",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 19
+                                    },
+                                    "groups": {
+                                        "uri": "/users/9451748/groups",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    },
+                                    "likes": {
+                                        "uri": "/users/9451748/likes",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 17
+                                    },
+                                    "moderated_channels": {
+                                        "uri": "/users/9451748/channels?filter=moderated",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 1
+                                    },
+                                    "portfolios": {
+                                        "uri": "/users/9451748/portfolios",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 0
+                                    },
+                                    "videos": {
+                                        "uri": "/users/9451748/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 365
+                                    },
+                                    "watchlater": {
+                                        "uri": "/users/9451748/watchlater",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 3
+                                    },
+                                    "shared": {
+                                        "uri": "/users/9451748/shared/videos",
+                                        "options": [
+                                            "GET"
+                                        ],
+                                        "total": 0
+                                    },
+                                    "pictures": {
+                                        "uri": "/users/9451748/pictures",
+                                        "options": [
+                                            "GET",
+                                            "POST"
+                                        ],
+                                        "total": 1
+                                    }
+                                }
+                            },
+                            "resource_key": "c0f528dc708975e83f3bc0f32cd8fcadeeeeff9f",
+                            "preferences": {
+                                "videos": {
+                                    "privacy": null
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "metadata": {
+                "connections": {
+                    "contents": {
+                        "uri": "/categories/documentary/videos?sort=featured",
+                        "options": [
+                            "GET"
+                        ],
+                        "total": 68988
+                    }
+                }
+            },
+            "category": {
+                "uri": "/categories/documentary",
+                "name": "Documentary",
+                "link": "https://vimeo.com/categories/documentary",
+                "top_level": true,
+                "pictures": {
+                    "uri": "/videos/182586640/pictures/591534428",
+                    "active": true,
+                    "type": "custom",
+                    "sizes": [
+                        {
+                            "width": 100,
+                            "height": 75,
+                            "link": "https://i.vimeocdn.com/video/591534428_100x75.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591534428_100x75.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 200,
+                            "height": 150,
+                            "link": "https://i.vimeocdn.com/video/591534428_200x150.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591534428_200x150.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 295,
+                            "height": 166,
+                            "link": "https://i.vimeocdn.com/video/591534428_295x166.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591534428_295x166.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 640,
+                            "height": 360,
+                            "link": "https://i.vimeocdn.com/video/591534428_640x360.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591534428_640x360.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        },
+                        {
+                            "width": 960,
+                            "height": 540,
+                            "link": "https://i.vimeocdn.com/video/591534428_960x540.jpg?r=pad",
+                            "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src=https://i.vimeocdn.com/video/591534428_960x540.jpg&src=http://f.vimeocdn.com/p/images/crawler_play.png"
+                        }
+                    ],
+                    "resource_key": "69954ea4e7a45e6329b4ffcec2cc7b01c3d31ffd"
+                },
+                "last_video_featured_time": null,
+                "parent": null,
+                "metadata": {
+                    "connections": {
+                        "channels": {
+                            "uri": "/categories/documentary/channels",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 9900
+                        },
+                        "groups": {
+                            "uri": "/categories/documentary/groups",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 1135
+                        },
+                        "users": {
+                            "uri": "/categories/documentary/users",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 697
+                        },
+                        "videos": {
+                            "uri": "/categories/documentary/videos",
+                            "options": [
+                                "GET"
+                            ],
+                            "total": 68988
+                        }
+                    }
+                },
+                "subcategories": [
+                    {
+                        "uri": "/categories/documentary/subcategories/artsandcraft",
+                        "name": "Arts & Craft",
+                        "link": "https://vimeo.com/categories/documentary/artsandcraft/videos"
+                    },
+                    {
+                        "uri": "/categories/documentary/subcategories/cultureandtech",
+                        "name": "Culture & Tech",
+                        "link": "https://vimeo.com/categories/documentary/cultureandtech/videos"
+                    },
+                    {
+                        "uri": "/categories/documentary/subcategories/nature",
+                        "name": "Nature",
+                        "link": "https://vimeo.com/categories/documentary/nature/videos"
+                    },
+                    {
+                        "uri": "/categories/documentary/subcategories/people",
+                        "name": "People",
+                        "link": "https://vimeo.com/categories/documentary/people/videos"
+                    },
+                    {
+                        "uri": "/categories/documentary/subcategories/sportsdocumentary",
+                        "name": "Sports",
+                        "link": "https://vimeo.com/categories/documentary/sportsdocumentary/videos"
+                    }
+                ],
+                "resource_key": "18c548549d079953dcf6e14749810ae872883da4"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### Ticket
[TVOS-373](https://vimean.atlassian.net/browse/TVOS-373)

#### Ticket Summary
Add new model object to represent ProgrammedContent objects returned from the new /programmed/* endpoints.  Add a new request for fetching objects from the new /programmed/cinema endpoint.

#### Implementation Summary
- Added VIMProgrammedContent model object
- Added a new VIMConnection for ProgrammedContents "contents" connection.
- Added Request+ProgrammedContent extension and added method for creating Cinema requests
- Added the FakeDataSource class to help with writing unit tests to check model parsing logic.  The FakeDataSource class allows you to read in a JSON file that can be created by saving the output of a curl request against an API endpoint.  The class then parses the model objects out of the JSON file using the same object mapper that's used by our networking requests.
- Added new unit tests to the test app to validate the VIMProgrammedContent model.
- Added a bunch of missing model files to the VimeoNetworking project file to fix compiler issues.

#### How to Test
1. Run the Sample apps unit tests.