### PR TITLE
Added MIT License Header

### DIFF
--- a/VimeoNetworking/VimeoNetworking/AccountStore.swift
+++ b/VimeoNetworking/VimeoNetworking/AccountStore.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/24/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
+++ b/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/28/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/AuthenticationController.swift
+++ b/VimeoNetworking/VimeoNetworking/AuthenticationController.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/21/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/ErrorCode.swift
+++ b/VimeoNetworking/VimeoNetworking/ErrorCode.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/25/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/ExceptionCatcher+Swift.swift
+++ b/VimeoNetworking/VimeoNetworking/ExceptionCatcher+Swift.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/KeychainStore.swift
+++ b/VimeoNetworking/VimeoNetworking/KeychainStore.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/24/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 import Security

--- a/VimeoNetworking/VimeoNetworking/Mappable.swift
+++ b/VimeoNetworking/VimeoNetworking/Mappable.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/22/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Models/PinCodeInfo.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/PinCodeInfo.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 5/9/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMAccount.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMAccount.h
@@ -1,6 +1,6 @@
 //
 //  VIMAccount.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 10/28/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMAccount.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMAccount.m
@@ -1,6 +1,6 @@
 //
 //  VIMAccount.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 10/28/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMActivity.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMActivity.h
@@ -1,6 +1,6 @@
 //
 //  VIMActivity.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/26/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMActivity.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMActivity.m
@@ -1,6 +1,6 @@
 //
 //  VIMActivity.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/26/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMAppeal.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMAppeal.h
@@ -1,6 +1,6 @@
 //
 //  VIMAppeal.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/24/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMAppeal.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMAppeal.m
@@ -1,6 +1,6 @@
 //
 //  VIMAppeal.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/24/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMBadge.swift
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMBadge.swift
@@ -1,9 +1,27 @@
 //
 //  VIMBadge.swift
-//  Pods
+//  VimeoNetworking
 //
 //  Created by Huebner, Rob on 9/16/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/VimeoNetworking/VimeoNetworking/Models/VIMCategory.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMCategory.h
@@ -1,6 +1,6 @@
 //
 //  VIMCategory.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Huebner, Rob on 5/14/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMCategory.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMCategory.m
@@ -1,6 +1,6 @@
 //
 //  VIMCategory.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 5/20/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMChannel.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMChannel.h
@@ -1,6 +1,6 @@
 //
 //  VIMChannel.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 9/30/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMChannel.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMChannel.m
@@ -1,6 +1,6 @@
 //
 //  VIMChannel.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 9/30/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMComment.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMComment.h
@@ -1,6 +1,6 @@
 //
 //  VIMComment.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/25/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMComment.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMComment.m
@@ -1,6 +1,6 @@
 //
 //  VIMComment.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/25/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMConnection.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMConnection.h
@@ -1,6 +1,6 @@
 //
 //  VIMConnection.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 6/16/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMConnection.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMConnection.m
@@ -1,6 +1,6 @@
 //
 //  VIMConnection.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 6/16/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMGroup.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMGroup.h
@@ -1,6 +1,6 @@
 //
 //  VIMGroup.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 10/9/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMGroup.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMGroup.m
@@ -1,6 +1,6 @@
 //
 //  VIMGroup.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 10/9/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMInteraction.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMInteraction.h
@@ -1,6 +1,6 @@
 //
 //  VIMInteraction.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/23/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMInteraction.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMInteraction.m
@@ -1,6 +1,6 @@
 //
 //  VIMInteraction.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/23/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPicture.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPicture.h
@@ -1,6 +1,6 @@
 //
 //  VIMPicture.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 5/31/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPicture.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPicture.m
@@ -1,6 +1,6 @@
 //
 //  VIMPicture.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 5/31/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPictureCollection.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPictureCollection.h
@@ -1,6 +1,6 @@
 //
 //  VIMPictureCollection.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Whitcomb, Andrew on 9/4/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPictureCollection.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPictureCollection.m
@@ -1,6 +1,6 @@
 //
 //  VIMPictureCollection.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Whitcomb, Andrew on 9/4/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPreference.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPreference.h
@@ -1,6 +1,6 @@
 //
 //  VIMPreference.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 6/16/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPreference.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPreference.m
@@ -1,6 +1,6 @@
 //
 //  VIMPreference.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 6/16/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPrivacy.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPrivacy.h
@@ -1,6 +1,6 @@
 //
 //  VIMPrivacy.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/24/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPrivacy.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPrivacy.m
@@ -1,6 +1,6 @@
 //
 //  VIMPrivacy.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Muhammad on 9/24/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMQuantityQuota.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMQuantityQuota.h
@@ -1,6 +1,6 @@
 //
 //  VIMQuantityQuota.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMQuantityQuota.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMQuantityQuota.m
@@ -1,6 +1,6 @@
 //
 //  VIMQuantityQuota.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMSizeQuota.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMSizeQuota.h
@@ -1,6 +1,6 @@
 //
 //  VIMSizeQuota.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMSizeQuota.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMSizeQuota.m
@@ -1,6 +1,6 @@
 //
 //  VIMSizeQuota.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMSoundtrack.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMSoundtrack.h
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMModelObject.h"
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMSoundtrack.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMSoundtrack.m
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMSoundtrack.h"
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMTag.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMTag.h
@@ -1,6 +1,6 @@
 //
 //  VIMTag.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Huebner, Rob on 11/4/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMTag.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMTag.m
@@ -1,6 +1,6 @@
 //
 //  VIMTag.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Huebner, Rob on 11/4/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMThumbnailUploadTicket.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMThumbnailUploadTicket.h
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 6/28/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #include "VIMModelObject.h"
 

--- a/VimeoNetworking/VimeoNetworking/Models/VIMThumbnailUploadTicket.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMThumbnailUploadTicket.m
@@ -5,8 +5,27 @@
 //  Created by Westendorf, Michael on 6/28/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "VIMThumbnailUploadTicket.h"
 
 @implementation VIMThumbnailUploadTicket
+
 @end

--- a/VimeoNetworking/VimeoNetworking/Models/VIMTrigger.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMTrigger.h
@@ -1,6 +1,6 @@
 //
 //  VIMTrigger.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Whitcomb, Andrew on 10/29/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMTrigger.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMTrigger.m
@@ -1,6 +1,6 @@
 //
 //  VIMTrigger.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Whitcomb, Andrew on 10/29/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUploadQuota.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUploadQuota.h
@@ -1,6 +1,6 @@
 //
 //  VIMUploadQuota.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUploadQuota.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUploadQuota.m
@@ -1,6 +1,6 @@
 //
 //  VIMUploadQuota.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/6/15.
 //  Copyright (c) 2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUploadTicket.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUploadTicket.h
@@ -1,6 +1,6 @@
 //
 //  VIMUploadTicket.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Alfred Hanssen on 11/21/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUploadTicket.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUploadTicket.m
@@ -1,6 +1,6 @@
 //
 //  VIMUploadTicket.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Alfred Hanssen on 11/21/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUser.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUser.h
@@ -1,6 +1,6 @@
 //
 //  VIMUser.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 4/4/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUser.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUser.m
@@ -1,6 +1,6 @@
 //
 //  VIMUser.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 4/4/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUserBadge.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUserBadge.h
@@ -1,6 +1,6 @@
 //
 //  VIMUserBadge.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Jake Oliver on 8/8/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMUserBadge.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMUserBadge.m
@@ -1,6 +1,6 @@
 //
 //  VIMUserBadge.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Jake Oliver on 8/8/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideo.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 3/23/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideo.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideo.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 3/23/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoDASHFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoDASHFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoDASHFile.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/16/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoDASHFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoDASHFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoDASHFile.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/16/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoDRMFiles.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoDRMFiles.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoDRMFiles.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoDRMFiles.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoDRMFiles.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoDRMFiles.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFairPlayFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFairPlayFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoFairPlayFile.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFairPlayFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFairPlayFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoFairPlayFile.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by King, Gavin on 7/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoFile.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 4/13/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoFile.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Kashif Mohammad on 4/13/13.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoHLSFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoHLSFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoHLSFile.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoHLSFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoHLSFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoHLSFile.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoLog.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoLog.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoLog.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/19/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoLog.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoLog.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoLog.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/19/14.
 //  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPlayFile.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPlayFile.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayRepresentation.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayRepresentation.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPlayRepresentation.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/11/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayRepresentation.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPlayRepresentation.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPlayRepresentation.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/11/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPreference.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPreference.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPreference.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 6/16/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoPreference.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoPreference.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoPreference.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 6/16/15.
 //  Copyright (c) 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoProgressiveFile.h
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoProgressiveFile.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoProgressiveFile.m
-//  Vimeo
+//  VimeoNetworking
 //
 //  Created by Lehrer, Nicole on 5/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoUtils.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoUtils.h
@@ -1,6 +1,6 @@
 //
 //  VIMVideoUtils.h
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/5/15.
 //  Copyright © 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoUtils.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoUtils.m
@@ -1,6 +1,6 @@
 //
 //  VIMVideoUtils.m
-//  VIMNetworking
+//  VimeoNetworking
 //
 //  Created by Hanssen, Alfie on 11/5/15.
 //  Copyright © 2015 Vimeo. All rights reserved.

--- a/VimeoNetworking/VimeoNetworking/Notification.swift
+++ b/VimeoNetworking/VimeoNetworking/Notification.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/25/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Objc_ExceptionCatcher.h
+++ b/VimeoNetworking/VimeoNetworking/Objc_ExceptionCatcher.h
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import <Foundation/Foundation.h>
 

--- a/VimeoNetworking/VimeoNetworking/Objc_ExceptionCatcher.m
+++ b/VimeoNetworking/VimeoNetworking/Objc_ExceptionCatcher.m
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import "ObjC_ExceptionCatcher.h"
 

--- a/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/23/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Cache.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Cache.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/14/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Category.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Category.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/25/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Channel.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Channel.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/25/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+ProgrammedContent.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+ProgrammedContent.swift
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 9/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Soundtrack.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Soundtrack.swift
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 4/21/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Toggle.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Toggle.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/26/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+User.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+User.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/22/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request+Video.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Video.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/5/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Request.swift
+++ b/VimeoNetworking/VimeoNetworking/Request.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/22/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 import AFNetworking

--- a/VimeoNetworking/VimeoNetworking/Response.swift
+++ b/VimeoNetworking/VimeoNetworking/Response.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/5/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/ResponseCache.swift
+++ b/VimeoNetworking/VimeoNetworking/ResponseCache.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/29/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Result.swift
+++ b/VimeoNetworking/VimeoNetworking/Result.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/23/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/Scope.swift
+++ b/VimeoNetworking/VimeoNetworking/Scope.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/23/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/String+Parameters.swift
+++ b/VimeoNetworking/VimeoNetworking/String+Parameters.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/29/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/VIMObjectMapper+Generic.swift
+++ b/VimeoNetworking/VimeoNetworking/VIMObjectMapper+Generic.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/12/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/VimeoClient.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoClient.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/21/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworking/VimeoNetworking.h
+++ b/VimeoNetworking/VimeoNetworking/VimeoNetworking.h
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/20/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #import <UIKit/UIKit.h>
 

--- a/VimeoNetworking/VimeoNetworking/VimeoSessionManager+Constructors.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoSessionManager+Constructors.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/29/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
+++ b/VimeoNetworking/VimeoNetworkingTests/NSErrorExtensionTests.swift
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 7/5/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 

--- a/VimeoNetworking/VimeoNetworkingTests/VimeoNetworkingTests.swift
+++ b/VimeoNetworking/VimeoNetworkingTests/VimeoNetworkingTests.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 4/20/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 @testable import VimeoNetworking

--- a/VimeoNetworkingExample-iOS/VimeoNetworking-Bridging-Header.h
+++ b/VimeoNetworkingExample-iOS/VimeoNetworking-Bridging-Header.h
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/21/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 #ifndef VimeoNetworking_Bridging_Header_h
 #define VimeoNetworking_Bridging_Header_h

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/AppDelegate.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/AppDelegate.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import UIKit
 import VimeoNetworking

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/DetailViewController.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/DetailViewController.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import UIKit
 

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import UIKit
 

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/VimeoClient+Shared.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/VimeoClient+Shared.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 5/13/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/FakeDataSource.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/FakeDataSource.swift
@@ -5,6 +5,24 @@
 //  Created by Westendorf, Michael on 7/25/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Foundation
 @testable import VimeoNetworkingExample_iOS

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/ModelObjectValidationTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/ModelObjectValidationTests.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 5/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 @testable import VimeoNetworkingExample_iOS

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoNetworkingExample_iOSTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoNetworkingExample_iOSTests.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 @testable import VimeoNetworkingExample_iOS

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSUITests/VimeoNetworkingExample_iOSUITests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSUITests/VimeoNetworkingExample_iOSUITests.swift
@@ -5,6 +5,24 @@
 //  Created by Huebner, Rob on 3/17/16.
 //  Copyright © 2016 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 


### PR DESCRIPTION
Added license header to all files. Updated module name that appears in comments above license header.

Many files touched, worth a glance but the changes are strictly copying and pasting the license header into place, and modifying the module name in comments just above the license header. 
