### PR TITLE
VIM-4736: AnyObject Parameters

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,32 +1,26 @@
 PODS:
-  - AFNetworking (2.6.3):
-    - AFNetworking/NSURLConnection (= 2.6.3)
-    - AFNetworking/NSURLSession (= 2.6.3)
-    - AFNetworking/Reachability (= 2.6.3)
-    - AFNetworking/Security (= 2.6.3)
-    - AFNetworking/Serialization (= 2.6.3)
-    - AFNetworking/UIKit (= 2.6.3)
-  - AFNetworking/NSURLConnection (2.6.3):
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.3):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.3)
-  - AFNetworking/Security (2.6.3)
-  - AFNetworking/Serialization (2.6.3)
-  - AFNetworking/UIKit (2.6.3):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
 
 DEPENDENCIES:
-  - AFNetworking (= 2.6.3)
+  - AFNetworking (= 3.1.0)
 
 SPEC CHECKSUMS:
-  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
 
-PODFILE CHECKSUM: 7f16f3abf847d3c95295561a00a1b0d9eae453cf
+PODFILE CHECKSUM: f029646618c3c6ff77b34f9b4b724035e4922175
 
 COCOAPODS: 1.0.1

--- a/VimeoNetworking/VimeoNetworking/AuthenticationController.swift
+++ b/VimeoNetworking/VimeoNetworking/AuthenticationController.swift
@@ -193,9 +193,9 @@ final public class AuthenticationController
     public func codeGrant(responseURL responseURL: NSURL, completion: AuthenticationCompletion)
     {
         guard let queryString = responseURL.query,
-            let parameters = queryString.parametersFromQueryString(),
-            let code = parameters[self.dynamicType.CodeKey],
-            let state = parameters[self.dynamicType.StateKey]
+            let parametersDictionary = queryString.parametersDictionaryFromQueryString(),
+            let code = parametersDictionary[self.dynamicType.CodeKey],
+            let state = parametersDictionary[self.dynamicType.StateKey]
         else
         {
             let errorDescription = "Could not retrieve parameters from code grant response"

--- a/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
@@ -55,8 +55,8 @@ extension Request where ModelType: VIMAccount
      */
     static func clientCredentialsGrantRequest(scopes scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypeClientCredentials,
-                                                         ScopeKey: Scope.combine(scopes)]
+        let parameters = [GrantTypeKey: GrantTypeClientCredentials,
+                          ScopeKey: Scope.combine(scopes)]
         
         return Request(method: .POST, path: AuthenticationPathClientCredentials, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -71,9 +71,9 @@ extension Request where ModelType: VIMAccount
      */
     static func codeGrantRequest(code code: String, redirectURI: String) -> Request
     {
-        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypeAuthorizationCode,
-                                                         CodeKey: code,
-                                                         RedirectURIKey: redirectURI]
+        let parameters = [GrantTypeKey: GrantTypeAuthorizationCode,
+                          CodeKey: code,
+                          RedirectURIKey: redirectURI]
         
         return Request(method: .POST, path: AuthenticationPathCodeGrant, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -89,10 +89,10 @@ extension Request where ModelType: VIMAccount
      */
     static func logInRequest(email email: String, password: String, scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypePassword,
-                                                         ScopeKey: Scope.combine(scopes),
-                                                         UsernameKey: email,
-                                                         PasswordKey: password]
+        let parameters = [GrantTypeKey: GrantTypePassword,
+                          ScopeKey: Scope.combine(scopes),
+                          UsernameKey: email,
+                          PasswordKey: password]
         
         return Request(method: .POST, path: AuthenticationPathAccessToken, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }

--- a/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Authentication.swift
@@ -55,7 +55,7 @@ extension Request where ModelType: VIMAccount
      */
     static func clientCredentialsGrantRequest(scopes scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [GrantTypeKey: GrantTypeClientCredentials,
+        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypeClientCredentials,
                                                          ScopeKey: Scope.combine(scopes)]
         
         return Request(method: .POST, path: AuthenticationPathClientCredentials, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
@@ -71,7 +71,7 @@ extension Request where ModelType: VIMAccount
      */
     static func codeGrantRequest(code code: String, redirectURI: String) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [GrantTypeKey: GrantTypeAuthorizationCode,
+        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypeAuthorizationCode,
                                                          CodeKey: code,
                                                          RedirectURIKey: redirectURI]
         
@@ -89,7 +89,7 @@ extension Request where ModelType: VIMAccount
      */
     static func logInRequest(email email: String, password: String, scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [GrantTypeKey: GrantTypePassword,
+        let parameters: VimeoClient.RequestDictionary = [GrantTypeKey: GrantTypePassword,
                                                          ScopeKey: Scope.combine(scopes),
                                                          UsernameKey: email,
                                                          PasswordKey: password]
@@ -104,7 +104,7 @@ extension Request where ModelType: VIMAccount
      */
     static func verifyAccessTokenRequest() -> Request
     {
-        return Request(method: .GET, path: AuthenticationPathAccessTokenVerify, parameters: nil, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
+        return Request(method: .GET, path: AuthenticationPathAccessTokenVerify, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
     
     /**
@@ -119,10 +119,10 @@ extension Request where ModelType: VIMAccount
      */
     static func joinRequest(name name: String, email: String, password: String, scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [ScopeKey: Scope.combine(scopes),
-                                                         DisplayNameKey: name,
-                                                         EmailKey: email,
-                                                         PasswordKey: password]
+        let parameters = [ScopeKey: Scope.combine(scopes),
+                          DisplayNameKey: name,
+                          EmailKey: email,
+                          PasswordKey: password]
         
         return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -137,9 +137,9 @@ extension Request where ModelType: VIMAccount
      */
     static func logInFacebookRequest(facebookToken facebookToken: String, scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [GrantTypeKey: GrantTypeFacebook,
-                                                         ScopeKey: Scope.combine(scopes),
-                                                         TokenKey: facebookToken]
+        let parameters = [GrantTypeKey: GrantTypeFacebook,
+                          ScopeKey: Scope.combine(scopes),
+                          TokenKey: facebookToken]
         
         return Request(method: .POST, path: AuthenticationPathFacebookToken, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -154,8 +154,8 @@ extension Request where ModelType: VIMAccount
      */
     static func joinFacebookRequest(facebookToken facebookToken: String, scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [ScopeKey: Scope.combine(scopes),
-                                                         TokenKey: facebookToken]
+        let parameters = [ScopeKey: Scope.combine(scopes),
+                          TokenKey: facebookToken]
         
         return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -170,8 +170,8 @@ extension Request where ModelType: VIMAccount
      */
     static func authorizePinCodeRequest(userCode userCode: String, deviceCode: String) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [PinCodeKey: userCode,
-                                                         DeviceCodeKey: deviceCode]
+        let parameters = [PinCodeKey: userCode,
+                          DeviceCodeKey: deviceCode]
         
         return Request(method: .POST, path: AuthenticationPathPinCodeAuthorize, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -185,7 +185,7 @@ extension Request where ModelType: VIMAccount
      */
     static func appTokenExchangeRequest(accessToken accessToken: String) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [AccessTokenKey: accessToken]
+        let parameters = [AccessTokenKey: accessToken]
         
         return Request(method: .POST, path: AuthenticationPathAppTokenExchange, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }
@@ -201,6 +201,20 @@ extension Request where ModelType: VIMNullResponse
     public static func deleteTokensRequest() -> Request
     {
         return Request(method: .DELETE, path: AuthenticationPathTokens, retryPolicy: .TryThreeTimes)
+    }
+    
+    /**
+     Construct a `Request` for resetting the user's password
+     
+     - parameter email: the user's email
+     
+     - returns: a new `Request`
+     */
+    public static func resetPasswordRequest(withEmail email: String) -> Request
+    {
+        let path = "/users/" + email + "/password/reset"
+        
+        return Request(method: .POST, path: path)
     }
 }
 
@@ -219,8 +233,8 @@ extension Request where ModelType: PinCodeInfo
      */
     static func getPinCodeRequest(scopes scopes: [Scope]) -> Request
     {
-        let parameters: VimeoClient.RequestParameters = [GrantTypeKey: GrantTypePinCode,
-                                                         ScopeKey: Scope.combine(scopes)]
+        let parameters = [GrantTypeKey: GrantTypePinCode,
+                          ScopeKey: Scope.combine(scopes)]
         
         return Request(method: .POST, path: AuthenticationPathPinCode, parameters: parameters, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: false)
     }

--- a/VimeoNetworking/VimeoNetworking/Request+Cache.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Cache.swift
@@ -8,23 +8,17 @@
 
 import Foundation
 
+
 public extension Request
 {
-        /// Generates a unique cache key for a request, taking into account endpoint and parameters
+    /// Generates a unique cache key for a request, taking into account endpoint and parameters
     var cacheKey: String
     {
         var cacheKey = "cached" + self.path
         
-        for (key, value) in self.parameters
+        if let parameters = self.parameters
         {
-            if key == "fields"
-            {
-                // avoiding the field filtering key due to excessive length
-                continue
-            }
-            
-            cacheKey += key
-            cacheKey += value.description
+            cacheKey = cacheKey + "." + String(parameters.description.hashValue)
         }
         
         cacheKey = cacheKey.stringByReplacingOccurrencesOfString("/", withString: ".")

--- a/VimeoNetworking/VimeoNetworking/Request+Channel.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Channel.swift
@@ -40,7 +40,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryChannels(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
+    public static func queryChannels(query query: String, refinements: VimeoClient.RequestParametersDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         

--- a/VimeoNetworking/VimeoNetworking/Request+Channel.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Channel.swift
@@ -40,7 +40,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryChannels(query query: String, refinements: VimeoClient.RequestParameters? = nil) -> Request
+    public static func queryChannels(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         

--- a/VimeoNetworking/VimeoNetworking/Request+Configs.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Configs.swift
@@ -1,0 +1,33 @@
+//
+//  Request+Configs.swift
+//  Pods
+//
+//  Created by King, Gavin on 10/31/16.
+//
+//
+
+import UIKit
+
+extension Request
+{
+    /**
+     Create a `Request` to get the app configs
+     
+     - parameter fromCache: request the configs from the local cache
+     
+     - returns: a new `Request`
+     */
+    public static func configsRequest(fromCache fromCache: Bool) -> Request
+    {
+        let path = "/configs"
+        
+        if fromCache
+        {
+            return Request(method: .GET, path: path, cacheFetchPolicy: .CacheOnly)
+        }
+        else
+        {
+            return Request(method: .GET, path: path, cacheFetchPolicy: .NetworkOnly, shouldCacheResponse: true)
+        }
+    }
+}

--- a/VimeoNetworking/VimeoNetworking/Request+Trigger.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Trigger.swift
@@ -22,7 +22,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func registerDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
+    public static func registerDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken)
         
@@ -38,7 +38,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func unregisterDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
+    public static func unregisterDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken)
 
@@ -53,7 +53,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func addPushNotificationTrigger(withParameters parameters: VimeoClient.RequestDictionary) -> Request
+    public static func addPushNotificationTrigger(withParameters parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         return Request(method: .POST, path: self.TriggerURI, parameters: parameters)
     }
@@ -79,7 +79,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func pushNotificationTriggers(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
+    public static func pushNotificationTriggers(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken) + self.TriggerURI
 

--- a/VimeoNetworking/VimeoNetworking/Request+Trigger.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Trigger.swift
@@ -22,7 +22,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func registerDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParameters) -> Request
+    public static func registerDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken)
         
@@ -38,7 +38,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func unregisterDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParameters) -> Request
+    public static func unregisterDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken)
 
@@ -53,7 +53,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func addPushNotificationTrigger(withParameters parameters: VimeoClient.RequestParameters) -> Request
+    public static func addPushNotificationTrigger(withParameters parameters: VimeoClient.RequestDictionary) -> Request
     {
         return Request(method: .POST, path: self.TriggerURI, parameters: parameters)
     }
@@ -79,7 +79,7 @@ extension Request
      
      - returns: a new `Request`
      */
-    public static func pushNotificationTriggers(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParameters) -> Request
+    public static func pushNotificationTriggers(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestDictionary) -> Request
     {
         let uri = self.uri(withDeviceToken: deviceToken) + self.TriggerURI
 

--- a/VimeoNetworking/VimeoNetworking/Request+User.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+User.swift
@@ -99,7 +99,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryUsers(query query: String, refinements: VimeoClient.RequestParameters? = nil) -> Request
+    public static func queryUsers(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         
@@ -118,7 +118,7 @@ public extension Request
      
      - returns: the new `Request`
      */
-    public static func patchUser(userURI userURI: String, parameters: VimeoClient.RequestParameters) -> Request
+    public static func patchUser(userURI userURI: String, parameters: VimeoClient.RequestDictionary) -> Request
     {
         return Request(method: .PATCH, path: userURI, parameters: parameters)
     }

--- a/VimeoNetworking/VimeoNetworking/Request+User.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+User.swift
@@ -99,7 +99,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryUsers(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
+    public static func queryUsers(query query: String, refinements: VimeoClient.RequestParametersDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         
@@ -118,7 +118,7 @@ public extension Request
      
      - returns: the new `Request`
      */
-    public static func patchUser(userURI userURI: String, parameters: VimeoClient.RequestDictionary) -> Request
+    public static func patchUser(userURI userURI: String, parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         return Request(method: .PATCH, path: userURI, parameters: parameters)
     }

--- a/VimeoNetworking/VimeoNetworking/Request+Video.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Video.swift
@@ -34,6 +34,49 @@ public extension Request
         return Request(path: videoURI)
     }
     
+    /**
+     Create a `Request` to get a password protected video
+     
+     - parameter videoURI: the URI of the video
+     - parameter password: the password for the video
+     
+     - returns: a new `Request`
+     */
+    static func passwordProtectedVideoRequest(videoURI videoURI: String, password: String) -> Request
+    {
+        let parameters = ["password": password]
+        
+        return Request(path: videoURI, parameters: parameters)
+    }
+    
+    /**
+     Create a `Request` to get a specific VOD video
+     
+     - parameter vodVideoURI: the VOD video's URI
+     
+     - returns: a new `Request`
+     */
+    static func vodVideoRequest(vodVideoURI vodVideoURI: String) -> Request
+    {
+        let parameters = ["_video_override": "true"]
+        
+        return Request(path: vodVideoURI, parameters: parameters)
+    }
+    
+    /**
+     Create a `Request` to get the selected users for the vieo
+     
+     - parameter videoURI: the URI of the video
+     
+     - returns: a new `Request`
+     */
+    static func selectedUsersRequest(videoURI videoURI: String) -> Request
+    {
+        let parameters = [VimeoClient.PerPageKey: 100]
+        
+        return Request(path: videoURI, parameters: parameters)
+    }
+    
     // MARK: - Search
     
     /**
@@ -44,7 +87,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryVideos(query query: String, refinements: VimeoClient.RequestParameters? = nil) -> Request
+    public static func queryVideos(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         
@@ -63,7 +106,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func patchVideoRequest(videoURI videoURI: String, parameters: VimeoClient.RequestParameters) -> Request
+    public static func patchVideoRequest(videoURI videoURI: String, parameters: VimeoClient.RequestDictionary) -> Request
     {
         return Request(method: .PATCH, path: videoURI, parameters: parameters)
     }

--- a/VimeoNetworking/VimeoNetworking/Request+Video.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+Video.swift
@@ -87,7 +87,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func queryVideos(query query: String, refinements: VimeoClient.RequestDictionary? = nil) -> Request
+    public static func queryVideos(query query: String, refinements: VimeoClient.RequestParametersDictionary? = nil) -> Request
     {
         var parameters = refinements ?? [:]
         
@@ -106,7 +106,7 @@ public extension Request
      
      - returns: a new `Request`
      */
-    public static func patchVideoRequest(videoURI videoURI: String, parameters: VimeoClient.RequestDictionary) -> Request
+    public static func patchVideoRequest(videoURI videoURI: String, parameters: VimeoClient.RequestParametersDictionary) -> Request
     {
         return Request(method: .PATCH, path: videoURI, parameters: parameters)
     }

--- a/VimeoNetworking/VimeoNetworking/String+Parameters.swift
+++ b/VimeoNetworking/VimeoNetworking/String+Parameters.swift
@@ -15,9 +15,9 @@ public extension String
      
      - returns: a dictionary of parameters if parsing succeeded
      */
-    func parametersFromQueryString() -> [String: String]?
+    func parametersDictionaryFromQueryString() -> [String: String]?
     {
-        var parameters: [String: String] = [:]
+        var parametersDictionary: [String: String] = [:]
         
         let scanner = NSScanner(string: self)
         while !scanner.atEnd
@@ -35,11 +35,11 @@ public extension String
             if let name = name?.stringByReplacingPercentEscapesUsingEncoding(NSUTF8StringEncoding),
                 let value = value?.stringByReplacingPercentEscapesUsingEncoding(NSUTF8StringEncoding)
             {
-                parameters[name] = value
+                parametersDictionary[name] = value
             }
         }
         
-        return parameters.count > 0 ? parameters : nil
+        return parametersDictionary.count > 0 ? parametersDictionary : nil
     }
     
     /**

--- a/VimeoNetworking/VimeoNetworking/VimeoClient.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoClient.swift
@@ -55,7 +55,10 @@ final public class VimeoClient
     }
     
         /// Dictionary containing URL parameters for a request
-    public typealias RequestParameters = [String: AnyObject]
+    public typealias RequestDictionary = [String: AnyObject]
+    
+        /// Array containing URL parameters for a request
+    public typealias RequestArray = [AnyObject]
     
         /// Dictionary containing a JSON response
     public typealias ResponseDictionary = [String: AnyObject]
@@ -65,14 +68,14 @@ final public class VimeoClient
     
     // MARK: -
     
-    private static let PagingKey = "paging"
-    private static let TotalKey = "total"
-    private static let PageKey = "page"
-    private static let PerPageKey = "per_page"
-    private static let NextKey = "next"
-    private static let PreviousKey = "previous"
-    private static let FirstKey = "first"
-    private static let LastKey = "last"
+    internal static let PagingKey = "paging"
+    internal static let TotalKey = "total"
+    internal static let PageKey = "page"
+    internal static let PerPageKey = "per_page"
+    internal static let NextKey = "next"
+    internal static let PreviousKey = "previous"
+    internal static let FirstKey = "first"
+    internal static let LastKey = "last"
     
     // MARK: -
     
@@ -207,9 +210,6 @@ final public class VimeoClient
             break
         }
         
-        let path = request.path
-        let parameters = request.parameters
-        
         let success: (NSURLSessionDataTask, AnyObject?) -> Void = { (task, responseObject) in
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)) {
                 networkRequestCompleted = true
@@ -223,6 +223,9 @@ final public class VimeoClient
                 self.handleTaskFailure(request: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
             }
         }
+
+        let path = request.path
+        let parameters = request.parameters
         
         let task: NSURLSessionDataTask?
         

--- a/VimeoNetworking/VimeoNetworking/VimeoClient.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoClient.swift
@@ -125,30 +125,6 @@ final public class VimeoClient
         }
     }
     
-//        /// Returns the current authenticated user, if one exists
-//    public var authenticatedUser: VIMUser?
-//    {
-//        return self.currentAccount?.user
-//    }
-//    
-//        /// Returns true if the current account exists and is authenticated
-//    public var isAuthenticated: Bool
-//    {
-//        return self.currentAccount?.isAuthenticated() ?? false
-//    }
-//    
-//        /// Returns true if the current account exists, is authenticated, and is of type User
-//    public var isAuthenticatedWithUser: Bool
-//    {
-//        return self.currentAccount?.isAuthenticatedWithUser() ?? false
-//    }
-//    
-//        /// Returns true if the current account exists, is authenticated, and is of type ClientCredentials
-//    public var isAuthenticatedWithClientCredentials: Bool
-//    {
-//        return self.currentAccount?.isAuthenticatedWithClientCredentials() ?? false
-//    }
-    
     // MARK: - Request
     
     /**

--- a/VimeoNetworking/VimeoNetworking/VimeoClient.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoClient.swift
@@ -55,10 +55,10 @@ final public class VimeoClient
     }
     
         /// Dictionary containing URL parameters for a request
-    public typealias RequestDictionary = [String: AnyObject]
+    public typealias RequestParametersDictionary = [String: AnyObject]
     
         /// Array containing URL parameters for a request
-    public typealias RequestArray = [AnyObject]
+    public typealias RequestParametersArray = [AnyObject]
     
         /// Dictionary containing a JSON response
     public typealias ResponseDictionary = [String: AnyObject]


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4736

#### Ticket Summary

Previously, VimeoNetworking only supported dictionary types for request parameters. We need to support array types as well as required by certain requests to out API.

#### Implementation Summary

- Modified the `parameters` of Request to be of type AnyObject (corresponding to the AFNetworking and Apple APIs)
- Cleaned up some cache code
- Moved some request code from the app to VimeoNetworking

#### How to Test

Make sure networking works as expected.