### PR TITLE
Add model and requests for PolicyDocuments.

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.h
@@ -1,9 +1,27 @@
 //
 //  VIMPolicyDocument.h
-//  Pods
+//  VimeoNetworking
 //
 //  Created by Westendorf, Michael on 11/8/16.
+//  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 #import "VIMModelObject.h"

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.h
@@ -1,0 +1,15 @@
+//
+//  VIMPolicyDocument.h
+//  Pods
+//
+//  Created by Westendorf, Michael on 11/8/16.
+//
+//
+
+#import "VIMModelObject.h"
+
+@interface VIMPolicyDocument : VIMModelObject
+
+@property (nonatomic, copy, nullable) NSString *html;
+
+@end

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.m
@@ -1,9 +1,27 @@
 //
 //  VIMPolicyDocument.m
-//  Pods
+//  VimeoNetworking
 //
 //  Created by Westendorf, Michael on 11/8/16.
+//  Copyright (c) 2014-2015 Vimeo (https://vimeo.com)
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 #import "VIMPolicyDocument.h"

--- a/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMPolicyDocument.m
@@ -1,0 +1,12 @@
+//
+//  VIMPolicyDocument.m
+//  Pods
+//
+//  Created by Westendorf, Michael on 11/8/16.
+//
+//
+
+#import "VIMPolicyDocument.h"
+
+@implementation VIMPolicyDocument
+@end

--- a/VimeoNetworking/VimeoNetworking/Request+PolicyDocument.swift
+++ b/VimeoNetworking/VimeoNetworking/Request+PolicyDocument.swift
@@ -1,0 +1,56 @@
+//
+//  Request+PolicyDocument.swift
+//  VimeoNetworking
+//
+//  Created by Westendorf, Mike on 11/9/16.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// `Request` returning a single `VIMPolicyDocument`
+public typealias PolicyDocumentRequest = Request<VIMPolicyDocument>
+
+public extension Request
+{
+    private static var TermsOfServiceURI: String { return "/documents/termsofservice" }
+    private static var PrivacyURI: String { return "/documents/privacy" }
+    
+    /**
+     Create a request to get the Terms of Service document
+     
+     - returns: a new `Request`
+     */
+    public static func getTermsOfServiceRequest() -> Request
+    {
+        return Request(path: TermsOfServiceURI)
+    }
+
+    /**
+     Create a request to get the Privacy document
+     
+     - returns: a new `Request`
+     */
+    public static func getPrivacyRequest() -> Request
+    {
+        return Request(path: PrivacyURI)
+    }
+}

--- a/VimeoNetworking/VimeoNetworking/VimeoNetworking.h
+++ b/VimeoNetworking/VimeoNetworking/VimeoNetworking.h
@@ -62,6 +62,7 @@ FOUNDATION_EXPORT const unsigned char VimeoNetworkingVersionString[];
 #import <VimeoNetworking/VIMSoundtrack.h>
 #import <VimeoNetworking/VIMVODItem.h>
 #import <VimeoNetworking/VIMRecommendation.h>
+#import <VimeoNetworking/VIMPolicyDocument.h>
 
 #import <VimeoNetworking/Objc_ExceptionCatcher.h>
 

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -211,8 +211,7 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.ondemand.page+json",
             "application/vnd.vimeo.ondemand.season+json",
             "application/vnd.vimeo.programmed.cinema+json",
-            "application/vnd.vimeo.policydocument+json",
-            "application.vnd.vimeo.policydocument+json"]
+            "application/vnd.vimeo.policydocument+json"]
         )
     }
 }

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -211,7 +211,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.ondemand.page+json",
             "application/vnd.vimeo.ondemand.season+json",
             "application/vnd.vimeo.programmed.cinema+json",
-            "application/vnd.vimeo.policydocument+json"]
+            "application/vnd.vimeo.policydocument+json",
+            "application.vnd.vimeo.policydocument+json"]
         )
     }
 }

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -193,7 +193,6 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             ["application/json",
             "text/json",
             "text/html",
-            "text/plain",
             "text/javascript",
             "application/vnd.vimeo.video+json",
             "application/vnd.vimeo.cover+json",

--- a/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoResponseSerializer.swift
@@ -193,6 +193,7 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             ["application/json",
             "text/json",
             "text/html",
+            "text/plain",
             "text/javascript",
             "application/vnd.vimeo.video+json",
             "application/vnd.vimeo.cover+json",
@@ -209,7 +210,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.song+json",
             "application/vnd.vimeo.ondemand.page+json",
             "application/vnd.vimeo.ondemand.season+json",
-            "application/vnd.vimeo.programmed.cinema+json"]
+            "application/vnd.vimeo.programmed.cinema+json",
+            "application/vnd.vimeo.policydocument+json"]
         )
     }
 }


### PR DESCRIPTION
#### Ticket
[TVOS-433](https://vimean.atlassian.net/browse/TVOS-433)
[TVOS-434](https://vimean.atlassian.net/browse/TVOS-434)

#### Ticket Summary
Added a new model and request for retrieving policy documents from the API endpoint.

#### Implementation Summary
- VIMPolicyDocument - model to represent document object returned from the API
- Request+PolicyDocument - extension to the Request class that adds convenience methods for creating document requests.

#### How to Test
N/A