### PR TITLE
VIM-4739: JSON Request Serializer

### DIFF
--- a/VimeoNetworking/VimeoNetworking/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/VimeoNetworking/VimeoRequestSerializer.swift
@@ -30,7 +30,7 @@ import AFNetworking
 
 /** `VimeoRequestSerializer` is an `AFHTTPRequestSerializer` that primarily handles adding Vimeo-specific authorization headers to outbound requests.  It can be initialized with either a dynamic `AccessTokenProvider` or a static `AppConfiguration`.
  */
-final public class VimeoRequestSerializer: AFHTTPRequestSerializer
+final public class VimeoRequestSerializer: AFJSONRequestSerializer
 {
     private static let AcceptHeaderKey = "Accept"
     private static let AuthorizationHeaderKey = "Authorization"


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4739

#### Ticket Summary

Make VimeoRequestSerializer a AFJSONRequestSerializer.

#### Implementation Summary

After going back and forth with the API, we fixed all the issues surrounding authentication and JSON request serializers. Now that this is fixed we can make JSON requests.

Resolved API issues:

https://github.vimeows.com/Vimeo-API/api/issues/679
https://github.vimeows.com/Vimeo-API/api/issues/727

#### How to Test

Make sure everything works as expected, especially auth.