### PR TITLE
VIM-4790: Keychain Fix

### DIFF
--- a/VimeoNetworking/VimeoNetworking/AccountStore.swift
+++ b/VimeoNetworking/VimeoNetworking/AccountStore.swift
@@ -30,13 +30,27 @@ import Foundation
 final class AccountStore
 {
     /// `AccountType` categorizes an account based on its level of access
-    enum AccountType: String
+    enum AccountType
     {
         /// Client credentials accounts can access only public resources
         case ClientCredentials
         
         /// User accounts have an authenticated user and can act on the user's behalf
         case User
+        
+        func keychainKey() -> String
+        {
+            switch self
+            {
+            case .ClientCredentials:
+                
+                return "ClientCredentialsAccountKey"
+                
+            case .User:
+                
+                return "UserAccountKey"
+            }
+        }
     }
     
     // MARK: - 
@@ -45,7 +59,7 @@ final class AccountStore
     
     // MARK: - 
     
-    private let dataStore: SecureDataStore
+    private let keychainStore: KeychainStore
     
     // MARK: -
     
@@ -58,7 +72,7 @@ final class AccountStore
      */
     init(configuration: AppConfiguration)
     {
-        self.dataStore = KeychainStore(service: configuration.keychainService, accessGroup: configuration.keychainAccessGroup)
+        self.keychainStore = KeychainStore(service: configuration.keychainService, accessGroup: configuration.keychainAccessGroup)
     }
     
     // MARK: -
@@ -78,7 +92,7 @@ final class AccountStore
         archiver.encodeObject(account)
         archiver.finishEncoding()
         
-        try self.dataStore.setData(data, forKey: type.rawValue)
+        try self.keychainStore.setData(data, forKey: type.keychainKey())
     }
     
     /**
@@ -94,7 +108,7 @@ final class AccountStore
     {
         do
         {
-            guard let data = try self.dataStore.dataForKey(type.rawValue)
+            guard let data = try self.keychainStore.dataForKey(type.keychainKey())
             else
             {
                 return nil
@@ -140,6 +154,6 @@ final class AccountStore
      */
     func removeAccount(type: AccountType) throws
     {
-        try self.dataStore.deleteDataForKey(type.rawValue)
+        try self.keychainStore.deleteDataForKey(type.keychainKey())
     }
 }

--- a/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
+++ b/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
@@ -56,7 +56,7 @@ public struct AppConfiguration
                 clientSecret: String,
                 scopes: [Scope],
                 keychainService: String,
-                keychainAccessGroup: String?,
+                keychainAccessGroup: String? = nil,
                 apiVersion: String = VimeoDefaultAPIVersionString)
     {
         self.clientIdentifier = clientIdentifier

--- a/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
+++ b/VimeoNetworking/VimeoNetworking/AppConfiguration.swift
@@ -31,12 +31,6 @@ import Foundation
  */
 public struct AppConfiguration
 {
-        /// Keychain identifier for the Vimeo application
-    public static let KeychainServiceVimeo = "Vimeo"
-    
-        /// Keychain identifier for the Cameo application
-    public static let KeychainServiceCameo = "Cameo"
-    
     public let clientIdentifier: String
     public let clientSecret: String
     public let scopes: [Scope]
@@ -61,8 +55,8 @@ public struct AppConfiguration
     public init(clientIdentifier: String,
                 clientSecret: String,
                 scopes: [Scope],
-                keychainService: String = KeychainServiceVimeo,
-                keychainAccessGroup: String? = nil,
+                keychainService: String,
+                keychainAccessGroup: String?,
                 apiVersion: String = VimeoDefaultAPIVersionString)
     {
         self.clientIdentifier = clientIdentifier

--- a/VimeoNetworking/VimeoNetworking/KeychainStore.swift
+++ b/VimeoNetworking/VimeoNetworking/KeychainStore.swift
@@ -27,44 +27,8 @@
 import Foundation
 import Security
 
-/**
- *  `SecureDataStore` represents an abstract object capable of securely storing, retrieving, and removing data.
- */
-protocol SecureDataStore
-{
-    /**
-     Save data for a given key
-     
-     - parameter data: data to save
-     - parameter key:  identifier for the saved data
-     
-     - throws: an error if saving failed
-     */
-    func setData(data: NSData, forKey key: String) throws
-    
-    /**
-     Load data for a given key
-     
-     - parameter key: identifier for the saved data
-     
-     - throws: an error if loading failed
-     
-     - returns: data, if found
-     */
-    func dataForKey(key: String) throws -> NSData?
-    
-    /**
-     Delete data for a given key
-     
-     - parameter key: identifier for the saved data
-     
-     - throws: an error if deleting failed
-     */
-    func deleteDataForKey(key: String) throws
-}
-
 /// `KeychainStore` saves data securely in the Keychain
-final class KeychainStore: SecureDataStore
+final class KeychainStore
 {
     private let service: String
     private let accessGroup: String?


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4790

#### Ticket Summary

VimeoNetworking was previously using a different keychain configuration to store accounts than VIMNetworking. This PR reverts that change. This allows for seamless migrations from VIMNetworking to VimeoNetworking.

#### Implementation Summary

Modified the keychain keys. Also removed the default keychain values from AppConfiguration.

#### How to Test

Logged in, migrate from 6.1.3 to 6.1.4. You should remain logged in.