### PR TITLE
VIM-4820: Added a new property fps to VIMVideoFile model object.

### DIFF
--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.h
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.h
@@ -39,6 +39,7 @@ extern NSString *const __nonnull VIMVideoFileQualityMobile;
 @property (nonatomic, strong, nullable) NSNumber *width;
 @property (nonatomic, strong, nullable) NSNumber *height;
 @property (nonatomic, strong, nullable) NSNumber *size;
+@property (nonatomic, strong, nullable) NSNumber *fps;
 @property (nonatomic, copy, nullable) NSString *link;
 @property (nonatomic, copy, nullable) NSString *linkSecure;
 @property (nonatomic, copy, nullable) NSString *quality;

--- a/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.m
+++ b/VimeoNetworking/VimeoNetworking/Models/VIMVideoFile.m
@@ -71,6 +71,11 @@ NSString *const VIMVideoFileQualityMobile = @"mobile";
         self.size = @(0);
     }
 
+    if (![self.fps isKindOfClass:[NSNumber class]])
+    {
+        self.fps = @(0);
+    }
+    
     if ([self.expires isKindOfClass:[NSString class]])
     {
         self.expirationDate = [[VIMModelObject dateFormatter] dateFromString:self.expires];


### PR DESCRIPTION
## Ticket

https://vimean.atlassian.net/browse/VIM-4820

## Ticket Summary

Cast video are sometimes choppy.

## Ticket Implementation

Chromecast does not support 2k/4k
The Chromecast processor can decode up to 720p at 60fps and 1080p at 30fps.
So we need to retrieve the fps value and make sure that the selected video to cast can be decoded by the chromecast processor.
 
## How to Test
Check that cast video works.