### PR TITLE
VIM-4833: Add support for passing userInfo when posting Notifications

### DIFF
--- a/VimeoNetworking/Sources/Notification.swift
+++ b/VimeoNetworking/Sources/Notification.swift
@@ -50,6 +50,11 @@ public class ObservationToken
     }
 }
 
+public enum UserInfoKey: NSString
+{
+    case PreviousAccount
+}
+
 /// `Notification` declares a number of global events that can be broadcast by the networking library and observed by clients.
 public enum Notification: String
 {
@@ -82,11 +87,11 @@ public enum Notification: String
      
      - parameter object: an optional object to pass to observers of this `Notification`
      */
-    public func post(object object: AnyObject?)
+    public func post(object object: AnyObject?, userInfo: [NSObject: AnyObject]? = nil)
     {
         dispatch_async(dispatch_get_main_queue())
         {
-            self.dynamicType.NotificationCenter.postNotificationName(self.rawValue, object: object)
+            self.dynamicType.NotificationCenter.postNotificationName(self.rawValue, object: object, userInfo: userInfo)
         }
     }
     

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -131,7 +131,7 @@ final public class VimeoClient
     // MARK: - Authentication
     
         /// Stores the current account, if one exists
-    public internal(set) var currentAccount: VIMAccount?
+    public var currentAccount: VIMAccount?
     {
         didSet
         {
@@ -144,7 +144,8 @@ final public class VimeoClient
                 self.sessionManager.clientDidClearAccount()
             }
             
-            Notification.AuthenticatedAccountDidChange.post(object: self.currentAccount)
+            Notification.AuthenticatedAccountDidChange.post(object: self.currentAccount,
+                                                            userInfo: [UserInfoKey.PreviousAccount.rawValue : oldValue ?? NSNull()])
         }
     }
     

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -131,7 +131,7 @@ final public class VimeoClient
     // MARK: - Authentication
     
         /// Stores the current account, if one exists
-    public var currentAccount: VIMAccount?
+    public internal(set) var currentAccount: VIMAccount?
     {
         didSet
         {
@@ -144,9 +144,14 @@ final public class VimeoClient
                 self.sessionManager.clientDidClearAccount()
             }
             
-            Notification.AuthenticatedAccountDidChange.post(object: self.currentAccount,
-                                                            userInfo: [UserInfoKey.PreviousAccount.rawValue : oldValue ?? NSNull()])
+            self.notifyObserversAccountChanged(self.currentAccount, previousAccount: oldValue)
         }
+    }
+    
+    public func notifyObserversAccountChanged(account: VIMAccount?, previousAccount: VIMAccount?)
+    {
+        Notification.AuthenticatedAccountDidChange.post(object: account,
+                                                        userInfo: [UserInfoKey.PreviousAccount.rawValue : previousAccount ?? NSNull()])
     }
     
     // MARK: - Request

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3C6F88841D999878006A24F4 /* programmed_cinema.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C6F88821D999878006A24F4 /* programmed_cinema.json */; };
 		3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88831D999878006A24F4 /* FakeDataSource.swift */; };
 		966F0F0E1E09D5740066DCF0 /* VimeoNetworkingExample_tvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966F0F0D1E09D5740066DCF0 /* VimeoNetworkingExample_tvOSTests.swift */; };
+		A7D414481E2E6FC500B68B14 /* VimeoClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D414471E2E6FC500B68B14 /* VimeoClientTests.swift */; };
 		B6315CBCEC56CC56CDD852C3 /* Pods_VimeoNetworkingExample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAFB88210DDF0B7DB12C7F1D /* Pods_VimeoNetworkingExample_tvOS.framework */; };
 		CC22A6749CADF4DA91D73F04 /* Pods_VimeoNetworkingExample_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D22A36411CC71C284010480 /* Pods_VimeoNetworkingExample_iOSTests.framework */; };
 		DEB396A3F44BBFBE9A602F1A /* Pods_VimeoNetworkingExample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46114AFA04898F979611854A /* Pods_VimeoNetworkingExample_iOS.framework */; };
@@ -98,6 +99,7 @@
 		A28A01D89F7D023CF49B4F1F /* Pods_VimeoNetworkingExample_iOS_VimeoNetworking_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOS_VimeoNetworking_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2F770DEBD4E467F7F728F84 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A76827E778C303147C297596 /* Pods-VimeoNetworkingExample-iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSUITests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSUITests/Pods-VimeoNetworkingExample-iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
+		A7D414471E2E6FC500B68B14 /* VimeoClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VimeoClientTests.swift; sourceTree = "<group>"; };
 		AAA8BDDF1F5FAC07D5EBE694 /* Pods-VimeoNetworkingExample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		B922437EFB7C0E4240397B12 /* Pods-VimeoNetworking tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworking tvOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworking tvOS/Pods-VimeoNetworking tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		C91C8608AAEE4CC821051413 /* Pods_VimeoNetworking_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworking_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -194,6 +196,7 @@
 				3C6F88831D999878006A24F4 /* FakeDataSource.swift */,
 				01CDBEF61CEB9C100093DDF4 /* ModelObjectValidationTests.swift */,
 				0C7364331DFF4871000C3585 /* NSErrorExtensionTests.swift */,
+				A7D414471E2E6FC500B68B14 /* VimeoClientTests.swift */,
 			);
 			path = "VimeoNetworkingExample-iOSTests";
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */,
 				0C7364351DFF4871000C3585 /* NSErrorExtensionTests.swift in Sources */,
 				3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */,
+				A7D414481E2E6FC500B68B14 /* VimeoClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/NSErrorExtensionTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/NSErrorExtensionTests.swift
@@ -112,7 +112,7 @@ class NSErrorExtensionTests: XCTestCase {
         
         XCTAssertNotNil(invalidParameters as? NSArray)
         
-        let invalidParamsDict = invalidParameters![0]
+        let invalidParamsDict = invalidParameters!.firstObject!!
         XCTAssertEqual(invalidParamsDict["error"], "Unable to log in Please enter a valid email address and/or password")
         XCTAssertEqual(invalidParamsDict["developer_message"], "Password and/or email provided are invalid")
         XCTAssertEqual(invalidParamsDict["error_code"], 2218)

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
@@ -5,6 +5,24 @@
 //  Created by Guhit, Fiel on 1/17/17.
 //  Copyright © 2017 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 @testable import VimeoNetworkingExample_iOS

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
@@ -7,29 +7,63 @@
 //
 
 import XCTest
+@testable import VimeoNetworkingExample_iOS
 
-class VimeoClientTests: XCTestCase {
+class VimeoClientTests: XCTestCase
+{
+    let configuration = AppConfiguration(clientIdentifier: "13175bcf4414a49c8ce74be465c441c3daec9de9",
+                                         clientSecret: "22d869d54feb4ee729b9fd87802c9cedcf3a9b71",
+                                         scopes: [.Public, .Private, .Purchased, .Create, .Edit, .Delete, .Interact, .Upload],
+                                         keychainService: "com.vimeo.keychain_service",
+                                         apiVersion: "3.3")
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+    lazy var client: VimeoClient =
+    {
+        return VimeoClient(appConfiguration: self.configuration)
+    }()
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testInitialCurrentAccountNotificationUserInfo()
+    {
+        let expectation = self.expectationWithDescription("Wait for initial account notification")
+        let token: ObservationToken? = Notification.AuthenticatedAccountDidChange.observe() { [unowned self] (notification: NSNotification) in
+            XCTAssert(self.client.currentAccount != nil)
+            XCTAssert(notification.userInfo != nil)
+            XCTAssert(notification.userInfo![UserInfoKey.PreviousAccount.rawValue] as? VIMAccount == nil)
+            
+            expectation.fulfill()
         }
+        
+        XCTAssert(token != nil)
+        
+        self.client.currentAccount = VIMAccount()
+        
+        self.waitForExpectationsWithTimeout(10, handler: nil)
+        
+        Notification.AuthenticatedAccountDidChange.removeObserver(self)
     }
     
+    func testSubsequentAccountNotificationUserInfo()
+    {
+        let firstAccount = VIMAccount()
+        let secondAccount = VIMAccount()
+        self.client.currentAccount = firstAccount
+        
+        let expectation = self.expectationWithDescription("Wait for subsequent account notification")
+        let token: ObservationToken? = Notification.AuthenticatedAccountDidChange.observe() { (notification: NSNotification) in
+            XCTAssert(notification.userInfo != nil)
+            
+            if let previousAccount = notification.userInfo![UserInfoKey.PreviousAccount.rawValue] as? VIMAccount {
+                XCTAssert(previousAccount == firstAccount)
+                expectation.fulfill()
+            }
+        }
+        
+        XCTAssert(token != nil)
+        
+        self.client.currentAccount = secondAccount
+        
+        self.waitForExpectationsWithTimeout(10, handler: nil)
+        
+        Notification.AuthenticatedAccountDidChange.removeObserver(self)
+    }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
@@ -1,0 +1,35 @@
+//
+//  VimeoClientTests.swift
+//  VimeoNetworkingExample-iOS
+//
+//  Created by Guhit, Fiel on 1/17/17.
+//  Copyright © 2017 Vimeo. All rights reserved.
+//
+
+import XCTest
+
+class VimeoClientTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoClientTests.swift
@@ -25,8 +25,8 @@ class VimeoClientTests: XCTestCase
     func testInitialCurrentAccountNotificationUserInfo()
     {
         let expectation = self.expectationWithDescription("Wait for initial account notification")
-        let token: ObservationToken? = Notification.AuthenticatedAccountDidChange.observe() { [unowned self] (notification: NSNotification) in
-            XCTAssert(self.client.currentAccount != nil)
+        let token: ObservationToken? = Notification.AuthenticatedAccountDidChange.observe() { (notification: NSNotification) in
+            XCTAssert(notification.object != nil)
             XCTAssert(notification.userInfo != nil)
             XCTAssert(notification.userInfo![UserInfoKey.PreviousAccount.rawValue] as? VIMAccount == nil)
             
@@ -35,7 +35,7 @@ class VimeoClientTests: XCTestCase
         
         XCTAssert(token != nil)
         
-        self.client.currentAccount = VIMAccount()
+        self.client.notifyObserversAccountChanged(VIMAccount(), previousAccount: nil)
         
         self.waitForExpectationsWithTimeout(10, handler: nil)
         
@@ -46,7 +46,6 @@ class VimeoClientTests: XCTestCase
     {
         let firstAccount = VIMAccount()
         let secondAccount = VIMAccount()
-        self.client.currentAccount = firstAccount
         
         let expectation = self.expectationWithDescription("Wait for subsequent account notification")
         let token: ObservationToken? = Notification.AuthenticatedAccountDidChange.observe() { (notification: NSNotification) in
@@ -60,7 +59,7 @@ class VimeoClientTests: XCTestCase
         
         XCTAssert(token != nil)
         
-        self.client.currentAccount = secondAccount
+        self.client.notifyObserversAccountChanged(secondAccount, previousAccount: firstAccount)
         
         self.waitForExpectationsWithTimeout(10, handler: nil)
         


### PR DESCRIPTION
#### Ticket
[VIM-4833](https://vimean.atlassian.net/browse/VIM-4823)

#### Ticket Summary
Downloads disappear after upgrading from 6.1.3 to 6.1.5 when logged out

#### Implementation Summary
Added ability to pass userInfo dictionary when posting notifications so that I can inspect previous user accounts when account changes.

#### How to Test
Unit test in VimeoClientTests.swift