### PR TITLE
VIM-4652: Parse Notification connection.

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMConnection.h
+++ b/VimeoNetworking/Sources/Models/VIMConnection.h
@@ -58,6 +58,7 @@ extern NSString *const __nonnull VIMConnectionNameRecommendedChannels;
 extern NSString *const __nonnull VIMConnectionNameRecommendedUsers;
 extern NSString *const __nonnull VIMConnectionNameModeratedChannels;
 extern NSString *const __nonnull VIMConnectionNameContents;
+extern NSString *const __nonnull VIMConnectionNameNotifications;
 
 @interface VIMConnection : VIMModelObject
 
@@ -69,6 +70,11 @@ extern NSString *const __nonnull VIMConnectionNameContents;
 @property (nonatomic, strong, nullable) NSNumber *extraVideosCount;
 @property (nonatomic, strong, nullable) NSNumber *mainVideosCount;
 @property (nonatomic, strong, nullable) NSNumber *viewableVideosCount;
+
+#pragma mark - Notifications related only
+@property (nonatomic, strong, nullable) NSNumber *totalNew;
+@property (nonatomic, strong, nullable) NSNumber *totalUnread;
+- (void)setNotifications:(nonnull NSDictionary *)dic;
 
 - (BOOL)canGet;
 - (BOOL)canPost;

--- a/VimeoNetworking/Sources/Models/VIMConnection.h
+++ b/VimeoNetworking/Sources/Models/VIMConnection.h
@@ -72,9 +72,8 @@ extern NSString *const __nonnull VIMConnectionNameNotifications;
 @property (nonatomic, strong, nullable) NSNumber *viewableVideosCount;
 
 #pragma mark - Notifications related only
-@property (nonatomic, strong, nullable) NSNumber *totalNew;
-@property (nonatomic, strong, nullable) NSNumber *totalUnread;
-- (void)setNotifications:(nonnull NSDictionary *)dic;
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, NSNumber *> *totalNotificationsNew;
+
 
 - (BOOL)canGet;
 - (BOOL)canPost;

--- a/VimeoNetworking/Sources/Models/VIMConnection.m
+++ b/VimeoNetworking/Sources/Models/VIMConnection.m
@@ -58,6 +58,7 @@ NSString *const VIMConnectionNameRecommendedChannels = @"recommended_channels";
 NSString *const VIMConnectionNameRecommendedUsers = @"recommended_users";
 NSString *const VIMConnectionNameModeratedChannels = @"moderated_channels";
 NSString *const VIMConnectionNameContents = @"contents";
+NSString *const VIMConnectionNameNotifications = @"notifications";
 
 @interface VIMConnection()
 @property (nonatomic, strong, nullable) NSNumber *extra_total;
@@ -90,4 +91,11 @@ NSString *const VIMConnectionNameContents = @"contents";
     return (self.options && [self.options containsObject:@"POST"]);
 }
 
+- (void)setNotifications:(nonnull NSDictionary *)dic
+{
+    // We can't both either just call `didFinishMapping` because one of the property received from the server is prefixed by `new..` and doesn't follow the naming convention.
+    // or use the `getObjectMapping` because it doesn't get called. See `didFinishMapping` comment [JL] 01/27/2017
+    self.totalNew = [dic objectForKey:@"new_total"];
+    self.totalUnread = [dic objectForKey:@"unread_total"];
+}
 @end

--- a/VimeoNetworking/Sources/Models/VIMConnection.m
+++ b/VimeoNetworking/Sources/Models/VIMConnection.m
@@ -60,10 +60,11 @@ NSString *const VIMConnectionNameModeratedChannels = @"moderated_channels";
 NSString *const VIMConnectionNameContents = @"contents";
 NSString *const VIMConnectionNameNotifications = @"notifications";
 
-@interface VIMConnection()
+@interface VIMConnection ()
 @property (nonatomic, strong, nullable) NSNumber *extra_total;
 @property (nonatomic, strong, nullable) NSNumber *main_total;
 @property (nonatomic, strong, nullable) NSNumber *viewable_total;
+@property (nonatomic, copy, nullable) NSDictionary *type_count;
 @end
 
 @implementation VIMConnection
@@ -79,6 +80,8 @@ NSString *const VIMConnectionNameNotifications = @"notifications";
     self.extraVideosCount = self.extra_total;
     self.mainVideosCount = self.main_total;
     self.viewableVideosCount = self.viewable_total;
+    
+    self.totalNotificationsNew = self.type_count;
 }
 
 - (BOOL)canGet
@@ -91,11 +94,4 @@ NSString *const VIMConnectionNameNotifications = @"notifications";
     return (self.options && [self.options containsObject:@"POST"]);
 }
 
-- (void)setNotifications:(nonnull NSDictionary *)dic
-{
-    // We can't both either just call `didFinishMapping` because one of the property received from the server is prefixed by `new..` and doesn't follow the naming convention.
-    // or use the `getObjectMapping` because it doesn't get called. See `didFinishMapping` comment [JL] 01/27/2017
-    self.totalNew = [dic objectForKey:@"new_total"];
-    self.totalUnread = [dic objectForKey:@"unread_total"];
-}
 @end

--- a/VimeoNetworking/Sources/Models/VIMUser.m
+++ b/VimeoNetworking/Sources/Models/VIMUser.m
@@ -153,6 +153,15 @@
             if([value isKindOfClass:[NSDictionary class]])
             {
                 VIMConnection *connection = [[VIMConnection alloc] initWithKeyValueDictionary:value];
+                
+                // Parse Notification Connection keys
+                if ([key isEqualToString:VIMConnectionNameNotifications])
+                {
+                    [connection setNotifications:value];
+                }
+                
+                if([connection respondsToSelector:@selector(didFinishMapping)])
+                    [connection didFinishMapping];
                 [connections setObject:connection forKey:key];
             }
         }

--- a/VimeoNetworking/Sources/Models/VIMUser.m
+++ b/VimeoNetworking/Sources/Models/VIMUser.m
@@ -154,14 +154,11 @@
             {
                 VIMConnection *connection = [[VIMConnection alloc] initWithKeyValueDictionary:value];
                 
-                // Parse Notification Connection keys
-                if ([key isEqualToString:VIMConnectionNameNotifications])
+                if([connection respondsToSelector:@selector(didFinishMapping)])
                 {
-                    [connection setNotifications:value];
+                    [connection didFinishMapping];
                 }
                 
-                if([connection respondsToSelector:@selector(didFinishMapping)])
-                    [connection didFinishMapping];
                 [connections setObject:connection forKey:key];
             }
         }


### PR DESCRIPTION
## Ticket

https://vimean.atlassian.net/browse/VIM-4652

## Ticket Summary

Update the badge app.

## Implementation Summary

In order to update the badge app, we need to retrieve a new `connection` provided by the object `User` > `metadata` > `connection` > `notifications`.


## How to Test
N/A