### PR TITLE
VIM-4132: Response Cache

### DIFF
--- a/VimeoNetworking/Sources/ResponseCache.swift
+++ b/VimeoNetworking/Sources/ResponseCache.swift
@@ -42,6 +42,11 @@ private protocol Cache
 /// Response cache handles the storage of JSON response dictionaries indexed by their associated `Request`.  It contains both memory and disk caching functionality
 final internal class ResponseCache
 {
+    struct Constant
+    {
+        static let cacheDirectory = "com.vimeo.Caches"
+    }
+    
     /**
      Stores a response dictionary for a request.
      
@@ -162,7 +167,7 @@ final internal class ResponseCache
                 
                 do
                 {
-                    if !fileManager.fileExistsAtPath(directoryPath)
+                       if !fileManager.fileExistsAtPath(directoryPath)
                     {
                         try fileManager.createDirectoryAtPath(directoryPath, withIntermediateDirectories: true, attributes: nil)
                     }
@@ -273,13 +278,17 @@ final internal class ResponseCache
         
         private func cachesDirectoryURL() -> NSURL
         {
+            // Apple /Caches directory
             guard let directory = NSSearchPathForDirectoriesInDomains(.CachesDirectory, .UserDomainMask, true).first
             else
             {
                 fatalError("no cache directories found")
             }
             
-            return NSURL(fileURLWithPath: directory)
+            // We need to create a directory in `../Library/Caches folder`. Otherwise, trying to remove the Apple /Caches folder will always fails. Note that it's noticeable while testing on a device.
+            let cacheDirectory = directory + Constant.cacheDirectory
+            
+            return NSURL(fileURLWithPath: cacheDirectory)
         }
         
         private func fileURLForKey(key key: String) -> NSURL?

--- a/VimeoNetworking/Sources/ResponseCache.swift
+++ b/VimeoNetworking/Sources/ResponseCache.swift
@@ -44,7 +44,7 @@ final internal class ResponseCache
 {
     struct Constant
     {
-        static let cacheDirectory = "com.vimeo.Caches"
+        static let CacheDirectory = "com.vimeo.Caches"
     }
     
     /**
@@ -167,7 +167,7 @@ final internal class ResponseCache
                 
                 do
                 {
-                       if !fileManager.fileExistsAtPath(directoryPath)
+                    if !fileManager.fileExistsAtPath(directoryPath)
                     {
                         try fileManager.createDirectoryAtPath(directoryPath, withIntermediateDirectories: true, attributes: nil)
                     }
@@ -285,10 +285,14 @@ final internal class ResponseCache
                 fatalError("no cache directories found")
             }
             
-            // We need to create a directory in `../Library/Caches folder`. Otherwise, trying to remove the Apple /Caches folder will always fails. Note that it's noticeable while testing on a device.
-            let cacheDirectory = directory + Constant.cacheDirectory
+            // We need to create a directory in `../Library/Caches folder`. Otherwise, trying to remove the Apple /Caches folder will always fail. Note that it's noticeable while testing on a device.
+            guard let url = NSURL(fileURLWithPath: directory).URLByAppendingPathComponent(Constant.CacheDirectory) else
+            {
+                assertionFailure("Unable to create cacheDirectory directory")
+                return NSURL(fileURLWithPath: directory)
+            }
             
-            return NSURL(fileURLWithPath: cacheDirectory)
+            return url
         }
         
         private func fileURLForKey(key key: String) -> NSURL?

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 general:
   artifacts:
     - "xcodebuild.log"
+    - "build/Logs"
 machine:
   xcode:
     version: 8.0


### PR DESCRIPTION
## Ticket

https://vimean.atlassian.net/browse/VIM-4132

## Ticket Summary

Cached files aren't removed when logged out.

## Implementation Summary

Added a sub directory to /Library/Caches folder so that when we call:
`removeAllResponseDictionaries` in `ResponseCache` file, we actually have the permissions to delete the files of this folder.
We used to try to remove the Caches folder that Apple has generated, but we don't have the permissions to remove it.
So we got this issue:
```Error Domain=NSCocoaErrorDomain Code=513 "“Caches” couldn’t be removed because you don’t have permission to access it." UserInfo={NSFilePath=/var/mobile/Containers/Data/Application/F307995B-BD12-45BB-AA61-6188CBC6F635/Library/Caches, NSUserStringVariant=(
    Remove
), NSUnderlyingError=0x113e4adf0 {Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted"}}
```

## How to Test

1. Log in as user A 
2. Upload a video with setting 'Only Me' 
3. Log out and log in as user B 
4. Navigate to user A profile 
5. You shouldn't see A private videos.