### PR TITLE
AF-3: Updated `caching policy`

### DIFF
--- a/VimeoNetworking/Sources/Request.swift
+++ b/VimeoNetworking/Sources/Request.swift
@@ -51,13 +51,7 @@ public enum CacheFetchPolicy
      */
     static func defaultPolicyForMethod(method: VimeoClient.Method) -> CacheFetchPolicy
     {
-        switch method
-        {
-        case .GET:
-            return .CacheThenNetwork
-        case .DELETE, .PATCH, .POST, .PUT:
-            return .NetworkOnly
-        }
+        return .NetworkOnly
     }
 }
 


### PR DESCRIPTION
## Ticket

https://vimean.atlassian.net/browse/AF-3
https://vimean.atlassian.net/browse/VIM-4809
https://vimean.atlassian.net/browse/AF-5

## Ticket Summary

Default the caching policy back to what we used to have in VIMNetworking.

## Implementation Summary

Updated caching policy to .NetworkOnly.

## How to Test
2 things to check:

A)
1. Tap on Explore 
2. Tap on any category 
3. Tap on a subcategory 
4. Tap on back 
5. Tap on a the same subcategory again
6. Subcategory should be open only once.

B)
Check that in VIMNetworking, it was NetworkOnly: 
https://github.com/vimeo/VIMNetworking/blob/v6.1.2/VIMNetworking/Networking/VimeoClient/VIMRequestDescriptor.m

```
- (instancetype)init
{
	self = [super init];
	if (self)
	{
        self.descriptorID = @"";
		self.urlPath = @"";
		self.HTTPMethod = HTTPMethodGET;
		self.parameters = nil;
		self.cachePolicy = VIMCachePolicy_NetworkOnly;
		self.modelClass = nil;
		self.modelKeyPath = @"";
        self.shouldCacheResponse = YES;
        self.shouldRetryOnFailure = NO;
	}
	
	return self;
}
```