### PR TITLE
VIM-4879: Fixed crash on accessing `Privacy` property.

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideoPreference.h
+++ b/VimeoNetworking/Sources/Models/VIMVideoPreference.h
@@ -25,10 +25,11 @@
 //
 
 #import "VIMModelObject.h"
+#import "VIMPrivacy.h"
 
 @interface VIMVideoPreference : VIMModelObject
 
-@property (nonatomic, copy, nullable) NSString *privacy;
+@property (nonatomic, copy, nullable) VIMPrivacy *privacy;
 @property (nonatomic, copy, nullable) NSString *password;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMVideoPreference.m
+++ b/VimeoNetworking/Sources/Models/VIMVideoPreference.m
@@ -26,13 +26,15 @@
 
 #import "VIMVideoPreference.h"
 
+static NSString * const kPrivacy = @"privacy";
+
 @implementation VIMVideoPreference
 
 #pragma mark - VIMMappable
 
 - (Class)getClassForObjectKey:(NSString *)key
 {
-    if ([key isEqualToString:@"privacy"])
+    if ([key isEqualToString:kPrivacy])
     {
         return [VIMPrivacy class];
     }

--- a/VimeoNetworking/Sources/Models/VIMVideoPreference.m
+++ b/VimeoNetworking/Sources/Models/VIMVideoPreference.m
@@ -28,4 +28,16 @@
 
 @implementation VIMVideoPreference
 
+#pragma mark - VIMMappable
+
+- (Class)getClassForObjectKey:(NSString *)key
+{
+    if ([key isEqualToString:@"privacy"])
+    {
+        return [VIMPrivacy class];
+    }
+    
+    return nil;
+}
+
 @end


### PR DESCRIPTION
## Ticket

https://vimean.atlassian.net/browse/VIM-4879

## Ticket Summary

Crash on uploading a Video.

## Implementation Summary

Updated the model `VIMVideoPreference` so that the property `privacy` instead of being a type `String`, it should be a `VIMPrivacy` object.

## How to Test

1. Open app
2. Log in 
3. Tap Upload
4. Select video
5. Upload should work.