### PR TITLE
Add Unverified User Error

### DIFF
--- a/VimeoNetworking/Sources/ErrorCode.swift
+++ b/VimeoNetworking/Sources/ErrorCode.swift
@@ -77,6 +77,7 @@ public enum VimeoErrorCode: Int
     case TokenNotGenerated = 5001
     case DRMStreamLimitHit = 3420
     case DRMDeviceLimitHit = 3421
+    case UnverifiedUser = 3411
 
     // Batch follow
     case BatchUserDoesNotExist = 2900


### PR DESCRIPTION
#### Ticket
[VIM-4897](https://vimean.atlassian.net/browse/VIM-4897)
Related to this [PR](https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/1189)

#### Ticket Summary
The app did not show the alert when an unverified user attempted to post a comment because:
a) There was neither title nor message for that error
b) The code for the error was not specified in the enum

#### Implementation Summary
I added the error code into the enum as well as the texts for the alert.

#### How to Test
1. Create an account and don't verify it.
2. Attempt to post a comment or a reply. You'll see the alert appearing.