### PR TITLE
VIM-4918: Default Privacy Migration

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideoPreference.m
+++ b/VimeoNetworking/Sources/Models/VIMVideoPreference.m
@@ -26,15 +26,26 @@
 
 #import "VIMVideoPreference.h"
 
-static NSString * const kPrivacy = @"privacy";
-
 @implementation VIMVideoPreference
 
 #pragma mark - VIMMappable
 
+- (void)didFinishMapping
+{
+    // In API version 3.3.1, privacy changed from a string to a VIMPrivacy object.
+    // This is a migration to convert pre-3.3.1 versions to the new version. [ghking] 2/23/17
+    
+    if ([self.privacy isKindOfClass:[NSString class]])
+    {
+        VIMPrivacy *privacy = [VIMPrivacy new];
+        privacy.view = self.privacy;
+        self.privacy = privacy;
+    }
+}
+
 - (Class)getClassForObjectKey:(NSString *)key
 {
-    if ([key isEqualToString:kPrivacy])
+    if ([key isEqualToString:@"privacy"])
     {
         return [VIMPrivacy class];
     }


### PR DESCRIPTION
#### Ticket

https://vimean.atlassian.net/browse/VIM-4918

#### Ticket Summary

Write a migration to upgrade the old version of privacy (a string) to the new version (an object).

#### Implementation Summary

Added the migration to create a new privacy object and set the string in the correct place. Jennifer already updated the model and code in another PR: https://github.vimeows.com/MobileApps/Vimeo-iOS/pull/1177

#### How to Test

- Log out
- Download the app store version
- Log in
- Upgrade
- Go to upload a video

The app should no longer crash at this point.