### PR TITLE
Updated VIMVideo SVOD Extension

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo+SVOD.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo+SVOD.h
@@ -11,7 +11,8 @@
 typedef NS_ENUM(NSUInteger, VIMVideoSVODAccess) {
     VIMVideoSVODAccessNotPurchased,
     VIMVideoSVODAccessMonthly,
-    VIMVideoSVODAccessUnknown
+    VIMVideoSVODAccessInvalid,
+    VIMVideoSVODAccessNotSVOD
 };
 
 @interface VIMVideo (SVOD)

--- a/VimeoNetworking/Sources/Models/VIMVideo+SVOD.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo+SVOD.m
@@ -16,12 +16,7 @@
 {
     VIMInteraction *interation = [self interactionWithName:VIMInteractionNameSVOD];
     
-    if (interation != nil)
-    {
-        return YES;
-    }
-    
-    return NO;
+    return (interation != nil);
 }
 
 - (VIMVideoSVODAccess)svodAccess

--- a/VimeoNetworking/Sources/Models/VIMVideo+SVOD.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo+SVOD.m
@@ -16,7 +16,12 @@
 {
     VIMInteraction *interation = [self interactionWithName:VIMInteractionNameSVOD];
     
-    return interation != nil;
+    if (interation != nil)
+    {
+        return YES;
+    }
+    
+    return NO;
 }
 
 - (VIMVideoSVODAccess)svodAccess
@@ -35,9 +40,12 @@
         }
         else
         {
-            return VIMVideoSVODAccessUnknown;
+            return VIMVideoSVODAccessInvalid;
         }
     }
+    
+    return VIMVideoSVODAccessNotSVOD;
 }
 
 @end
+


### PR DESCRIPTION

#### Ticket

N/A

#### Issue Summary

- We didn't return an invalid type for SVODAccess if the video isn't SVOD.

#### Implementation Summary

- Created a new type Invalid for svodAccess. That way if a video isn't svod and we try to access it, it will return an invalid type.

#### How to Test

N/A