### PR TITLE
AF-28: Add new request for SVOD purchasing

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,386 +7,392 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0006266C44A6C58EAD4032169F6D9A57 /* VimeoRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589730830A01A361F90E6967F2D67DB /* VimeoRequestSerializer.swift */; };
 		00717F97B372A0C8177761ECE1EBFCC9 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B36ADD33E9C0EBB3DBD3F8EFBDDFD940 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0184C163C6471121C73CBBDB13E2E56C /* Pods-VimeoNetworkingExample-iOSTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AD287BBA14C09C83412FE6DBA1ADBE5D /* Pods-VimeoNetworkingExample-iOSTests-dummy.m */; };
-		0200FB7BB157828827A03357698A8F38 /* VIMTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = 798C71B67EC392EADE04DAB73BD406D9 /* VIMTrigger.m */; };
+		01C16C6919B93E479D94677F13864DE4 /* Request+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6909CDE156096B54AD70B70F2A1ED784 /* Request+Authentication.swift */; };
 		02272414083C9390E4F6F98032C99293 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C59A9F1DF1A65D69106D04DC07FEB3C9 /* Security.framework */; };
-		02A60797AB2E7A22718A7D8D3212F6C7 /* VIMPictureCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D534D18281F270EBBA2C5AD2E2C783 /* VIMPictureCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02D5F6EC0061A0EB52863B7F14EC4C98 /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6154623B4613F057480E0DBFB7FF50C /* ErrorCode.swift */; };
-		02EDE0EFDD1B36E5A6C45C95DFC7C933 /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 339121042BB79912B92A5DBE8757F7C2 /* VIMUser.m */; };
-		031BCFDD19F8FB249C754BD28A1724B1 /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = EE223A37C992831E3A1F99385B800676 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		036605CE55A074714314FD2FEF5983C9 /* VimeoNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 923177D7128CCE52104C1C609BE2D261 /* VimeoNetworking-iOS-dummy.m */; };
-		03F6A5681601B109067376CBA944C060 /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C8A8A93EEAFBD89D838AA09D6801E832 /* VIMVideoFairPlayFile.m */; };
-		0582EC50933C9460FC107CA251126D8F /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 5500F221D922DA37348F1AA7E091F17E /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		058E91B1AA3886617456D6B5B035486F /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D415A26C2C8901948B30CC37B4F5EF /* AuthenticationController.swift */; };
-		05DFBF0E17065C691921E2DACEC74306 /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771137F242745FA7174D18F6B2B55E36 /* SubscriptionCollection.swift */; };
-		05F98B8B879E3614D7FFDE3B78B6207E /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = EE223A37C992831E3A1F99385B800676 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		06343579E029D3BDC558031DBAD57168 /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A68E5D954E9C3C2E6092B1B67A3E1E6 /* String+Parameters.swift */; };
+		02B61471DF8C004F50C48117B354F1D8 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22F7F712B8A00EAACAF907A56AB3615 /* Notification.swift */; };
+		0337FF15FAB682618D5E478C0F576E0E /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 1456E82583F2E91622BF0C4CB24D8282 /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		050145917E0FA157F3625A3D18F2EB6B /* Request+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3BC3A65FB1B196F662670C0DBB455 /* Request+Cache.swift */; };
+		062305F23AEBBE6BEBE7BCF79E0F8A3D /* VIMSizeQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 01191A945E37E8EDE78E408AEC174BBF /* VIMSizeQuota.m */; };
+		06A67749D239314447CD697F8392321D /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C308F741B8317EDC1D9DA106084966 /* VimeoSessionManager.swift */; };
+		06F54812A811BD886B505E54B2FDBC06 /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBA7569FDD87D5E66E0D710A69A73E2 /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		072DD28304E57C0C1B97746E24385F8A /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16296BB028B9E535A1456AFF995004E /* Request+Video.swift */; };
 		07A838805D75951F0C07DFE532F807F7 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 737AF7F9A1C09E38A4225A0EAD753152 /* UIWebView+AFNetworking.m */; };
-		07BA4421114B4A2F5256C3F653D20E49 /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E298AAB2BEC7F6549699CECD0035E11 /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0845C2A86AA6AD4793C4229B8EF1ED7F /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 517155516D8B9E4AC1FF2AD324D8F03D /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0873AB02BC05BDF8CAA155C1CD206B9C /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = ADA8F0D740690B50CD675C7534F3D3F9 /* VIMTag.m */; };
-		08C597630C6D082FC8EBDA042F0F4F7E /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ED07A77DE93F9B9E08DDDC75F3EC773 /* VIMVideo.m */; };
-		08F37278851D249E9A53DCEDEE6BF7EB /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = AAEDBD81DC147A4E5C253DA14C56613B /* VIMNotificationsConnection.m */; };
-		0B996EFCB302003B448F6BD1C3DA980D /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B09820A935CEE6EC9658C595DE1F8D /* VIMObjectMapper.m */; };
-		0E417D2C7A2F4F6335530A6C9D6D01E9 /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 09203B0DF735A1912AA153068A050CAF /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		100221D1D5BB45A28687416656FBC1B9 /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC7D5950400DB7546EECE5B0D4D25F /* Request+PolicyDocument.swift */; };
+		07F080B82C14CD3C9D13546FEDA1FD2E /* Request+Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6394F7D67FC3782A07ACFCE8E622E768 /* Request+Channel.swift */; };
+		0BF4A5799DFA6A339E04619ED82F2A72 /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D83909308A593C42FF7DBF5381052C3 /* VIMVideoPreference.m */; };
+		0D7127BEBD5D3FF944FB142581E64149 /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = A8B4FA8C0590BAC5B34E0FB918C588A3 /* VIMActivity.m */; };
+		0ED32D890D1A269871D9527542BC54BB /* VIMTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = CA65C7C00A605BB2802D8F203E4D8110 /* VIMTrigger.m */; };
+		0F41AB9FD84B4638AF824B084266FD8A /* VIMObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 96AB198755E9562EB7B876CB0F0774CE /* VIMObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		104E6876B90B4D50379E4A9A99779FE8 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = C5ABDE60B47B2CFCC904788D43005C7C /* UIProgressView+AFNetworking.m */; };
+		10530E42A9D3A786B7A14B63ECBF17CD /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22F7F712B8A00EAACAF907A56AB3615 /* Notification.swift */; };
 		105BC7B62FD47A2281D6F6F3F100B5F0 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = C5ABDE60B47B2CFCC904788D43005C7C /* UIProgressView+AFNetworking.m */; };
-		10F2CCF00FCBF6815E490F5BF1554AE4 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E4F26C178839F4809F1A26D06153A9 /* Request.swift */; };
+		10D3BA72E42EA8D162BDAEA36A007030 /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = E96440544E7AE1DACD14D44B11AAB1E2 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		11037B4A805A1451D215D0BA2FCACB0C /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9C6788456E3C6CB1F9496329863213F /* AFNetworking.framework */; };
-		115968822ECE4190F409994D08BB918C /* VIMVideoPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = B05862F2CFC1FC063F0681CF0AED0205 /* VIMVideoPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		117C30C843F11A99E9EF9786A6A7655C /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A375AEE2A37C0735E690CA1AC8A685C /* Notification.swift */; };
-		11B0ABB4732024E56D85DA5CE35A717E /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AF35296C8C00D637F4BB34E969A220 /* Request+Video.swift */; };
-		12E6FF81A05D29B481CE753644C9F13A /* VIMTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A73E1F60C716DFE7022B504B586624 /* VIMTrigger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11C4C4B213448E8E6F1A000E9F076B4A /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = E982102FDBF3A7B8E676EE912FB73697 /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11CBAEBB88BB65C9439C6CA281C6B3A0 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC28F4BBBD260F1FD163C117165AB6E /* Subscription.swift */; };
 		133648C2ACAD932C65DE12AB83012961 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C824D3CBB8350B498A8E16265B0BE7 /* AFHTTPSessionManager.m */; };
-		13A26B0F01FA7588C5F9BEA706FB6FA1 /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C8A8A93EEAFBD89D838AA09D6801E832 /* VIMVideoFairPlayFile.m */; };
-		13AC18EC5198FA629BE816ACA095C833 /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 09203B0DF735A1912AA153068A050CAF /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		140E1E78EE8F0BEA0899F38CD230D456 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E2F400FB9E6F12109D8FA3D0E5E2B /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		146612F56E89AEA20516389E1E97BF91 /* VIMCredit.m in Sources */ = {isa = PBXBuildFile; fileRef = D989F47CA4089C24A674C2F080D701B5 /* VIMCredit.m */; };
-		14C27DA867F7BBCDDBC1034CC74D9A00 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 124229104F1F5A171DD89D457BFD65E4 /* VIMVideoHLSFile.m */; };
+		13DFE8302344490FD08197B7C1B19D90 /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C85333BEEAE2F31305F9A10ABB399E04 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14C33620EE8EEC6CD3D4A40B791C209B /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A4DB82CC4E649E3A3DB2B5F421C069 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1504470FE94783C6049BFD44B47925FF /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E11A064A120789D57ACC2CB6EDA9526 /* VimeoSessionManager+Constructors.swift */; };
-		15304973B7661FFA03E39681178673ED /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE62B26CD90E5B64946B696500786C /* AccountStore.swift */; };
-		1819D1EC00B5F34DD8DE12529CCC5A70 /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1DF9AB6F331C77CA71DD6B7E255D9E /* Request+Picture.swift */; };
-		1830609789A44922C8C6F1E2CEC831ED /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F927D4B012FBD352564066F8BF470052 /* Request+Comment.swift */; };
-		1837566A4F054C2AE34A680EAFA841C2 /* VIMPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = E035D94411FF23FBDF847FD809A0EECF /* VIMPicture.m */; };
+		1553686AA956EFA70B1B260F710BF440 /* VIMSizeQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 46302053FFBE4A1DE028AACC0E3FFAD6 /* VIMSizeQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		171A42864B310DE68C8FF95C31EEEC53 /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04ED8340220B49DAA663FC53D924519D /* AuthenticationController.swift */; };
+		174C8D335CE9E1219B422927E500B2B4 /* VIMUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3DB838C85A5F887BC3BE2954FD56 /* VIMUploadTicket.m */; };
+		1781B2BC0AF2765F20AC1CB63C1A82AE /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = E4D4A1BB8E751CC6AD00D5E512C8E0AD /* VIMQuantityQuota.m */; };
+		17B4638A0B274CADDBCE8028EC5924A9 /* VIMPictureCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = C946B4B13BD1FC7135CED9E3639BD3E6 /* VIMPictureCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18B6EAA62481EC3E6F4E444D336BF45D /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7452337F7798C98A14B2BEB8B75409 /* Request+Notifications.swift */; };
 		18DDC5F4943C6894CC86557AC60ED8EF /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 07E5575BBC8C7295ACA3404520CA527C /* AFAutoPurgingImageCache.m */; };
-		1946DF32A19882421A3AA9DA6AAEBCF8 /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 5500F221D922DA37348F1AA7E091F17E /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		19953558576AADEB3917F2E3272659A1 /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 50A0AA5B2D4E05972B4F2ACD8A14D6B9 /* VIMUploadQuota.m */; };
-		1B396CBCBD5D185A47DE0F0FFA84BCD8 /* Request+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91872B936AE6EE73A9B644B3EA3F715A /* Request+Cache.swift */; };
-		1C0294A1385E9857BB86FA1B35DAABB0 /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292E0C05CA34891FE8E831B2E808809E /* VIMProgrammedContent.swift */; };
+		18F263C0E0DAF5D8202F23E53A305471 /* VIMVideoPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C31C2D32930DBB30C817C1D604355C1 /* VIMVideoPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19F0AF17BE426F63B5A354DC27373590 /* VIMVideoFile.h in Headers */ = {isa = PBXBuildFile; fileRef = EB986F5DCE12497A6EEA8957FF17B63B /* VIMVideoFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A383D4B32F2B4CA1207C5B1BE849C4F /* VIMComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 78430A2F58C85F8471B830042D3A9DE6 /* VIMComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BDC7D8F6165CE05A525D51A4BAAC19C /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BEE65EABAF41C071B0A356203532E4 /* Result.swift */; };
+		1C2D89F4FAC93BD7C08A16E3738E4052 /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2664FAAA28B1A8A721A7E3964648C9FB /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C68E92EB435B78038273C8AC63BC380 /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3393CCCD8B9E11861D5344277458C2B3 /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1CD55C53F8615D24BF27D373F35309AC /* VIMVideo+VOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BA6108B999C05BAF20B545FAAA0D26A /* VIMVideo+VOD.m */; };
 		1D3018AA33347B489EA4F092DEEA6FB5 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B0D8653FC50F48DA48C7463CA718E52A /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1FB22E70D190645B26B1F0BC92E1CCDF /* VIMChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = C875B420A7A550346F838025CD450223 /* VIMChannel.m */; };
-		201A60069A6182C7BD433AB1EA218722 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7011A73F3E0BF3B5467B0308C532EC85 /* ResponseCache.swift */; };
-		2027F0DEB9A35B49812AACA06815F86B /* Request+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91872B936AE6EE73A9B644B3EA3F715A /* Request+Cache.swift */; };
 		2046B95CA0A09111313C0869219A7452 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 656FBEC4C6308C4F5F0873C5E6B787F4 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2108FCAB8DAA25568D722C1CF805FA64 /* AFNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 936C6D8DA5D4BEFE2939FFBF42346516 /* AFNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2181111AD9D59DD00A288E59DEAA39F5 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 124229104F1F5A171DD89D457BFD65E4 /* VIMVideoHLSFile.m */; };
-		222C199D4BD981C70AB0C0BDD41D4C75 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F658D9E363552377641D391AEABBDE /* Mappable.swift */; };
-		2338A11765CAA409BE4120ED8F6A3D26 /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A46E9E13DF7CF574AE8BE912A1937CBA /* VIMVODItem.m */; };
-		23A2AF7EA56FBAD63F2F3EA53B984083 /* VIMCredit.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8B0F8D06B6963AFA613D5540B20448 /* VIMCredit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2108FCAB8DAA25568D722C1CF805FA64 /* AFNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F655D6685258FAA14B2C835CE892B04 /* AFNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		221AFD6E11E93254DBA95C7A0427F125 /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B4D21E54F7C54C3216761425A04A66 /* Request+Soundtrack.swift */; };
+		22C1F9752CBDCE28BDD4D32C4FD52B80 /* VIMUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = BA6A3DB838C85A5F887BC3BE2954FD56 /* VIMUploadTicket.m */; };
+		2344A881B3879979DCBF15725946DF8D /* VIMVideoDRMFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9571AAD3AFA5A25E5CE60FB3DA4065 /* VIMVideoDRMFiles.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23C7A2297208FA7F24E7151E95F75DA4 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 56C397664C4ACDEA5C3543FFFF98C440 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2417EE870CBC38AD24587E3050E3176D /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E21215A1A7453B914B49A163844FF5A2 /* VIMVODConnection.m */; };
-		242E754F39362643C3C7CB9763BF4B14 /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E671C023C7983DC6DEFF18A3ECE49C /* Scope.swift */; };
-		245465FC3D540C6364C1540C3368FD81 /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = 17664F34992B004CE69FDFFDC5A3196B /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		248B23125A054D05958316FFA0F175BB /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CAFF6DA4FE0A11F64E7BEE3F1A5E801C /* VIMVideoUtils.m */; };
-		2592B811150ADCC04659DF80BC04EAD5 /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7E3623C60B3CEA68419632CE9D7CBD /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		25F5127CBD826CC9F65336B12A6FDB6D /* VIMNotificationsConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 36EEBE5D0E88C1F7A926DF06AFEAD7D3 /* VIMNotificationsConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		240D069658A3F857B8274F7EA67B3CCC /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E0513C7DE2C022B3A44B2540BEA4332 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		24A8683CB767D39DA29DAD19C066ED9A /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ECD9DB2E90D9479010A66146E935FEE /* VimeoSessionManager+Constructors.swift */; };
+		25718A6CB80EC175052A59DCD78C495D /* VIMAppeal.h in Headers */ = {isa = PBXBuildFile; fileRef = 93FABF6EB294DF08E450BF31F8B6C32C /* VIMAppeal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		262E9BB53B76EE70D2E2D0FE39E3ABF2 /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4DB6F852A348D5C4B9DFE151885233 /* AFImageDownloader.m */; };
-		263EBA42B18AD317152F3623A508546F /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B0ED99B4A6356750583D3A9BF624DA7 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2821073DE94794AA29C18B9CC0F5458A /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = E6938D1F58272D3B69F54B79AD04D861 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		270DB404580B9C2AE704B82E6BF02C1A /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690975C455446102C3B73BE1B60D3FD7 /* KeychainStore.swift */; };
+		277BAEF4FF899D561B88D99AA9089042 /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523151A937F41DC5B653894FDB9D448D /* Request+Configs.swift */; };
+		279603356888B3B2041E2CDE50423CF3 /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B73FC9797518500A1A7D836707CE7D78 /* VIMVideoFairPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		283FB32387F8FE605285817BA06B972F /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 473D7E9AAA642355C084D5D5A7B7CF40 /* AFURLSessionManager.m */; };
-		28C5C9896C26F711C23CCDD854862FDC /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = E1297CBCCBC0690C1047F1991E1B5B40 /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		28EC8B3BA6FEBA4612AE88E10A17E681 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEA2176BCBF0B053CA62178B6E8BE31 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		292C88882FBD2427CF5C9C0D310024D3 /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2706D82A1741A66D809C2297C6CB56 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		298108794F0E437EEAE03BEB93F75381 /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F5400D264F3C9259F38D027C580269 /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		291CBE9393FB930B45DA941CDE9D82F5 /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E05FC37D99D9236704387733255F601 /* VIMNotification.m */; };
 		2A7031B240241BE149403740E51DEA3E /* Pods-VimeoNetworkingExample-iOSTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A3EDEFD098DD3AA769689319A8DAF72A /* Pods-VimeoNetworkingExample-iOSTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A976BB0F0DF361849B79F41B20AC328 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2D208C4CC086A891F12E4C15EBFF2 /* Mappable.swift */; };
 		2AD0526440746F9F05B8A715F11ECF51 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 656FBEC4C6308C4F5F0873C5E6B787F4 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AFE9AAC5867421AB3B667D56D7C2CE6 /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = F124A50F309625B2C3F86D1520F14A49 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2B0945946493F90217FE5FBD9587ADC6 /* VIMVideoDRMFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = F582EEBB44C65E57F5CD07F5251643F5 /* VIMVideoDRMFiles.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C8976A22F21DD1B0354AEE2BFEF52B0 /* VIMPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 4268200039AFCC987F67F25FDB3145F9 /* VIMPreference.m */; };
+		2B74AB1ED7ED992849D6B56B28FB6B6C /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A5F7B9659356AA141A193B05FE7FDC /* Request.swift */; };
+		2C7BE2765B134E0638392E21E22A3BA5 /* Request+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6909CDE156096B54AD70B70F2A1ED784 /* Request+Authentication.swift */; };
 		2CAE1D3E1F5EEF6BF2F1087AECFBAAC4 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = BD0E3E063250CDEE712CB6FED2FA284E /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D99BFB92138465C854AD3C5384D6A75 /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE65005CFBE682C530A83C14F4149BDB /* VimeoReachability.swift */; };
-		2DD8BC202B641518FCF2B87245DF415E /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 61199E51D666ABD1754E7146E219AEFE /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2DEA5341BAE0B6C0173EF66F9FECFAC0 /* VIMRecommendation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D743FD5CB60F7013F8A1B7F336B8165 /* VIMRecommendation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D2537D525D90C2C1954B7AE20AB6C32 /* VimeoNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CF722C1ECE5F7A8B7D42C4D9A3B1DA1 /* VimeoNetworking-iOS-dummy.m */; };
+		2D697C6A1E02DEBFBB3096E76D1687AF /* VIMThumbnailUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 48511DC8610B847616DBF17962816670 /* VIMThumbnailUploadTicket.m */; };
 		2E0AA3C22FA193E2DA12114D5ECAE18A /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1609B8B4D14EA62B4782C3A0AC84158F /* AFNetworkReachabilityManager.m */; };
+		2E838A982F3E9E443BBB46E3AFA9FD19 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = 70F18FFB1D81E5EE980E46CBD03773F6 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2EAD773F4D41904EF643DC51F1178845 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 197917CA70CA90B5E2744BDCDAC7B800 /* Foundation.framework */; };
-		2EB1232A651A2552C351F852320C6762 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF11167575460C49AB2C032A29B65C /* VIMBadge.swift */; };
-		2F11BC1B1C2369ED61721940DF3B8502 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF11167575460C49AB2C032A29B65C /* VIMBadge.swift */; };
-		2FC1A85B3A509019A065796054419835 /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B09820A935CEE6EC9658C595DE1F8D /* VIMObjectMapper.m */; };
-		303A034795C39A131FB1E9C668E9FBAD /* VIMRecommendation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D743FD5CB60F7013F8A1B7F336B8165 /* VIMRecommendation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		30BF639ABC808D4DDBE8516518180C40 /* VIMVideo+VOD.h in Headers */ = {isa = PBXBuildFile; fileRef = B60BA00D92FEEAB4E64F76F7B3929F7A /* VIMVideo+VOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3186A7ED24DD708275431B9B598AFA8A /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C18388A3250EC4C760D7512A99A466B /* VIMVideoPlayFile.m */; };
-		31F10A083FE95E039FA8F7723FFD25A5 /* VIMPictureCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D534D18281F270EBBA2C5AD2E2C783 /* VIMPictureCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		322B32268559EBAEFC01D6305C13F7C6 /* ExceptionCatcher+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FB75AF1632C64351A746EBE8143C71 /* ExceptionCatcher+Swift.swift */; };
-		3266BCD41650DDEC344DBBE9221DD383 /* VimeoNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BE52AC625BF69C2302B6063E1EB9D46E /* VimeoNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FCC8E89BCB2F52AC5226A69442D0A85 /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD40B1BB905107488280C57B0EA65FC6 /* NSError+Extensions.swift */; };
+		32BC10A002B552CE4020E962FB7BBD5B /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 436C8D5EC7EC30863563888B1C6A1472 /* VIMUploadQuota.m */; };
 		3375C0D32DCF0B6992B3D44458B3C8D4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CF46D31AE82B7E6D80A18A5E1FA4E20D /* AFURLResponseSerialization.m */; };
 		3392907797F114E953C679ABA921BC78 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C1846EF380E8486B4A1F6C9AC4C8A1E /* AFSecurityPolicy.m */; };
+		33B1DF181BB86C8A02497A189B93195F /* VIMVODItem.h in Headers */ = {isa = PBXBuildFile; fileRef = C5317EBE4C20F0CC5B737A04AC6CF084 /* VIMVODItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		340457C0F1D082F668CFF7E1DF3D61C1 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BB188794E997CD5840FBBAFC4196F89C /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3427999648A02BD49C5D71488529409F /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7B59BB14C734DC3B6D4AB6914BB83C /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		345343367D9511CBCA90AFC41B9B4ABA /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C1846EF380E8486B4A1F6C9AC4C8A1E /* AFSecurityPolicy.m */; };
-		34B814BB73BB87795190564A2E2D2DD6 /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = B31B2C5A0269172047F18AD00F5AC373 /* VIMVideoPreference.m */; };
+		3471E83B817D18AA2122EC844A626E39 /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 736190EDBD464ACE8CECBBD6E25B8746 /* VIMGroup.m */; };
+		349770811D45EB26AE22AD10F840C5E7 /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = CF65E1AADC01DEF3C1642483C3F990D2 /* VIMTag.m */; };
+		34C0DA8DE2088E9775D93C1DB8C715E5 /* VIMPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E677F784833BF969753B402CD57F22C /* VIMPreference.m */; };
 		3517B770BE855D36D4DD051FB084B034 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B892065F8B8B671D848DFBCBD400E53D /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		359354D8A6FE7403C281E6E16C27B3FC /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E11A064A120789D57ACC2CB6EDA9526 /* VimeoSessionManager+Constructors.swift */; };
+		351C57DCBD6AC41DA2A528CA31868CE7 /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F9599E9BB9B067C861D9E6C78CEC7 /* VIMSoundtrack.m */; };
+		358AD05968500C6F6C60C794D3D04C7C /* Request+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C6442502277D255EF0D73ED43EFBC /* Request+User.swift */; };
+		3626D9D2C451F6888BB176F9478C780D /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 55A341CD7CF9827C5AC2227A045BBC91 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3651018F1F0E0F1EDB2169BB44719266 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 839E964A6942F7C2DC01F73329271649 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		37C582939B5F7DC57834CE49FE56DBE6 /* VIMThumbnailUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 51406E890E759FA65CED3449833C35E5 /* VIMThumbnailUploadTicket.m */; };
-		37D93C09E94BD28158D8CE96127098D5 /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 736B2CF0F0A0E1460A1987D420D301BE /* VIMPictureCollection.m */; };
-		3855DF878994B29D1A84B21EED2F6495 /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34FEADA1EA0CF060F7EBD86CA8204C /* Request+Soundtrack.swift */; };
+		3785DD659AE39F5F91F100491CA1DB10 /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875C52E8E384150B35899F656FFC0B2 /* Request+Trigger.swift */; };
+		389F2EE461219398F4EA7DF88D80B61C /* VIMTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DB80FFC555378A2C0315A7D1CE27704 /* VIMTrigger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		392E961C28CF6D04564A806D1EE602CE /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CF46D31AE82B7E6D80A18A5E1FA4E20D /* AFURLResponseSerialization.m */; };
 		39A04831428F2079777FB4C63ED01515 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 197917CA70CA90B5E2744BDCDAC7B800 /* Foundation.framework */; };
+		3A6EE5B9CA6805E7D9A5A9D160365FBD /* VIMVideoHLSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B140EF76317A6BC8E805C42E8D7C32A /* VIMVideoHLSFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B9C697FE763738B7DBED5913B17D98D /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 940AF774431B71336D974C4817FC68D3 /* VIMVideoPlayRepresentation.m */; };
+		3D43BFB25134DE82F1314E9743891D8F /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 38AAF65A396A42208A8655BC9D7F529A /* VIMVideoProgressiveFile.m */; };
 		3E193AD16FFC6FAF727DC56EC48C97F8 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1609B8B4D14EA62B4782C3A0AC84158F /* AFNetworkReachabilityManager.m */; };
-		3E2F75EE7DCC3DEB5D79DCAE72016774 /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E985479470294B3B4F3403C0D3B565 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E76297663E04487B1C9D3E4C33CADF4 /* VIMVideo+SVOD.h in Headers */ = {isa = PBXBuildFile; fileRef = D626EFF0C0BE215902014B2985EB2D54 /* VIMVideo+SVOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E9398865F07736F00AF474DA6519885 /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABD0DD2B17A67950A4DF876C96C1A9 /* Request+Comment.swift */; };
+		3F1747447AA3F3AAB21FE9BC7DD0D54D /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CE692A4643EC075830B8A8D2EC0892 /* VIMVideo.m */; };
 		3F2D70A83E074C07C7C89DEC1C7BFA0D /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 7E0A850621EF8DB7A95C3AEDE9B54CB3 /* digicert-sha2.cer */; };
-		3F8F2DCA2B62902AC6B0679585ED1C73 /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE62B26CD90E5B64946B696500786C /* AccountStore.swift */; };
-		3FEB7CC8C957BD21FE80671A66247BD5 /* VIMObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7BC91BD8CF44D1DFED22B6399DFDA6 /* VIMObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		407EB4FD52D53E2D608F23A8823AB1DF /* VIMAppeal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E5671B2CEB95051F846F78E494E50D7 /* VIMAppeal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40973460F8DD37CD1D0989FCF848439F /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = E6CE1860B2693ADDE6451AFD7D93C2BF /* VIMSeason.m */; };
-		40BE1F38750259412E6F6A769BC3F188 /* Request+Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5538B95260F5A16330F27CC496C0E64B /* Request+Channel.swift */; };
-		4135FC0BAFAA1BB626C5DDAE7296E17F /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C18388A3250EC4C760D7512A99A466B /* VIMVideoPlayFile.m */; };
-		42CAEF3BA70168EB177BF63AC4FD00FD /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A375AEE2A37C0735E690CA1AC8A685C /* Notification.swift */; };
+		404A63F81D690AFC955DB96DB0CC8124 /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D83909308A593C42FF7DBF5381052C3 /* VIMVideoPreference.m */; };
+		407A8D13C01E169C0D8D007B79BA6EFA /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D389417470062CD360290BE2A7FF74 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40AD347FF4BB155BBBBD7343C9C0F231 /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = AE42D8F1DD5BCD1CD58E7CEE1EA571AE /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		421293F489569363A6EA8461507BE8D1 /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 55A341CD7CF9827C5AC2227A045BBC91 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		42DB1E96793A349DAD67890036C0DAAB /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = F87E4E126F204E9CD8AA72F763844720 /* VIMPictureCollection.m */; };
 		4361504926FEFF45F6D4AA34C6556E43 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FC1C7CCCD8E4917FA797C889FC9A9CD /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4382084F7BA5EFCA056EC4F6BDF5EF62 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A74725B0AAC035A5400A2E634928DF0 /* VIMVideoDASHFile.m */; };
-		442AA267CCF949E75F356C3758CB6255 /* VIMChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = C875B420A7A550346F838025CD450223 /* VIMChannel.m */; };
-		44D451688916D2C9484F6D36F841CB0D /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 339121042BB79912B92A5DBE8757F7C2 /* VIMUser.m */; };
-		455FE5E94D7523461E557270A9719790 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 95FDBB9E62BC08809CFDF4FB13603EFB /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45704AFD0CCE70E89337F284CF753B98 /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = ADA8F0D740690B50CD675C7534F3D3F9 /* VIMTag.m */; };
-		4590E6C1ED55D86D27BE09FCBB3E5028 /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 45BAA0B58A098356105F549216E19269 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45DBC372715FD83F2CE0C788EF42EB6D /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94F7CC0224824E9546F4B501DB03573 /* Request+Notifications.swift */; };
-		464D217CD9002AB9F37517309B00F579 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669BE8F834243C35434C4FB5ED83D6DF /* Response.swift */; };
-		4663D81DE5B993B40529369D21B657E1 /* VIMSizeQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = E19789298FED6865966EEF863826646C /* VIMSizeQuota.m */; };
+		4381FCC17E10883AE56EE089D722ED12 /* VimeoRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69F76DBD9E65B40AD472672DE92C4B9 /* VimeoRequestSerializer.swift */; };
+		4396512027103A5A5CBB7E59C39C0F4A /* VIMRecommendation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DBD3F7E349B96289AE20E9F2A78799 /* VIMRecommendation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		439963B2C27DB6A471408D974B439F50 /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B6DC63928A173B984CB141C424354D7 /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4414C2BE5EA37A450A5FF8BBC78BF7A3 /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = B605A075268FF4892F0C9D9D6F620FFD /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4580B9B9E7AD6C55A42ACE850D6F02EA /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A20FB839C88BC5EC47ACE75A5107905 /* AccountStore.swift */; };
+		45A5D144B01BCC04F9E3D82FFDA22C32 /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A2A35780B8623B82634E47027FFED61 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46077B8950E9D08134A414AA2E2F031A /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D0C751EB315EAC791F044CCB3D40BF /* VIMInteraction.m */; };
+		46A7C7C0E22D3E37CA4DB77E06119386 /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBD1FF411F252BAEDE0AE5DE8BF864F /* VIMVideoPlayFile.m */; };
+		46D17B4256B20D2975A12263E9BB6E8F /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 7900BBC9F776E494AF9162DFE4650222 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		46DE41A766A44C64ACD4D6ACF403856A /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B892065F8B8B671D848DFBCBD400E53D /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4830B2E7A8067EB3F107582F4D4B3E48 /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = AAEDBD81DC147A4E5C253DA14C56613B /* VIMNotificationsConnection.m */; };
-		49A228D9A776D7655EEA89E4AA8E1574 /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34FEADA1EA0CF060F7EBD86CA8204C /* Request+Soundtrack.swift */; };
-		49A8F1A96FA359CCAF34BDFF67754BE1 /* VIMPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = E035D94411FF23FBDF847FD809A0EECF /* VIMPicture.m */; };
-		4A20C03C1E49DA2D7FB94F5333A93232 /* VIMVODItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 734BC714BD7883E229A749D5FCD959BD /* VIMVODItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AC651A094079C72BC176FB29DE21B2F /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C952C24463AAB0C85837069ED51E33 /* VIMObjectMapper+Generic.swift */; };
-		4B82F0596669196ED2BA3FA100D3425D /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AD679486A4AC3BE6AC694E2120F19E /* VIMActivity.m */; };
-		4BB7780199EBCB61A791DD1E13AE126F /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4317F045FE3314AEAC78685D8905E5 /* VIMVideoFile.m */; };
+		470CBD3CBADA92A738ED83159487F8F8 /* VIMVideoHLSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B140EF76317A6BC8E805C42E8D7C32A /* VIMVideoHLSFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		471D8301D3C8DE724E94E64BFD83EAA3 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 52AE2B99F1B20F4EB550846F1E35CE66 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47465988A6FD34408AD786A128335FD6 /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 1007E89CB1BA9CEE28AC124F4ACB44D5 /* VIMPolicyDocument.m */; };
+		47654015D628778C927D41A545BD538A /* VIMPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E677F784833BF969753B402CD57F22C /* VIMPreference.m */; };
+		4767979687854F3DA71CB98920DFCDD5 /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4307A32427BDE785689408CDF1FFB4 /* VimeoResponseSerializer.swift */; };
+		4ADECAF00F508DEDF6FB535B1C723AC0 /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B43ED7F71FBA6AF0A283986F36F523 /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4BEBC6EB2C3333B6FB54B4F05B4A1F06 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 245B7DC7C32AA325A5053F1C3FA576FE /* SystemConfiguration.framework */; };
-		4C8486DFFDF221453DE0ABC3876AEA21 /* Request+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805AA9E647399745D11A6706FC5DD81A /* Request+Authentication.swift */; };
+		4C5B7B7689235245C4C7549161E6F7A2 /* VIMVideo+SVOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CEFF5FE44CD9018B27A0AE71C24D457 /* VIMVideo+SVOD.m */; };
+		4C72A34C04C343E27E3C442987A0E6B3 /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 7900BBC9F776E494AF9162DFE4650222 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C8F42808E4DA17CE4BACDE88885E5F6 /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 982732C79018F5203BE6E7E685A7107C /* VIMVideoFairPlayFile.m */; };
 		4CD6BA70057E9D0B4AE28FA874A18E29 /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 7E0A850621EF8DB7A95C3AEDE9B54CB3 /* digicert-sha2.cer */; };
 		4CF98C69E62F59634FF245A84F4DAF07 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E8145278825D2B77107418074D1494 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D5C86FF587706B016555A5791370C97 /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = F87E4E126F204E9CD8AA72F763844720 /* VIMPictureCollection.m */; };
+		4DBB41B04D00DA027E5CD2D152C4BADE /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584F81421BAA557AF945BBA1D8D9AB6C /* VimeoClient.swift */; };
+		4DC858480DA70CC477C4D6047270E487 /* Request+Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6394F7D67FC3782A07ACFCE8E622E768 /* Request+Channel.swift */; };
+		4DE310D9D6DCEF9F95A9937B1CA083DE /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A5F7B9659356AA141A193B05FE7FDC /* Request.swift */; };
+		4DEE5F146D8FFDC27DBB40E98526BEE3 /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = 84D516F4EBA47242E0D9760E4F7C1353 /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4E77488ECAE3D3CCF8F2AA55FE66C922 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = D92C6DC78822CA3DB419E2F0F7813740 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4F0DC1F46032BDD53E61FA2DDC33247F /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 564E30C21468FA8DACA24A8E768A2C3B /* VIMComment.m */; };
-		4F52E3ACDF979F439590609D309EA457 /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3594508BA6BE964CCC7EA7ACE831F4 /* VIMCategory.m */; };
-		5000685786C5A77370BA993BA4483707 /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 471D33D599D075E83CF7527E467F7F1C /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		50DF7F0693D5E5447ECF55EC28471EC5 /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F9A4D52E090ADB6875D0781DA849D8 /* VIMAppeal.m */; };
-		51CBA644A87F7D5F815C782D12A3F7F4 /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BE65117389447A238073067BF67BB8 /* PlayProgress.swift */; };
-		51D91DA61BC333F13018A2140B5A8371 /* VIMComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 179C54BB1ED2F615E881E6B6F085FA8D /* VIMComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52ED03F2FA11B674B9B4497A5E6CEA58 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 08355F852018C46FA265697C2DC149C9 /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		531A00EEBD3B8318444B041626CD304C /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D415A26C2C8901948B30CC37B4F5EF /* AuthenticationController.swift */; };
+		4EFFCE0B3A801753E6779E7EF94CA58A /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 1456E82583F2E91622BF0C4CB24D8282 /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FBBCF4AA1F767BDD2F028133E8E7411 /* Request+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3BC3A65FB1B196F662670C0DBB455 /* Request+Cache.swift */; };
+		508EF7FEB0E46FD8888BD35F326C66C8 /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDCCFCA74DCB70FC8304247A43E7A5C /* NSURLSessionConfiguration+Extensions.swift */; };
+		50BC3C1FD3B0E8792996CFE8270E97DE /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E05FC37D99D9236704387733255F601 /* VIMNotification.m */; };
+		51770D0B5C43A7D3BDCD31F0D7BD6107 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C886C806158CE045537B8268BDD40A /* VIMVideoDASHFile.m */; };
+		51CA54E2DA27E556CB2E22F65551ED3C /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 982732C79018F5203BE6E7E685A7107C /* VIMVideoFairPlayFile.m */; };
+		53AB7BF5214785C7D3516CC64D984826 /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 38AAF65A396A42208A8655BC9D7F529A /* VIMVideoProgressiveFile.m */; };
 		54A2E4C7475C5FB2D165EB7A9ECABB89 /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 07E5575BBC8C7295ACA3404520CA527C /* AFAutoPurgingImageCache.m */; };
 		54FC0F7E040233C9C696326AC3576077 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2947707C0AB4B96015ECE4CAAC4B6BAD /* Foundation.framework */; };
-		55FA63E5735FD016716E63F331634BC8 /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = F1DE65342B0FE267B3D2E83243AE4EB2 /* VIMPolicyDocument.m */; };
-		574D4F20FEE227D98DCC1C529827C88D /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771137F242745FA7174D18F6B2B55E36 /* SubscriptionCollection.swift */; };
-		577D706CD8A0F89A876B5E6ACAFF82DA /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 26B92B499A5D5B2A31470AFDFA787984 /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		57FD8C9D831FD88F46755944F85E172F /* Request+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8176C5051EFDE888C571B411FFC422D /* Request+User.swift */; };
-		5895781244B1CE73F8CC81A53A6F41AC /* VIMUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BD749BDAAB6F8F73BD7F3CCC4CF61E /* VIMUploadTicket.m */; };
-		59DBAE90AFE5BA827F27BEF93951A2BF /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B37124BF2D0C922CE03CB58867A210 /* Request+Category.swift */; };
-		5AF9BBFF3291790C31C333DA4C6E380A /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F0CECD6330DF68A6916A638FD98AB5 /* VIMRecommendation.m */; };
-		5C2F630EE801A0DF2EA50F366A233B89 /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684CAAA7E1F06FFB876478090C3C8DD3 /* Request+ProgrammedContent.swift */; };
-		5C32CE5F88F45247288766384AE9CE5D /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F5994649FBA3A14B23B23D3FCA85A2 /* VimeoClient.swift */; };
-		5C9E0B491C28464F3EDDCC014D740A12 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = E6938D1F58272D3B69F54B79AD04D861 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E14747DDA8AB00385668026C59F23DA /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B5311892B58BCB246FCA8017CE6BA94 /* VIMVideoPlayRepresentation.m */; };
-		5F13101A369895BB854EED64A5DDC822 /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = 281594D3591B4C4D8504EEA3CD2AA768 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5F26EA8E41C3079E66B063F1450195D4 /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA584B5334FB72FEC2DD0A6CAF29167 /* VIMConnection.m */; };
-		61811447CB13E5742F4AD326F8A77F31 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 08355F852018C46FA265697C2DC149C9 /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		642ED818A9477FD2AB367325D1485649 /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1DF9AB6F331C77CA71DD6B7E255D9E /* Request+Picture.swift */; };
+		562BC5475D1790C1E3B63FB960D0CA84 /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D0C751EB315EAC791F044CCB3D40BF /* VIMInteraction.m */; };
+		570267FEE2CF302BA3CB89C4B628952E /* VIMVideo+VOD.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A583D9AEA48462ED7025103564EC1A /* VIMVideo+VOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		59F0D2BE21C4ADCF91396A8576F00DFF /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 96C8C6F8BCE7ACAAAF67CB6CA7FDCD0D /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B2C1647A65300DE829DF3DE2897F53C /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3071D58C5C91FF7CDCBFEC7BE4CFE200 /* VIMConnection.m */; };
+		5CDC0CB47AA501BC4435745945FED12B /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C48F19556B7A419C08AD20108343A2 /* Scope.swift */; };
+		5D2B70BA11DC4158D6EA6579918A1ACD /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = E982102FDBF3A7B8E676EE912FB73697 /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EC2569A896397A308E71A2C1A3DF219 /* VIMNotificationsConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A1C2B241368B5431C8350C437E5C4C37 /* VIMNotificationsConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F2EF10247DB9374BD0CB9294CB0D365 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E158346041ED7D2756E0BABCE3359180 /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6016B588D7A827B954DAD8638A162392 /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E0D09E3E6932A763A908776E806721 /* String+Parameters.swift */; };
+		60F922552B4B1E9EDE238F8C9F1BEC37 /* VIMPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E1640A6DAB4920E2BD4CC2D26003AD0 /* VIMPrivacy.m */; };
+		619CE60F3806F5FC18321C81B5690EEE /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA854CAD12FF6A039EE1803203DC92F /* VIMVideoUtils.m */; };
 		646094043F88EC0F6CBF6ABCF6F6B108 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CB0DBE67EE0E5DBCC57752F1FAF702E /* UIRefreshControl+AFNetworking.m */; };
-		64B5365A7E303534E00D6F4C41225316 /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AF35296C8C00D637F4BB34E969A220 /* Request+Video.swift */; };
-		655F0E830FE980C6F6802007EE3B7626 /* VIMObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7BC91BD8CF44D1DFED22B6399DFDA6 /* VIMObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		688B39E39786B905B219FF39B60FBAFF /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D09E94BEF337DFC92D742834825936 /* VimeoResponseSerializer.swift */; };
-		6B299CC8783E85DA94E1117C56A72B5A /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CAFF6DA4FE0A11F64E7BEE3F1A5E801C /* VIMVideoUtils.m */; };
-		6B597370B50EC5244FE88D90A5E9DAA4 /* VIMVideoDRMFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = F582EEBB44C65E57F5CD07F5251643F5 /* VIMVideoDRMFiles.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65459214406E6C7668A6B7BEDC91A706 /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C18B361F0105107F7CD7ED3369F060B7 /* Objc_ExceptionCatcher.m */; };
+		6820B239B89F20FEF3BE3FD8AAA81848 /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C44EB0245A9263C02C1DE892254EF1 /* VIMObjectMapper+Generic.swift */; };
+		682F9F1CDB41659C2B5508AF487C7A84 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 43AFBB835F93D6364FAF476CF9B99817 /* VIMVideoHLSFile.m */; };
+		6845E89B4666D44D1B40EB21B5A9B8C1 /* VIMChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE2A1362958BB9EA1461DD137B8AC56D /* VIMChannel.m */; };
+		689405D16A5F2C57FCB4576DE10C8154 /* Request+Purchasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995E2A4882A91722B328223AE1907399 /* Request+Purchasing.swift */; };
+		68AE584196FA61BA8CBECDA29A7A4F82 /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 1007E89CB1BA9CEE28AC124F4ACB44D5 /* VIMPolicyDocument.m */; };
+		69AAB03BC6DB451CA18DE79846EA943D /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 04DE9119228F4D6A30C7C5FC2161EAD4 /* VIMVideoFile.m */; };
+		6A1FDB975033653489EC97F8A79EEBA5 /* PinCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53568F3F8B42860E008F52E55F6FB90F /* PinCodeInfo.swift */; };
+		6A5E7C7AF75702330A69A1917E85F2AA /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35790B480E77599EB94E272BD2455ED /* Request+Picture.swift */; };
+		6B6F91D31027A30E42A75D170E1D9E65 /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11514B79FCE3AA78352293D67C56CCFC /* Request+Toggle.swift */; };
 		6B85FCDF20F6D88B46A33C0CAE76B7DE /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CB0DBE67EE0E5DBCC57752F1FAF702E /* UIRefreshControl+AFNetworking.m */; };
-		6C2CFDC9328CC48088F2529F1095F51E /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292E0C05CA34891FE8E831B2E808809E /* VIMProgrammedContent.swift */; };
-		6C34DC7801F7246417633D5E29E93AD4 /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DBC77E4281BD8A9FCF17C27BC6645D /* VimeoSessionManager.swift */; };
-		6CE6F3808CD7BD4F766770669C17FEEE /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0802A3F20A40169F2385826DC8492AA9 /* Request+Trigger.swift */; };
+		6CC19E53AC93DE3EF8FC23AF19B11361 /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = C4A170AE2F7C9BA8AC627713514A2F68 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CF4676A55D177939AA3BEE126BDD727 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DEFE6F9B852E6B533E166938D98B2011 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D626350217F9FB359C4086BF65A7683 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A74725B0AAC035A5400A2E634928DF0 /* VIMVideoDASHFile.m */; };
-		6D7068CAB1963C91BCA0A40BEFD0B681 /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 517155516D8B9E4AC1FF2AD324D8F03D /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E69F059A0F78B124E37C16A4B620380 /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7E3623C60B3CEA68419632CE9D7CBD /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EE3FA8D4C0A48B2C289CABA55546E37 /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7B59BB14C734DC3B6D4AB6914BB83C /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F338B1C849A84DF7D63EE4E99E37F96 /* VIMSizeQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 46302053FFBE4A1DE028AACC0E3FFAD6 /* VIMSizeQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F65585C038B1D3E500D17EA3E4F984C /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 131C00E5DAC05AB4DF652C33062FFC35 /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F816118CEBBC6B6AE314841BDA23584 /* VIMAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 994B41DA9BA49B07FADDF4A326863DE6 /* VIMAccount.m */; };
+		6FE507CA6D1CFC53DCC348D8EFB126DE /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC758E8D30A0F1FDFB079DD305DF047F /* Response.swift */; };
 		709192415331306947F497DBE3572673 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 67BBFCD72D381FBD52E17B6B00433608 /* UIButton+AFNetworking.m */; };
-		7176B1CCCE595C77FA2252FE8B74F21D /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 61199E51D666ABD1754E7146E219AEFE /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71CDD7C40CDF92E444CF869C6505250F /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E298AAB2BEC7F6549699CECD0035E11 /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		74F2F27A57D4DD80CE12E38D17859981 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7011A73F3E0BF3B5467B0308C532EC85 /* ResponseCache.swift */; };
+		70A20145EFE75465C38A118E93AAFB97 /* VIMRecommendation.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DBD3F7E349B96289AE20E9F2A78799 /* VIMRecommendation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71F417159314926E616EF19CD6D28847 /* VIMPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E1640A6DAB4920E2BD4CC2D26003AD0 /* VIMPrivacy.m */; };
+		72A33279880FF20C244EA0069BBEED56 /* VIMVideoDRMFiles.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9571AAD3AFA5A25E5CE60FB3DA4065 /* VIMVideoDRMFiles.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72A4AA6395495E579526A7269F1D111C /* ExceptionCatcher+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DFD9B4663434957354444113757AEB /* ExceptionCatcher+Swift.swift */; };
+		73422A4A5AEE4C2A96D31C38AF68F4D0 /* VIMTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = CA65C7C00A605BB2802D8F203E4D8110 /* VIMTrigger.m */; };
+		746139278E66149DD3F46A4BD9EAB027 /* VimeoNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 333E74E9D12E8587F8596072434B2DC2 /* VimeoNetworking-tvOS-dummy.m */; };
+		747D0C3E1A4B0C78E5C7C90B28E5852C /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CBA7569FDD87D5E66E0D710A69A73E2 /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		751FA6D8D63237F3C3F632560B3B1284 /* VimeoRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69F76DBD9E65B40AD472672DE92C4B9 /* VimeoRequestSerializer.swift */; };
+		753FE16B4DFB90321CF4096A8D08F793 /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AABD0DD2B17A67950A4DF876C96C1A9 /* Request+Comment.swift */; };
 		7540B3341205665B12B164E1B40C3695 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C1673169E3D04DC71FFCED7531DF18 /* UIImageView+AFNetworking.m */; };
-		75D0AD80CA0FDB50976525AC22732FEE /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 627D6A4C038285A0976237937BDF0752 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77371F847DB67642899DD595D6EA60E7 /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F5994649FBA3A14B23B23D3FCA85A2 /* VimeoClient.swift */; };
+		7598B794915D2D92F58FB481C0C5DF28 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C886C806158CE045537B8268BDD40A /* VIMVideoDASHFile.m */; };
+		75B6B1DD3ACA837CDEEE8D88F948E6F4 /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = 09404CBEC79FC3224ACB8B06C8D89282 /* VIMSeason.m */; };
+		77114475B404C5F02121916B1694F92A /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB9221DABD0055F8247E5D435332EED /* VIMVideoDRMFiles.m */; };
+		77147384B212D47FB5479E0A47582152 /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 940AF774431B71336D974C4817FC68D3 /* VIMVideoPlayRepresentation.m */; };
 		77457B736AB9BDA9E60464DD0A5A4753 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 700303B0A4E880011AFA42F555F78B6D /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		775C8C32395479BF9922D7920C29C2EF /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B0D8653FC50F48DA48C7463CA718E52A /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		786F124B93851808CE206803726509E1 /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F45BAC7FFA5FCFA7AFACF9AB1D0F12 /* NSURLSessionConfiguration+Extensions.swift */; };
+		77F285F3622DE18D8E824D8C266D3268 /* VIMVideoPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C31C2D32930DBB30C817C1D604355C1 /* VIMVideoPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		781AD58BB50D3E4BE1FA91C8D0ACB544 /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = A8B4FA8C0590BAC5B34E0FB918C588A3 /* VIMActivity.m */; };
+		794BFC62C030F45F77B8BEEECCB0354B /* VIMUploadQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 96C8C6F8BCE7ACAAAF67CB6CA7FDCD0D /* VIMUploadQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ACCC8EE65205F97F9EA2EC0FE9B666F /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B73FC9797518500A1A7D836707CE7D78 /* VIMVideoFairPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C37074869A6C52F623FE54B44DEE0B3 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042A843F834375AB7A2344563BA0B741 /* MobileCoreServices.framework */; };
-		7CFC9B4B2F3BA8566BADA2791A82F38E /* Request+Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5538B95260F5A16330F27CC496C0E64B /* Request+Channel.swift */; };
-		7DA13F718DE3FF2AC4CFECE68CBB92E6 /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DBC77E4281BD8A9FCF17C27BC6645D /* VimeoSessionManager.swift */; };
-		7E717256B6DE6B1B0E908703D101987E /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 534E14F2B03338A7A344281334105191 /* VIMNotification.m */; };
-		8141CC4C4553CE8A01C4EFF428565033 /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 627D6A4C038285A0976237937BDF0752 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81C1D1C88BAB4552978DB636EDA6F919 /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B37124BF2D0C922CE03CB58867A210 /* Request+Category.swift */; };
-		81EA11EB01DCA8D04F99DEBBDF737E24 /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F927D4B012FBD352564066F8BF470052 /* Request+Comment.swift */; };
-		82A69DCF203117B065B1E3A01FCABAC8 /* VIMGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 1309CB98D2B0E4D5A1581913EB681AD3 /* VIMGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		82A6A3D6B8FD3EDE1F49CB262B9CE44F /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA584B5334FB72FEC2DD0A6CAF29167 /* VIMConnection.m */; };
-		83DCA3621CA7D33C727CEEE4AC072497 /* VIMVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 35DF3F42E2AA53C89B5CBDEE523150A5 /* VIMVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		85E0D887455F41BD93EEFCEC6A5FBF1F /* VIMTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A73E1F60C716DFE7022B504B586624 /* VIMTrigger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		85E63A687EF81297647181B84C69D644 /* AFNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B3EAC33181285B8B24E63F3B5AF614CC /* AFNetworking-iOS-dummy.m */; };
-		8699E1CBDD0FDDBFEA3F13C3FCC8AD97 /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F47636C468189B8FE0647F6112D5464 /* VIMQuantityQuota.m */; };
+		7D13135432BCC564E672803619EC85B9 /* VimeoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6C3BDC1B1BAECB9607F1398C161C08 /* VimeoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D80822A38476954EDB66A5ECE9B3B40 /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 3393CCCD8B9E11861D5344277458C2B3 /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DB79FBF2D77644954876F1849703C62 /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = CF65E1AADC01DEF3C1642483C3F990D2 /* VIMTag.m */; };
+		7DC0EF19CAFD463DE669FFA314A90773 /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = 84D516F4EBA47242E0D9760E4F7C1353 /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		802DD040F72B5B0139A6812F7BE91CB4 /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDCCFCA74DCB70FC8304247A43E7A5C /* NSURLSessionConfiguration+Extensions.swift */; };
+		808CAFD9B246D2F1A707DA12F72DB8AF /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8354F04605CD9749E74E18A8F35425 /* VIMProgrammedContent.swift */; };
+		82F67AA0A0AF7C0DD82A4C017213B0D2 /* VIMVideoFile.h in Headers */ = {isa = PBXBuildFile; fileRef = EB986F5DCE12497A6EEA8957FF17B63B /* VIMVideoFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		837C51114EDE83B70FF846CE0C35938C /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = B605A075268FF4892F0C9D9D6F620FFD /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84380A223BD139C9DFFAD3A6E6734964 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DCB3176AEDC01F983620ECC07D12E3 /* AppConfiguration.swift */; };
+		84A0ED33B6BCAC1C1E9738E92960E235 /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B43ED7F71FBA6AF0A283986F36F523 /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84AF828EBE67D8A70BBF07D9A6F1B650 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D8EADD112B72372D01930045B40D07 /* Constants.swift */; };
+		84B3D0193916DDA38D4299CFDC30A726 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC758E8D30A0F1FDFB079DD305DF047F /* Response.swift */; };
+		85E63A687EF81297647181B84C69D644 /* AFNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 13D39574532297EB9CBA2F2A62390B6F /* AFNetworking-iOS-dummy.m */; };
+		86C69476A2BC7A7834CB0D2619AB118A /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8354F04605CD9749E74E18A8F35425 /* VIMProgrammedContent.swift */; };
 		87015DE6FE5348AF48F541C69510648C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2947707C0AB4B96015ECE4CAAC4B6BAD /* Foundation.framework */; };
 		872A2D33CE11426771ADBA0FF2EEB35C /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = D92C6DC78822CA3DB419E2F0F7813740 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87E1272DF69030AE5C1E6FA5FA328928 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 473D7E9AAA642355C084D5D5A7B7CF40 /* AFURLSessionManager.m */; };
-		880E3CDEBA40B53033719AA0E64C5D2F /* VimeoRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589730830A01A361F90E6967F2D67DB /* VimeoRequestSerializer.swift */; };
 		88541FB483A4BDB6EF02EF5860CB3DAE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2947707C0AB4B96015ECE4CAAC4B6BAD /* Foundation.framework */; };
-		88EBCC3ABB0121AE65385DE423E17C81 /* VIMThumbnailUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 51406E890E759FA65CED3449833C35E5 /* VIMThumbnailUploadTicket.m */; };
-		8970BA14107BD60EF422212476FB80C7 /* VIMGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 1309CB98D2B0E4D5A1581913EB681AD3 /* VIMGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AFBE34AF57A71975C3FA8B3BA525FBE /* AFNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 948D643DF3F7192C27FF5E8BD7064A4F /* AFNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B18FB8D93938576C1184F639FB58C9C /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AD679486A4AC3BE6AC694E2120F19E /* VIMActivity.m */; };
-		8BE589B4BA75F81FA335FDB898DE973F /* VIMSizeQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 773E651333ED23356F5B6B4A2C74BF6E /* VIMSizeQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CA1AD6B35BBF47EBED614338C115446 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8ECCC343EB76513F98BCE43E3C62A63 /* AppConfiguration.swift */; };
+		885E89D934793567CA90F84DB4676F36 /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDE55D4C67FCFD91DF2D54641523FE1 /* Request+Category.swift */; };
+		8867D2940ED47BB9D46CEAEE4C2E137C /* VimeoNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B3DD258FEA974E858B769890622478AB /* VimeoNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A199838AD3ABD57AF08647A1A91B906 /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = B69E8AE4E8E09DEFBF3A2BBF52787052 /* VIMRecommendation.m */; };
+		8AAE3872665437F56D6C6441C3D24493 /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F3D2845CDF2659A23B03641F8A66C1 /* Spatial.swift */; };
+		8AFBE34AF57A71975C3FA8B3BA525FBE /* AFNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B4657CB2ADE8C4AF346AEA36B72FEC77 /* AFNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B1DF6CFC392DAE357840CB5984D322F /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A2A35780B8623B82634E47027FFED61 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B7A222E509AC4849C2EF5CB7C8ACFEC /* VIMVODItem.h in Headers */ = {isa = PBXBuildFile; fileRef = C5317EBE4C20F0CC5B737A04AC6CF084 /* VIMVODItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8CC2C51E63A0F4EFF95B8C0D1FFCF1BF /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4DB6F852A348D5C4B9DFE151885233 /* AFImageDownloader.m */; };
-		8CF0CE27E670EEA4E7C8875DCF1B1D09 /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 50A0AA5B2D4E05972B4F2ACD8A14D6B9 /* VIMUploadQuota.m */; };
-		8D5252EE0BDD0EE7E198A72906EC432F /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4635386CED75377DB6612716F497B /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DDA340603EAC5D83A1645A0517C329E /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE6546E0C59DB3C0BAA64D0C2EA01A6 /* Request+Configs.swift */; };
-		8E2AC23055C05A41096F25E567C661A9 /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CFA606A383C992A4AD2F0E0297CB568 /* VIMSoundtrack.m */; };
-		8E402650A756F2E94B7C1879F2750D10 /* VIMPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 4268200039AFCC987F67F25FDB3145F9 /* VIMPreference.m */; };
-		8E66BE8B9E7509A2078D6A148F687FAB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1410805711F5C3B8C5349F7A54B879 /* Result.swift */; };
-		8E8261555B4F3C397051DE725BACAE60 /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 461A2F51AD0136F4FBB09E77CDDF0519 /* VIMGroup.m */; };
-		8FFA7923EAFB15E44CE6F79BCC5C4C29 /* VimeoNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DD0B00BEFE4EC4A6D4169CB2D857FAFE /* VimeoNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9083719EB79EADB8366E3C853BDB8190 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6AA5001AC39CF18E85E71CECF418D0 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90E5B69E9DA9968C585400998C7215E2 /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 80C5471E78D64BF02F17B063DBA3F77C /* VIMVideoDRMFiles.m */; };
-		925FC087967213BFD500A2E05178D8FB /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F658D9E363552377641D391AEABBDE /* Mappable.swift */; };
+		8D585CF9CC891A53EE60A45ADF57E671 /* VIMVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = E4908E6209B0874E069635BA3305A278 /* VIMVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E5D1EB6D6125FC200B0EA7F8566B530 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F562F610CF6498DF3ACC32CA8B717A3 /* VIMUserBadge.m */; };
+		8F3F391C0053559FEA23F7F90BB63D73 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 72011EB002491733A4DDC5E1D15191D2 /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F80D42848D697E9AE3788A74F6F2317 /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B875C52E8E384150B35899F656FFC0B2 /* Request+Trigger.swift */; };
+		8FA6D7E4522531133BD1D87D334CA26E /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35790B480E77599EB94E272BD2455ED /* Request+Picture.swift */; };
+		907131ACBE86D6BC513A5A6A419F699B /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C85333BEEAE2F31305F9A10ABB399E04 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		910AE9F89C1EFA6DDD46FDFD1C7153A5 /* VIMTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DB80FFC555378A2C0315A7D1CE27704 /* VIMTrigger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92FC328F61FF58E53A2655E052365317 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F562F610CF6498DF3ACC32CA8B717A3 /* VIMUserBadge.m */; };
 		93B26B108CD9143683A34435CAFB62CD /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 67BBFCD72D381FBD52E17B6B00433608 /* UIButton+AFNetworking.m */; };
-		93C5DDAD2D2BF508DEC653C50CEEE0C1 /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = BCFC3340D44487494021D17F1B0032D9 /* VIMInteraction.m */; };
-		94BC8F01979CDDE388262BC05FEC4FDA /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 037D6AED08466DC62BD3FAB79CEF1153 /* VIMVideoProgressiveFile.m */; };
-		95B81FE8EA30C7AA436B190F9F8994F5 /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0802A3F20A40169F2385826DC8492AA9 /* Request+Trigger.swift */; };
-		975A9C53CF43DB62C7B97EFE3F3B0D2C /* VIMVideo+VOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D06DF72635F680385E75F3C97399EB0 /* VIMVideo+VOD.m */; };
-		9778E8A25EE1F2F2C7D6AA2DD51195B7 /* VIMVideo+VOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D06DF72635F680385E75F3C97399EB0 /* VIMVideo+VOD.m */; };
-		995AB2C105128EBA13C6B120720691C0 /* VIMCredit.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8B0F8D06B6963AFA613D5540B20448 /* VIMCredit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B0C720A6B769D9BC04C35ED835B59DB /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 564E30C21468FA8DACA24A8E768A2C3B /* VIMComment.m */; };
-		9B473AF317E4D657CC9342D888F9772E /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BE65117389447A238073067BF67BB8 /* PlayProgress.swift */; };
-		9B48B748D0F20BD3E7F9DFC880CEC0DA /* VIMPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = D7B0A8437B102DB9AC47F5E104762B97 /* VIMPrivacy.m */; };
-		9B501397CE6DBCD0F429119089B50015 /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A68E5D954E9C3C2E6092B1B67A3E1E6 /* String+Parameters.swift */; };
-		9BAA801FDC7DBFB3543302853CF59650 /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F45BAC7FFA5FCFA7AFACF9AB1D0F12 /* NSURLSessionConfiguration+Extensions.swift */; };
+		9581978CD9797E61B4B4245BD2E4A7CC /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C44EB0245A9263C02C1DE892254EF1 /* VIMObjectMapper+Generic.swift */; };
+		96903E8D8A907273BE333E0193BF683E /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = E96440544E7AE1DACD14D44B11AAB1E2 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9943585E131232FE86CA151B86E9F8BC /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2D208C4CC086A891F12E4C15EBFF2 /* Mappable.swift */; };
+		9B71371B36FAB303C669C7FD78C83EC1 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D4B5215801D2D5C63CCDF0419672E78 /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B7623D429E92D46675E6D96FF896732 /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 383610F11263F07C8D784A9F10AD42A3 /* PlayProgress.swift */; };
+		9C0657EE5B3F82F88846CBE56F3313A6 /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 131C00E5DAC05AB4DF652C33062FFC35 /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9CB8505AF1BF06B190F2497F1A22CA3F /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A19D957B49D3BD3CABBB7A1FB15AC26 /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9CDCEBE9386F450950739E26A9834C08 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FC1C7CCCD8E4917FA797C889FC9A9CD /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9CF274DC38242FC0F7B51A4E15280033 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6AA5001AC39CF18E85E71CECF418D0 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D2D98243C5933F819B08452D5823FD4 /* Request+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805AA9E647399745D11A6706FC5DD81A /* Request+Authentication.swift */; };
 		9D305E2EC3640C235E7D18D3C81C9480 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C88F775ECF0360B05F98B42449EB724 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9DBBFA368AC396198066247066F6E52B /* VIMPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = D7B0A8437B102DB9AC47F5E104762B97 /* VIMPrivacy.m */; };
+		9E21712763B90A76733BE3A373F209C3 /* VIMThumbnailUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 48511DC8610B847616DBF17962816670 /* VIMThumbnailUploadTicket.m */; };
+		9E2E5481CD74924F5A8F6D7906BD9534 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 72011EB002491733A4DDC5E1D15191D2 /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E3853549EA2E01D48F49C9FBBA50B68 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 700303B0A4E880011AFA42F555F78B6D /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E6F9175F92BD79B778F9E0196B36F7A /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 051C78B450DB6DC089554A98C52169DA /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A07E57598ABB781C51F717C54FD0B7EF /* VIMTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = 798C71B67EC392EADE04DAB73BD406D9 /* VIMTrigger.m */; };
-		A2036C720BFB0F96047AC7CEC0399C2F /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F5400D264F3C9259F38D027C580269 /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A2B019CC61891672D2DAAB0304EBBCAC /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8ECCC343EB76513F98BCE43E3C62A63 /* AppConfiguration.swift */; };
+		9EC83E495F458EFB8A02A13C56B9B52F /* VIMVideoPlayRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9948C38E0266C1BA795F936FD748AB /* VIMVideoPlayRepresentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A13B6F9EEAC70119FA5B9738E7E0B0FB /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C748830CA64F6F99AEF35A159EA35B /* VIMBadge.swift */; };
+		A1E1BA14295271BDBADA5085C6504E72 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC28F4BBBD260F1FD163C117165AB6E /* Subscription.swift */; };
 		A2C0A5DF12ECFE0DFC9BA404AA736F52 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 56C397664C4ACDEA5C3543FFFF98C440 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A38045A5825E3B7DE0DC4578D5B06746 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 737AF7F9A1C09E38A4225A0EAD753152 /* UIWebView+AFNetworking.m */; };
+		A395D1071C702CC601592BF100D7F156 /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F49888AA2998709A179E549F965BDFAF /* VIMModelObject.m */; };
+		A3F1B72D861DC9FFCCBF2504D3A2B61F /* VIMGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B1D926D49D146EA24B31A59FA01AC9D /* VIMGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A4215ABE80F276776FDF90573B14827A /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 466F66A73E061D9070D392689B346068 /* VIMObjectMapper.m */; };
 		A49DC905560E90186091AD737BB51A5E /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C88F775ECF0360B05F98B42449EB724 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A6619736B4DC89136ABBFFDCC1904E36 /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B1BE9F49C799214FE09C3A414BF863F2 /* VIMVideoFairPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A681D2D8F578B32E6C6A8E59BA15E472 /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ED07A77DE93F9B9E08DDDC75F3EC773 /* VIMVideo.m */; };
+		A504311D188FAE18FDA214B2D42DC4FF /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = 09404CBEC79FC3224ACB8B06C8D89282 /* VIMSeason.m */; };
+		A5424078D239128F554ED685E3473A5D /* VIMCredit.h in Headers */ = {isa = PBXBuildFile; fileRef = 74AF20740335B0044F97B0D2732847AF /* VIMCredit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A67A524F1BDA4FE60566B342989DF8A3 /* VIMPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = F6E293EF1A0B5647FA0964FC336CDD7F /* VIMPicture.m */; };
+		A6BF36DBEE0930576AD51BAF917A19A4 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E158346041ED7D2756E0BABCE3359180 /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A711DBA42FB9611FBBEFA07DD18BBAB3 /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F9599E9BB9B067C861D9E6C78CEC7 /* VIMSoundtrack.m */; };
 		A74B51ACBB1EFAE1FD89F5BACEA04612 /* Pods-VimeoNetworkingExample-tvOSTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F713551893DD24923ADD2D70432FD08C /* Pods-VimeoNetworkingExample-tvOSTests-dummy.m */; };
 		A7630DB01B82694021E8AACDA4A7C03E /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = E8632641A85F1E3BFF24373979525E28 /* AFURLRequestSerialization.m */; };
-		A78E8102501345127C538D43630F5A6B /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC7D5950400DB7546EECE5B0D4D25F /* Request+PolicyDocument.swift */; };
-		A83988DEADA8DCDCC052D20F16754EC6 /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CFA606A383C992A4AD2F0E0297CB568 /* VIMSoundtrack.m */; };
-		A93B5764082E991201F5E88CD6A8AB01 /* ExceptionCatcher+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FB75AF1632C64351A746EBE8143C71 /* ExceptionCatcher+Swift.swift */; };
-		A97B4234D9DE1963BCFAC21429D554A8 /* VIMVideoHLSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = D3D1305DB0B10B92F5CA211649C7F867 /* VIMVideoHLSFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA60314EC9AA305715FF49E69E60687E /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F9A4D52E090ADB6875D0781DA849D8 /* VIMAppeal.m */; };
-		AABF1D3432FAAE6051C9CDC67C383316 /* VIMVideo+VOD.h in Headers */ = {isa = PBXBuildFile; fileRef = B60BA00D92FEEAB4E64F76F7B3929F7A /* VIMVideo+VOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB518EB5625691064576968E6BCBD077 /* VIMVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 35DF3F42E2AA53C89B5CBDEE523150A5 /* VIMVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A78788A0495DABD2829651F7E6391C65 /* VIMCredit.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E43BE43C06FE63236F981EA98FDB96 /* VIMCredit.m */; };
+		A899E92FF645845235F31E2CB23488C2 /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B8BA27056712CD4A3C0F1B1E66E5A7 /* VimeoReachability.swift */; };
+		A8D2D202D4C07B7BACD6EAA2D39B2417 /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 5573FA464AE0A0FCFFD01F9295F2E398 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A8DE16E0E7CAF5A7EF82F815F000A5CC /* VIMChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = EE2A1362958BB9EA1461DD137B8AC56D /* VIMChannel.m */; };
+		AA58C040EC269B0F8A3F394FA6E3A7E5 /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 736190EDBD464ACE8CECBBD6E25B8746 /* VIMGroup.m */; };
+		AA7A509B413506DE9C44B05C3DCAC80F /* VIMVideo+VOD.h in Headers */ = {isa = PBXBuildFile; fileRef = 00A583D9AEA48462ED7025103564EC1A /* VIMVideo+VOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC3C26D63AEDAD40CE7D7E97E6E7CF79 /* Pods-VimeoNetworkingExample-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F11F4297E41B9F58A715AC2CE23200F /* Pods-VimeoNetworkingExample-tvOS-dummy.m */; };
+		ACA30D3184248FF0CF90516AFB1568C9 /* VIMUploadQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 436C8D5EC7EC30863563888B1C6A1472 /* VIMUploadQuota.m */; };
 		ACBBD3E5609FF742DB70AAC1F1DB12B7 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 839E964A6942F7C2DC01F73329271649 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ACE3093CFD280280BD8D187D62004D3A /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = CA69700735E40098B99A3BAF6585DABC /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AED1FF2D8FFD727BD1DC1D9D62889EF2 /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B0ED99B4A6356750583D3A9BF624DA7 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACEF2BEE2A6017072523A8424A25AE39 /* VIMSizeQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 01191A945E37E8EDE78E408AEC174BBF /* VIMSizeQuota.m */; };
+		AD23408F78611CDA5D63E894305DFBA3 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690975C455446102C3B73BE1B60D3FD7 /* KeychainStore.swift */; };
+		AD4AC0BF479A3097B2B6A412009425B1 /* VIMVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = E4908E6209B0874E069635BA3305A278 /* VIMVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ADEDCA7FFC59157A1F8E8D4BF8DC292D /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E0513C7DE2C022B3A44B2540BEA4332 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEA41A6D01A2AEC8C6415C70E9188E82 /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2664FAAA28B1A8A721A7E3964648C9FB /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEF621C8F1C29CDA1F6C64FCFF040193 /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C07B6C47D385D9C238370F5C13AD9BE /* VIMCategory.m */; };
+		AF044584400F136AC2802B1019690678 /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C308F741B8317EDC1D9DA106084966 /* VimeoSessionManager.swift */; };
+		AF27ABC93C5B8070FBEA54251D468223 /* VIMVideo+SVOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CEFF5FE44CD9018B27A0AE71C24D457 /* VIMVideo+SVOD.m */; };
+		AF3AD02F4DD36724B5E662B159EB3804 /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7452337F7798C98A14B2BEB8B75409 /* Request+Notifications.swift */; };
 		B01D23DE56E7B03F25C59F9CF8F9E028 /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0EC285BFAAC685CB438808A8A89D55 /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B01D31927069BA39228C29AA522CABA7 /* VIMCredit.m in Sources */ = {isa = PBXBuildFile; fileRef = D989F47CA4089C24A674C2F080D701B5 /* VIMCredit.m */; };
-		B08138657BFE04DCB7B73A0A4E4F2C43 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = E9849BB6928A5B6C987569BECB73F85D /* VIMUserBadge.m */; };
-		B0C7A40E1A0298D7A3BDAECD5432AF5F /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E4F26C178839F4809F1A26D06153A9 /* Request.swift */; };
-		B0EEA40D4E1EB8BE2BF5F624FF1A2CCB /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = CA69700735E40098B99A3BAF6585DABC /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2E35AE04E999C089CDBE8C0091D4CAA /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4317F045FE3314AEAC78685D8905E5 /* VIMVideoFile.m */; };
+		B0EA8A5832D64AF78E78963401468E52 /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B6DC63928A173B984CB141C424354D7 /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B0FA8BB638763A081212B4CA92ECE71B /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F1AF5084E99C0F4553041BE57E768059 /* VIMVODItem.m */; };
 		B3AF6D82691DF3E0E77E846C66276411 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = CEF43F8D96E8E27A17F1D6DE44F3BE4C /* UIActivityIndicatorView+AFNetworking.m */; };
-		B49190D8E31D20ACB6B9F27C9ADA6451 /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F0CECD6330DF68A6916A638FD98AB5 /* VIMRecommendation.m */; };
+		B3D6E132309F583CCDEB298A6FF48397 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE094AC51A1EB5C25F33C21CAD250647 /* ResponseCache.swift */; };
+		B402F18717AB6016348F51E2847D68BE /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = B69E8AE4E8E09DEFBF3A2BBF52787052 /* VIMRecommendation.m */; };
+		B44BE43A0C091A760504774D6551F5AF /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9F9C2F781B6DDC1E880839E796BFF5 /* VIMComment.m */; };
+		B494529798EE4A6367A49A1D6FCEFD0B /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F370F20A1F53D9EF7C866FA840F2A7 /* VIMUser.m */; };
 		B556DEE110375D71E467F607AAC97660 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C1673169E3D04DC71FFCED7531DF18 /* UIImageView+AFNetworking.m */; };
-		B58D4D6E1CC96BAD08BC807C6A2E4795 /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 534E14F2B03338A7A344281334105191 /* VIMNotification.m */; };
-		B5E46A80723B608B5E488FBD676D3727 /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D8FA677EDCA290CE81578A58D796802 /* Objc_ExceptionCatcher.m */; };
-		B5F025475C62E9285585FB45A67D20B5 /* VIMSizeQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = E19789298FED6865966EEF863826646C /* VIMSizeQuota.m */; };
-		B601CD20F42F70422635A7367BE22A79 /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE65005CFBE682C530A83C14F4149BDB /* VimeoReachability.swift */; };
-		B6511135962D026FA2D41FC3C6248233 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13AFDE4971226993D6B394BB494A1BF /* KeychainStore.swift */; };
-		B6C28E3D9192D909B47A1F2A27D97A45 /* VIMVideoFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A5CCEF03C0068F60B7C4E65E52B274 /* VIMVideoFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B65E217EF1F8BB2125A9153CAF5DA5BE /* VIMVideo+VOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BA6108B999C05BAF20B545FAAA0D26A /* VIMVideo+VOD.m */; };
+		B670217329A7B9989B747ECDDDDF4F81 /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = F35A94430D3B9BC1D0E8575FC6FD6A68 /* VIMAppeal.m */; };
 		B6C4B0EFA0D490F70AE9AA04F916A49A /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B36ADD33E9C0EBB3DBD3F8EFBDDFD940 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B70CAB4AD407CF277EB53C72073B15E8 /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 736B2CF0F0A0E1460A1987D420D301BE /* VIMPictureCollection.m */; };
-		B71CBDF592000379AF7CC7F245D237DC /* PinCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C9C1826B251AF90151E9157195F473 /* PinCodeInfo.swift */; };
+		B6EF3249BA4270C859231F0E24FAC030 /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB86906C8CB7AAC0084430ED4BC9F05 /* Request+PolicyDocument.swift */; };
 		B8000901B98D1B45B1951CDBB11C2318 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = E8632641A85F1E3BFF24373979525E28 /* AFURLRequestSerialization.m */; };
-		B91B7EFBB65A985786AD41D97E1CC4A2 /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = E6CE1860B2693ADDE6451AFD7D93C2BF /* VIMSeason.m */; };
-		B95C715F729B507EF4E64404897971CC /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 45BAA0B58A098356105F549216E19269 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B8808A2ED9F99C0CDD01F2201F436873 /* Request+Purchasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995E2A4882A91722B328223AE1907399 /* Request+Purchasing.swift */; };
+		B97F92E47A255E435F26BF1D8274D7C9 /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16296BB028B9E535A1456AFF995004E /* Request+Video.swift */; };
 		BA389B8F02B788944394EC2C1D6C05F3 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DEFE6F9B852E6B533E166938D98B2011 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAC3CA0A821A667444E71F332134263E /* VimeoNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B78AA4DA3641A1ADD28EAD3146817CE5 /* VimeoNetworking-tvOS-dummy.m */; };
-		BC649F571B043518F29C13F64E550CA9 /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 018B567BFCF88294495C99032387F716 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC3E54D748CD5770B404CB11C97F49A4 /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 5573FA464AE0A0FCFFD01F9295F2E398 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BE3514DE6585828753FD3D98F75BC0B5 /* Pods-VimeoNetworkingExample-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D89E36C92FEB6E79957F0DF9A7147DD1 /* Pods-VimeoNetworkingExample-iOS-dummy.m */; };
+		BE3D8403216071CFE1887687C823458A /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 04DE9119228F4D6A30C7C5FC2161EAD4 /* VIMVideoFile.m */; };
+		BE58DE274FC1ACBCA55703F6F34D23AC /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ECD9DB2E90D9479010A66146E935FEE /* VimeoSessionManager+Constructors.swift */; };
 		BEAA265C092C8444234FE798386AB41A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25EFC72564F7562F3ADF2AA5E03E7441 /* Security.framework */; };
+		BF342849A1A8951FFED401FF23266433 /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A19D957B49D3BD3CABBB7A1FB15AC26 /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF6D71B553EEAA23104D874B26E4FE7C /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 347BCCB07384A61A6DA9584C80B157BE /* VIMNotificationsConnection.m */; };
+		BFA6BFB26B0B13E985AFFD82C8C67736 /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 347BCCB07384A61A6DA9584C80B157BE /* VIMNotificationsConnection.m */; };
 		BFC12D720661F3BFEA2E9CF11809A356 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 197917CA70CA90B5E2744BDCDAC7B800 /* Foundation.framework */; };
-		BFF75E28F70D90045D1C1006997F21A5 /* VIMVideoPlayRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD62B04AC526CAF7F714450BD320599 /* VIMVideoPlayRepresentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C000C1219EFB19B564633205278B393C /* VIMVideoPlayRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = CDD62B04AC526CAF7F714450BD320599 /* VIMVideoPlayRepresentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C03BE8F1B0E61B5C577BB71A5F6819E0 /* PinCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C9C1826B251AF90151E9157195F473 /* PinCodeInfo.swift */; };
-		C2C8F2263389E39FFD1F71A135F0EEDA /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = 281594D3591B4C4D8504EEA3CD2AA768 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C2CA6BF49034EA9AC3F33A02F9B9CEB8 /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6154623B4613F057480E0DBFB7FF50C /* ErrorCode.swift */; };
-		C2DEDE9FE77F4C1FBA644D0D511A358C /* VIMUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 36BD749BDAAB6F8F73BD7F3CCC4CF61E /* VIMUploadTicket.m */; };
-		C35CC60ABB51CD318ED154D8A22A23C3 /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = BCFC3340D44487494021D17F1B0032D9 /* VIMInteraction.m */; };
+		C0485CBD42BFA3F43ACFDA2F84981CDC /* PinCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53568F3F8B42860E008F52E55F6FB90F /* PinCodeInfo.swift */; };
+		C102A69D1EF1FB15552FDE7727423EE0 /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB86906C8CB7AAC0084430ED4BC9F05 /* Request+PolicyDocument.swift */; };
+		C14D5688344FEFC33D324ADB3456D3D3 /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D389417470062CD360290BE2A7FF74 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3170A46191D74997616A1373C6F5EC5 /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150A41B0820E472218521E2E495FD2E7 /* SubscriptionCollection.swift */; };
+		C408CFA7BD4ACE0F27863A78A73999C8 /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C07B6C47D385D9C238370F5C13AD9BE /* VIMCategory.m */; };
 		C480A0FA0106F88F5A62E8CAB143B4CB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92181A66EF3261CA0DEB9B10D1D053F7 /* CoreGraphics.framework */; };
-		C486F3898C0C886D1AF9FA21E5F83039 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 95FDBB9E62BC08809CFDF4FB13603EFB /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C4E216A301F5D2B7C849813B5116155E /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BE7D2FA110F5E62D9B974A2F2433F1 /* ErrorCode.swift */; };
 		C4E6ED94159191F27E49BAD37FC1EAB3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 197917CA70CA90B5E2744BDCDAC7B800 /* Foundation.framework */; };
-		C6162B70D30979996AB8420A39FA71FF /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 471D33D599D075E83CF7527E467F7F1C /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C685087A2147E4DDFBFB6ADAE3E0D68C /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94F7CC0224824E9546F4B501DB03573 /* Request+Notifications.swift */; };
-		C7227FEF3F64B4122338A4F2A9FD6E63 /* VIMAppeal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E5671B2CEB95051F846F78E494E50D7 /* VIMAppeal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5468F34FC6E9F58C81994AF3516E89E /* VIMCredit.h in Headers */ = {isa = PBXBuildFile; fileRef = 74AF20740335B0044F97B0D2732847AF /* VIMCredit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C567D1A819CE1C5B880D38F1C5EE734E /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C18B361F0105107F7CD7ED3369F060B7 /* Objc_ExceptionCatcher.m */; };
+		C604C615AD5891A82A9481F6815573AB /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 43AFBB835F93D6364FAF476CF9B99817 /* VIMVideoHLSFile.m */; };
+		C624409EC98B15E29276012F8BE0C469 /* VIMGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B1D926D49D146EA24B31A59FA01AC9D /* VIMGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C65DE79FC32FD0DBC1518C6909B10C9C /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F49888AA2998709A179E549F965BDFAF /* VIMModelObject.m */; };
+		C660CC774B4DB38228C63764923129B9 /* ExceptionCatcher+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DFD9B4663434957354444113757AEB /* ExceptionCatcher+Swift.swift */; };
+		C6C08B125A87FB7D49F717766D9F8676 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE094AC51A1EB5C25F33C21CAD250647 /* ResponseCache.swift */; };
+		C71E810C647D91CF00CDFB44457BB920 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C748830CA64F6F99AEF35A159EA35B /* VIMBadge.swift */; };
 		C8283EB1E24A80E6ACF5DA3983BD20D7 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C625EB25EA7B16EDEDCA7113844B19 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C97FA1BD01FF8502006FA3B899DD7455 /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E21215A1A7453B914B49A163844FF5A2 /* VIMVODConnection.m */; };
+		C86311A709F14155020EDFDBF689DFE6 /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBD1FF411F252BAEDE0AE5DE8BF864F /* VIMVideoPlayFile.m */; };
+		C8A49BDC2BD2C131536053424CE2A57E /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04ED8340220B49DAA663FC53D924519D /* AuthenticationController.swift */; };
 		C9C55674F82F2F2CA0B0A65B65A1A088 /* Pods-VimeoNetworkingExample-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DE58CE542373B68EA97653A0A3B2E2E0 /* Pods-VimeoNetworkingExample-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB3240C21FEE3FCFC8E0BFFE7589DB52 /* VIMSizeQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 773E651333ED23356F5B6B4A2C74BF6E /* VIMSizeQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB37517595CAC423F6921ACE7211C78E /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B7210BF3175AE9477B1365623B889C /* NSError+Extensions.swift */; };
-		CB72AE92F5068EA3F4A984365DDC2B93 /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 037D6AED08466DC62BD3FAB79CEF1153 /* VIMVideoProgressiveFile.m */; };
-		CC484BEBDF1320DD3445B43AA9BA8BDB /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A11BA8F5452BE7B50EDC5D2EB708DD68 /* VIMModelObject.m */; };
-		CCB3878B8DB7468D5D35EE841EEE60DA /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B1BE9F49C799214FE09C3A414BF863F2 /* VIMVideoFairPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAD6530EA2DC2AE22C66037E9205D719 /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA854CAD12FF6A039EE1803203DC92F /* VIMVideoUtils.m */; };
+		CB693E0BC6006B8A172805DD3A995546 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DCB3176AEDC01F983620ECC07D12E3 /* AppConfiguration.swift */; };
+		CBFFEC130063C5AA7FDCA37F379872C2 /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = AF9F9C2F781B6DDC1E880839E796BFF5 /* VIMComment.m */; };
+		CC6078F2D5E91B0CE1CBA29C4978FBC5 /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = AE42D8F1DD5BCD1CD58E7CEE1EA571AE /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC62B311C4828883FF056B506D1FBE3A /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F370F20A1F53D9EF7C866FA840F2A7 /* VIMUser.m */; };
+		CC788AB866FEC293C934A720A2187C2A /* VimeoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6C3BDC1B1BAECB9607F1398C161C08 /* VimeoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD7DF9469F2EBB8AE99B74DB9BE31924 /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = BBF70D980EA19B9847F04EF52848C471 /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CDA0367DA6FD13EDB4825B2FF9267DF2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2947707C0AB4B96015ECE4CAAC4B6BAD /* Foundation.framework */; };
-		CE1A8711395FB0870EA8FAF66C29F1C5 /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = A5846E2F640947CD77BB63D0426AC635 /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CE29B83FBAF2A81E567030AA586FFFBC /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EC74ACA9F3D08C480F9F6283A0CF2A /* Spatial.swift */; };
-		D1AB00B1EEAC45A854CA9BEFBD1D4A7B /* VIMVideoHLSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = D3D1305DB0B10B92F5CA211649C7F867 /* VIMVideoHLSFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D1DDBF717F29D80B4BBBB4F2C92B66D3 /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB38341FA26EB67D0360778AB8263BB /* Request+Toggle.swift */; };
-		D28E06C251E250C089B3FF3372D7A215 /* VimeoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 48E669C24E4A5A0BA40872A681A7568F /* VimeoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D409B113E9442B1EE85D090319C4979D /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = E1297CBCCBC0690C1047F1991E1B5B40 /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDAF6041E9CC3B34E86288AB8D526D99 /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 466F66A73E061D9070D392689B346068 /* VIMObjectMapper.m */; };
+		CE3E04511A82712A10DFE475CAF5EEC8 /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = F1AF5084E99C0F4553041BE57E768059 /* VIMVODItem.m */; };
+		D1BAF681ED6CDC76A7DA7C4187C7DE03 /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDE55D4C67FCFD91DF2D54641523FE1 /* Request+Category.swift */; };
+		D29F5CC38020546CD4015E0E16ABC6F7 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = 70F18FFB1D81E5EE980E46CBD03773F6 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D39E938602E0FADB1D8E514CA1DF87F6 /* VIMCredit.m in Sources */ = {isa = PBXBuildFile; fileRef = 32E43BE43C06FE63236F981EA98FDB96 /* VIMCredit.m */; };
+		D4857FF5854D312DC38C07533F828CC9 /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 586604445A393AD884FD7F6DE0B33773 /* VIMVODConnection.m */; };
+		D542089ADB0B22AF6C79AD8E4575B2EB /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 3071D58C5C91FF7CDCBFEC7BE4CFE200 /* VIMConnection.m */; };
 		D66595AF0806BBD184B35D4784FD633F /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9C6788456E3C6CB1F9496329863213F /* AFNetworking.framework */; };
-		D6A5989AF85BF0F0346FE8BAAF94B8E2 /* AFNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B45352B75935A1039A3343B2CA62C4E3 /* AFNetworking-tvOS-dummy.m */; };
+		D6A5989AF85BF0F0346FE8BAAF94B8E2 /* AFNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6259AB2BD4828E47BBDE327788AC3F48 /* AFNetworking-tvOS-dummy.m */; };
 		D6D32B19824842A2D8AD39CD22BFA2DF /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C625EB25EA7B16EDEDCA7113844B19 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D833DDC5DBFEA3CB360E564E4B487111 /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F47636C468189B8FE0647F6112D5464 /* VIMQuantityQuota.m */; };
-		D8CCE8DE7BA9756C7EC54CD77FE04BA4 /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB38341FA26EB67D0360778AB8263BB /* Request+Toggle.swift */; };
-		D9B3C4268A0DE915980F7E4A27B9E949 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FB7F79E9CBCC5B81B00434F8F8FA1C /* Constants.swift */; };
-		DC26B35D135A0918C05958134223ED87 /* VIMComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 179C54BB1ED2F615E881E6B6F085FA8D /* VIMComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DC4EF5BC6145725173627B8676111C0E /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E50806D5A1AC489DED566E2B0753E7 /* Subscription.swift */; };
+		D7E7A1FEFBEC43602F4EBB393EE9BBD1 /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = C4A170AE2F7C9BA8AC627713514A2F68 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8849F8CCB0FE22D8A97E04455356E82 /* VIMObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 96AB198755E9562EB7B876CB0F0774CE /* VIMObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8C8766A46EFE16B07589D9CB05090BE /* VIMAppeal.h in Headers */ = {isa = PBXBuildFile; fileRef = 93FABF6EB294DF08E450BF31F8B6C32C /* VIMAppeal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D90A4E363C9A6E6CC9203C0C53D9E0DE /* VIMComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 78430A2F58C85F8471B830042D3A9DE6 /* VIMComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9A152488EA121DABF605337B3216B13 /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = BBF70D980EA19B9847F04EF52848C471 /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9C08C1F997787C073D5F671A41229F7 /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E0D09E3E6932A763A908776E806721 /* String+Parameters.swift */; };
+		DB7DB6C28957ABCC1103C650EA7A03FC /* VIMPictureCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = C946B4B13BD1FC7135CED9E3639BD3E6 /* VIMPictureCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB8D5964D071A54B1D73C1A3FE5B79F2 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BEE65EABAF41C071B0A356203532E4 /* Result.swift */; };
+		DBBF767DEDC946F8AC1055B1A7CC9B15 /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523151A937F41DC5B653894FDB9D448D /* Request+Configs.swift */; };
+		DBCE9BFAEB06DADB0E529833E6273658 /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB9221DABD0055F8247E5D435332EED /* VIMVideoDRMFiles.m */; };
 		DC9084AC3A8E734456A646DD4E6579D4 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C824D3CBB8350B498A8E16265B0BE7 /* AFHTTPSessionManager.m */; };
-		DD62436125756BB4BF0C7638953E6BC3 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13AFDE4971226993D6B394BB494A1BF /* KeychainStore.swift */; };
-		DE450C40B04A7D4B1EA505BA7D2E8081 /* VIMAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FEE4B5B94BDCC7698C47FA8B8F1F676 /* VIMAccount.m */; };
+		DE2E101BE6E02092E3852E9E5FA27EAE /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A20FB839C88BC5EC47ACE75A5107905 /* AccountStore.swift */; };
 		DE87DB98E21C1323433151D0EB1872A0 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA13BE76C146E8F26A0C1B2A1824A07 /* SystemConfiguration.framework */; };
-		DEAC1924A02E4F14DAA78231D503419A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FB7F79E9CBCC5B81B00434F8F8FA1C /* Constants.swift */; };
-		DFB308FCD8896A53DE485EB962D66B25 /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = B4E985479470294B3B4F3403C0D3B565 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E03638779639ED6E81D96E6BABB6152A /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D09E94BEF337DFC92D742834825936 /* VimeoResponseSerializer.swift */; };
-		E0A4618A17DF9FFAF36B3C1503E487D6 /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B5311892B58BCB246FCA8017CE6BA94 /* VIMVideoPlayRepresentation.m */; };
-		E1238B29910205070D736EE3D713BCFB /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = B31B2C5A0269172047F18AD00F5AC373 /* VIMVideoPreference.m */; };
+		E073608831BF049AC622540E3A85984D /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 586604445A393AD884FD7F6DE0B33773 /* VIMVODConnection.m */; };
 		E134799D9CCFEBDA1665156F3525C3D4 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BB188794E997CD5840FBBAFC4196F89C /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E15505BDBDB14C308FE87E7596015A4B /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 051C78B450DB6DC089554A98C52169DA /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E4D9A13CEB074630927BDC6894F264EE /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = F124A50F309625B2C3F86D1520F14A49 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E61DD78C2BE9792592BCE0BC197DDC56 /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C952C24463AAB0C85837069ED51E33 /* VIMObjectMapper+Generic.swift */; };
+		E30F51998DC9368FEDB88B2BD022508B /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B8BA27056712CD4A3C0F1B1E66E5A7 /* VimeoReachability.swift */; };
+		E3D2959B6447A8EDBB3D339E965B2E70 /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584F81421BAA557AF945BBA1D8D9AB6C /* VimeoClient.swift */; };
+		E419A0371CA6150772C77EE1CF64F9AC /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150A41B0820E472218521E2E495FD2E7 /* SubscriptionCollection.swift */; };
+		E43B9D0A70B0BB3547EB57B2474EC200 /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 383610F11263F07C8D784A9F10AD42A3 /* PlayProgress.swift */; };
+		E5E3AE0B2F1FF86FA5D1202651EA965F /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BE7D2FA110F5E62D9B974A2F2433F1 /* ErrorCode.swift */; };
 		E66EC1E6F61060BBE56B2F27E0FDD06C /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A4DB82CC4E649E3A3DB2B5F421C069 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E742710537CED7F7EFFEEBC9A1701ACF /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3594508BA6BE964CCC7EA7ACE831F4 /* VIMCategory.m */; };
-		E78817B2FCA75D0553F7FCA25507C05F /* VIMVideoFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A5CCEF03C0068F60B7C4E65E52B274 /* VIMVideoFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E78D0700D94D83F9066502E380DAFCE0 /* VIMNotificationsConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 36EEBE5D0E88C1F7A926DF06AFEAD7D3 /* VIMNotificationsConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E80D774238007901F37560BC452AF2BC /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E50806D5A1AC489DED566E2B0753E7 /* Subscription.swift */; };
-		E8889C98EE609F6A7138C39E74F5C687 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E8E2F400FB9E6F12109D8FA3D0E5E2B /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E90973CE9DD7CFF7689D914655115C93 /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 461A2F51AD0136F4FBB09E77CDDF0519 /* VIMGroup.m */; };
-		E998128ED93545DC18A05AD6DB1D6CDE /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = 17664F34992B004CE69FDFFDC5A3196B /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7E861D127FA5ED1673C71DD85EAC591 /* Request+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1C6442502277D255EF0D73ED43EFBC /* Request+User.swift */; };
+		E81C76ECA26C42F8F9BB680B129158A8 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D4B5215801D2D5C63CCDF0419672E78 /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E88834A3CF8AE64C89C5FC2BAC3E0E9C /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C48F19556B7A419C08AD20108343A2 /* Scope.swift */; };
+		E8F765EA4CAFA7ACB19FFA30556CB88B /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B4D21E54F7C54C3216761425A04A66 /* Request+Soundtrack.swift */; };
+		EA41C7DA7E5A6BCEB01FA60C7DC4793A /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776387159FB71B2AFDD480EC17E9C7A4 /* Request+ProgrammedContent.swift */; };
 		EB6ACED989A2BE453D1D254B34E7D0DF /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E8145278825D2B77107418074D1494 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ECA25636CA551896177B9E9489A09399 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = BD0E3E063250CDEE712CB6FED2FA284E /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECEA6C84DB129376569EC89B555CC437 /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4635386CED75377DB6612716F497B /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ED1B03FC1F0E5FE0EA76EBA9D0817C90 /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2706D82A1741A66D809C2297C6CB56 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EE98D11C9D7F5313D0FBEE74D03A1185 /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EC74ACA9F3D08C480F9F6283A0CF2A /* Spatial.swift */; };
-		EEC61ED199D1840BDFE39B1DEB215C6F /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 018B567BFCF88294495C99032387F716 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF01D047ABFD34F4378A7BAC7D209410 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669BE8F834243C35434C4FB5ED83D6DF /* Response.swift */; };
-		EF54F90FAEAF820269C1E932A8D8D185 /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = 80C5471E78D64BF02F17B063DBA3F77C /* VIMVideoDRMFiles.m */; };
+		ED55C6DDB30EF9B937BE3A1C83045058 /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = E4D4A1BB8E751CC6AD00D5E512C8E0AD /* VIMQuantityQuota.m */; };
+		ED5BB5B55CC9684839A61CECC262311A /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD40B1BB905107488280C57B0EA65FC6 /* NSError+Extensions.swift */; };
+		EE9BFE4D612B0EF2A0A484F5DAE35643 /* VIMNotificationsConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A1C2B241368B5431C8350C437E5C4C37 /* VIMNotificationsConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF2404EDC083DA329102FFEA0F2427CB /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F3D2845CDF2659A23B03641F8A66C1 /* Spatial.swift */; };
 		EF71A0066AA04CF35163C9C001F6E9C5 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EFAA64EDB405E880BEC5AF34EF8AE334 /* AFNetworkActivityIndicatorManager.m */; };
+		EFA1157E9B8C08C6193D8D2361400843 /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = F35A94430D3B9BC1D0E8575FC6FD6A68 /* VIMAppeal.m */; };
 		EFF77DF9B056320A0AB07C001EE9AEE2 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = CEF43F8D96E8E27A17F1D6DE44F3BE4C /* UIActivityIndicatorView+AFNetworking.m */; };
-		F1173E7026E8AE2B280DD9511E6B1689 /* VIMVideoPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = B05862F2CFC1FC063F0681CF0AED0205 /* VIMVideoPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1C1EAA6C7C94D49A0082D6B0FD2B1CC /* VIMVODItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 734BC714BD7883E229A749D5FCD959BD /* VIMVODItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F47412D3769D21E5F845607454B76108 /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = F1DE65342B0FE267B3D2E83243AE4EB2 /* VIMPolicyDocument.m */; };
-		F564FCEA964A0C89B96AFF7DE5553002 /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = A5846E2F640947CD77BB63D0426AC635 /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F5E4110001AF7F5A92907BA40AB487DE /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684CAAA7E1F06FFB876478090C3C8DD3 /* Request+ProgrammedContent.swift */; };
+		F0304524C51108ECFF0CFC8BC5E67201 /* VIMPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = F6E293EF1A0B5647FA0964FC336CDD7F /* VIMPicture.m */; };
+		F256CE84F45C161960C84EE6FE032171 /* VIMVideo+SVOD.h in Headers */ = {isa = PBXBuildFile; fileRef = D626EFF0C0BE215902014B2985EB2D54 /* VIMVideo+SVOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3456F97563F696719D1042E42C728E2 /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11514B79FCE3AA78352293D67C56CCFC /* Request+Toggle.swift */; };
+		F3934A6D54B97CC5066CDB0E6CE495D5 /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4307A32427BDE785689408CDF1FFB4 /* VimeoResponseSerializer.swift */; };
+		F3CCC66FC75B9BA44FCFC278C8E3A167 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 52AE2B99F1B20F4EB550846F1E35CE66 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F56E9CB98F24BB0C6B814FB75AFCF987 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D8EADD112B72372D01930045B40D07 /* Constants.swift */; };
 		F66DDED380965CD4C3DFFEFB00139AB1 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EFAA64EDB405E880BEC5AF34EF8AE334 /* AFNetworkActivityIndicatorManager.m */; };
-		F6BB5D7A7C569953E236938A8525B306 /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D8FA677EDCA290CE81578A58D796802 /* Objc_ExceptionCatcher.m */; };
-		F843EA39AF1F66F168112A3C5C6280DF /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B7210BF3175AE9477B1365623B889C /* NSError+Extensions.swift */; };
-		F94AA75025B14E2EF2786566701DFC3C /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E671C023C7983DC6DEFF18A3ECE49C /* Scope.swift */; };
-		F982426A719895E299E753E07E63E416 /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A11BA8F5452BE7B50EDC5D2EB708DD68 /* VIMModelObject.m */; };
-		FAC2E673E46BF682E4E01C2D45327F81 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = E9849BB6928A5B6C987569BECB73F85D /* VIMUserBadge.m */; };
-		FB0A40E6838E63050E8ABDF9C941A4FF /* VIMAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FEE4B5B94BDCC7698C47FA8B8F1F676 /* VIMAccount.m */; };
-		FB1725656EBF9072D99E14E52B2D959D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1410805711F5C3B8C5349F7A54B879 /* Result.swift */; };
-		FB449A9A92A00880703C67B0EAA09455 /* Request+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8176C5051EFDE888C571B411FFC422D /* Request+User.swift */; };
-		FB95F38D9289F9A11D24428B362BC9FC /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE6546E0C59DB3C0BAA64D0C2EA01A6 /* Request+Configs.swift */; };
-		FBAA0FF3E3B25AFA51A5D06756BFEE0C /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 26B92B499A5D5B2A31470AFDFA787984 /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FC2DAF48659FA83C97B30DB9A7F57169 /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = A46E9E13DF7CF574AE8BE912A1937CBA /* VIMVODItem.m */; };
-		FDDEB11EEFD470FE8F04BC188B48A202 /* VimeoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 48E669C24E4A5A0BA40872A681A7568F /* VimeoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8C3C4F239C59B6C53388A512D0F9EA3 /* VIMAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 994B41DA9BA49B07FADDF4A326863DE6 /* VIMAccount.m */; };
+		FB7E8849EA81EE3357C33D687B8F3216 /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 04CE692A4643EC075830B8A8D2EC0892 /* VIMVideo.m */; };
+		FBA12830D8CF7CCF13B9C2CD44917448 /* VimeoNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 211708A14F8B6B0F638C9B9008F65EE3 /* VimeoNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD789926F5067CFAEF5199829D7AD0A5 /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776387159FB71B2AFDD480EC17E9C7A4 /* Request+ProgrammedContent.swift */; };
+		FF7B05BB285B84507BFA114FEC22157E /* VIMVideoPlayRepresentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F9948C38E0266C1BA795F936FD748AB /* VIMVideoPlayRepresentation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -435,262 +441,265 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00FB7F79E9CBCC5B81B00434F8F8FA1C /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		0106797BAE2ED118E6D8122C481FC9F9 /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		018B567BFCF88294495C99032387F716 /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
-		01E7FC57F3D5796FAD0A58C0F557C64F /* AFNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "AFNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
+		00A583D9AEA48462ED7025103564EC1A /* VIMVideo+VOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+VOD.h"; sourceTree = "<group>"; };
+		00E0D09E3E6932A763A908776E806721 /* String+Parameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Parameters.swift"; sourceTree = "<group>"; };
+		01191A945E37E8EDE78E408AEC174BBF /* VIMSizeQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSizeQuota.m; sourceTree = "<group>"; };
+		01C748830CA64F6F99AEF35A159EA35B /* VIMBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMBadge.swift; sourceTree = "<group>"; };
 		02EEBCBA39BF1BEF3DD81313C3531B7E /* Pods-VimeoNetworkingExample-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		037D6AED08466DC62BD3FAB79CEF1153 /* VIMVideoProgressiveFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoProgressiveFile.m; sourceTree = "<group>"; };
 		042A843F834375AB7A2344563BA0B741 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		04CE692A4643EC075830B8A8D2EC0892 /* VIMVideo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideo.m; sourceTree = "<group>"; };
+		04DE9119228F4D6A30C7C5FC2161EAD4 /* VIMVideoFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFile.m; sourceTree = "<group>"; };
+		04ED8340220B49DAA663FC53D924519D /* AuthenticationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthenticationController.swift; sourceTree = "<group>"; };
 		051C78B450DB6DC089554A98C52169DA /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
 		05A4DB82CC4E649E3A3DB2B5F421C069 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
 		0759D1F589032598A86DE58EBAEE3C3C /* Pods-VimeoNetworkingExample-tvOSTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-VimeoNetworkingExample-tvOSTests.modulemap"; sourceTree = "<group>"; };
 		07E5575BBC8C7295ACA3404520CA527C /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
-		0802A3F20A40169F2385826DC8492AA9 /* Request+Trigger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Trigger.swift"; sourceTree = "<group>"; };
-		08355F852018C46FA265697C2DC149C9 /* VIMUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUser.h; sourceTree = "<group>"; };
-		08CC97AFCA85D85BCF5C92FDF30A3E5B /* VimeoNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
-		09203B0DF735A1912AA153068A050CAF /* VIMPolicyDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPolicyDocument.h; sourceTree = "<group>"; };
-		0B1DF9AB6F331C77CA71DD6B7E255D9E /* Request+Picture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Picture.swift"; sourceTree = "<group>"; };
-		0B5311892B58BCB246FCA8017CE6BA94 /* VIMVideoPlayRepresentation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayRepresentation.m; sourceTree = "<group>"; };
-		0E3A58D5510DD7F3F27CF8589C49D193 /* AFNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-prefix.pch"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
-		0ED07A77DE93F9B9E08DDDC75F3EC773 /* VIMVideo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideo.m; sourceTree = "<group>"; };
+		09404CBEC79FC3224ACB8B06C8D89282 /* VIMSeason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSeason.m; sourceTree = "<group>"; };
+		0C07B6C47D385D9C238370F5C13AD9BE /* VIMCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCategory.m; sourceTree = "<group>"; };
+		0EA854CAD12FF6A039EE1803203DC92F /* VIMVideoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoUtils.m; sourceTree = "<group>"; };
 		0F11F4297E41B9F58A715AC2CE23200F /* Pods-VimeoNetworkingExample-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-tvOS-dummy.m"; sourceTree = "<group>"; };
-		0FA584B5334FB72FEC2DD0A6CAF29167 /* VIMConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMConnection.m; sourceTree = "<group>"; };
-		10C9C351A7E075F52C531993712EE452 /* AFNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "AFNetworking-tvOS.xcconfig"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
+		0FFF03E2945BFCB7DDFF8DD8D8B46E44 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1007E89CB1BA9CEE28AC124F4ACB44D5 /* VIMPolicyDocument.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPolicyDocument.m; sourceTree = "<group>"; };
+		11514B79FCE3AA78352293D67C56CCFC /* Request+Toggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Toggle.swift"; sourceTree = "<group>"; };
 		11C824D3CBB8350B498A8E16265B0BE7 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		124229104F1F5A171DD89D457BFD65E4 /* VIMVideoHLSFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoHLSFile.m; sourceTree = "<group>"; };
-		12E4F26C178839F4809F1A26D06153A9 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		1309CB98D2B0E4D5A1581913EB681AD3 /* VIMGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMGroup.h; sourceTree = "<group>"; };
+		131C00E5DAC05AB4DF652C33062FFC35 /* VIMQuantityQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMQuantityQuota.h; sourceTree = "<group>"; };
+		13D39574532297EB9CBA2F2A62390B6F /* AFNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
+		1456E82583F2E91622BF0C4CB24D8282 /* VIMSoundtrack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSoundtrack.h; sourceTree = "<group>"; };
+		14BE0669B4AB8716AC03D24A4CD39075 /* AFNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "AFNetworking-iOS.modulemap"; sourceTree = "<group>"; };
 		14C625EB25EA7B16EDEDCA7113844B19 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
-		1589730830A01A361F90E6967F2D67DB /* VimeoRequestSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoRequestSerializer.swift; sourceTree = "<group>"; };
-		15BF26706675BBA43BAC1E9F20B3C91B /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		150A41B0820E472218521E2E495FD2E7 /* SubscriptionCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionCollection.swift; sourceTree = "<group>"; };
+		1556C19F01E93C6B9B4911FC49EC4C49 /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
 		1609B8B4D14EA62B4782C3A0AC84158F /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		17664F34992B004CE69FDFFDC5A3196B /* VIMAccount.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMAccount.h; sourceTree = "<group>"; };
-		179C54BB1ED2F615E881E6B6F085FA8D /* VIMComment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMComment.h; sourceTree = "<group>"; };
+		17F3D2845CDF2659A23B03641F8A66C1 /* Spatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Spatial.swift; sourceTree = "<group>"; };
 		197917CA70CA90B5E2744BDCDAC7B800 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		1D743FD5CB60F7013F8A1B7F336B8165 /* VIMRecommendation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMRecommendation.h; sourceTree = "<group>"; };
-		1D8FA677EDCA290CE81578A58D796802 /* Objc_ExceptionCatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Objc_ExceptionCatcher.m; sourceTree = "<group>"; };
+		1A20FB839C88BC5EC47ACE75A5107905 /* AccountStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStore.swift; sourceTree = "<group>"; };
+		1C1C6442502277D255EF0D73ED43EFBC /* Request+User.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+User.swift"; sourceTree = "<group>"; };
 		1DBEB18A15583E8DDD54F51081B45E91 /* Pods-VimeoNetworkingExample-iOSTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-iOSTests-acknowledgements.plist"; sourceTree = "<group>"; };
+		1ECD9DB2E90D9479010A66146E935FEE /* VimeoSessionManager+Constructors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VimeoSessionManager+Constructors.swift"; sourceTree = "<group>"; };
+		1F9948C38E0266C1BA795F936FD748AB /* VIMVideoPlayRepresentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayRepresentation.h; sourceTree = "<group>"; };
+		211708A14F8B6B0F638C9B9008F65EE3 /* VimeoNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-umbrella.h"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		245B7DC7C32AA325A5053F1C3FA576FE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		25AD679486A4AC3BE6AC694E2120F19E /* VIMActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMActivity.m; sourceTree = "<group>"; };
 		25EFC72564F7562F3ADF2AA5E03E7441 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		26B92B499A5D5B2A31470AFDFA787984 /* Objc_ExceptionCatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Objc_ExceptionCatcher.h; sourceTree = "<group>"; };
-		281594D3591B4C4D8504EEA3CD2AA768 /* VIMUserBadge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUserBadge.h; sourceTree = "<group>"; };
-		292E0C05CA34891FE8E831B2E808809E /* VIMProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMProgrammedContent.swift; sourceTree = "<group>"; };
+		2664FAAA28B1A8A721A7E3964648C9FB /* Objc_ExceptionCatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Objc_ExceptionCatcher.h; sourceTree = "<group>"; };
 		2947707C0AB4B96015ECE4CAAC4B6BAD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		2B0ED99B4A6356750583D3A9BF624DA7 /* VIMModelObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMModelObject.h; sourceTree = "<group>"; };
-		2E8E2F400FB9E6F12109D8FA3D0E5E2B /* VIMVODConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODConnection.h; sourceTree = "<group>"; };
-		2EFF11167575460C49AB2C032A29B65C /* VIMBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMBadge.swift; sourceTree = "<group>"; };
-		30C952C24463AAB0C85837069ED51E33 /* VIMObjectMapper+Generic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VIMObjectMapper+Generic.swift"; sourceTree = "<group>"; };
+		2E05FC37D99D9236704387733255F601 /* VIMNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotification.m; sourceTree = "<group>"; };
+		2F655D6685258FAA14B2C835CE892B04 /* AFNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
+		3071D58C5C91FF7CDCBFEC7BE4CFE200 /* VIMConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMConnection.m; sourceTree = "<group>"; };
 		30CF99E42103F16F5145ED3A9AF1A266 /* Pods-VimeoNetworkingExample-iOSTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOSTests-resources.sh"; sourceTree = "<group>"; };
-		339121042BB79912B92A5DBE8757F7C2 /* VIMUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUser.m; sourceTree = "<group>"; };
-		35DF3F42E2AA53C89B5CBDEE523150A5 /* VIMVideo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideo.h; sourceTree = "<group>"; };
-		36BD749BDAAB6F8F73BD7F3CCC4CF61E /* VIMUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUploadTicket.m; sourceTree = "<group>"; };
-		36EEBE5D0E88C1F7A926DF06AFEAD7D3 /* VIMNotificationsConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotificationsConnection.h; sourceTree = "<group>"; };
+		32E43BE43C06FE63236F981EA98FDB96 /* VIMCredit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCredit.m; sourceTree = "<group>"; };
+		333E74E9D12E8587F8596072434B2DC2 /* VimeoNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VimeoNetworking-tvOS-dummy.m"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
+		3393CCCD8B9E11861D5344277458C2B3 /* VIMPolicyDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPolicyDocument.h; sourceTree = "<group>"; };
+		341F9599E9BB9B067C861D9E6C78CEC7 /* VIMSoundtrack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSoundtrack.m; sourceTree = "<group>"; };
+		347BCCB07384A61A6DA9584C80B157BE /* VIMNotificationsConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotificationsConnection.m; sourceTree = "<group>"; };
 		3749586BDE8BE50A4362D8485C27C73D /* Pods-VimeoNetworkingExample-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOS-resources.sh"; sourceTree = "<group>"; };
-		3A375AEE2A37C0735E690CA1AC8A685C /* Notification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
-		3BEF7D1145F3EC76C4FEA0953E8419AD /* VimeoNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-prefix.pch"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
-		3C16A19E3DAB489CC04BFF254CD26AFC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3C18388A3250EC4C760D7512A99A466B /* VIMVideoPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayFile.m; sourceTree = "<group>"; };
+		383610F11263F07C8D784A9F10AD42A3 /* PlayProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlayProgress.swift; sourceTree = "<group>"; };
+		38AAF65A396A42208A8655BC9D7F529A /* VIMVideoProgressiveFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoProgressiveFile.m; sourceTree = "<group>"; };
+		3B6DC63928A173B984CB141C424354D7 /* VIMTag.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTag.h; sourceTree = "<group>"; };
+		3BC28F4BBBD260F1FD163C117165AB6E /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
+		3BF2D208C4CC086A891F12E4C15EBFF2 /* Mappable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mappable.swift; sourceTree = "<group>"; };
+		3D4B5215801D2D5C63CCDF0419672E78 /* VIMUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUser.h; sourceTree = "<group>"; };
+		3E0513C7DE2C022B3A44B2540BEA4332 /* VIMChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMChannel.h; sourceTree = "<group>"; };
+		3E7452337F7798C98A14B2BEB8B75409 /* Request+Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Notifications.swift"; sourceTree = "<group>"; };
 		3FA13BE76C146E8F26A0C1B2A1824A07 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		407935CE5045694FB2B03BA39E13ED03 /* Pods-VimeoNetworkingExample-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOS-frameworks.sh"; sourceTree = "<group>"; };
-		40E50806D5A1AC489DED566E2B0753E7 /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
-		4268200039AFCC987F67F25FDB3145F9 /* VIMPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPreference.m; sourceTree = "<group>"; };
-		45BAA0B58A098356105F549216E19269 /* VIMNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotification.h; sourceTree = "<group>"; };
-		461A2F51AD0136F4FBB09E77CDDF0519 /* VIMGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMGroup.m; sourceTree = "<group>"; };
+		436C8D5EC7EC30863563888B1C6A1472 /* VIMUploadQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUploadQuota.m; sourceTree = "<group>"; };
+		43AFBB835F93D6364FAF476CF9B99817 /* VIMVideoHLSFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoHLSFile.m; sourceTree = "<group>"; };
+		46302053FFBE4A1DE028AACC0E3FFAD6 /* VIMSizeQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSizeQuota.h; sourceTree = "<group>"; };
+		466F66A73E061D9070D392689B346068 /* VIMObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMObjectMapper.m; sourceTree = "<group>"; };
 		470C50E5EE000BE0F536D896BCB8BEFC /* Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		471D33D599D075E83CF7527E467F7F1C /* VIMQuantityQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMQuantityQuota.h; sourceTree = "<group>"; };
 		473D7E9AAA642355C084D5D5A7B7CF40 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
-		48E669C24E4A5A0BA40872A681A7568F /* VimeoNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VimeoNetworking.h; sourceTree = "<group>"; };
+		47AD238FFE71102DE91076A285FEC92D /* AFNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "AFNetworking-tvOS.xcconfig"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
+		48511DC8610B847616DBF17962816670 /* VIMThumbnailUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMThumbnailUploadTicket.m; sourceTree = "<group>"; };
+		48B8BA27056712CD4A3C0F1B1E66E5A7 /* VimeoReachability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoReachability.swift; sourceTree = "<group>"; };
+		4C31C2D32930DBB30C817C1D604355C1 /* VIMVideoPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPreference.h; sourceTree = "<group>"; };
+		4C63C59D1B22CBA5630ABA097BBFC83F /* VimeoNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "VimeoNetworking-iOS.modulemap"; sourceTree = "<group>"; };
+		4CB86906C8CB7AAC0084430ED4BC9F05 /* Request+PolicyDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+PolicyDocument.swift"; sourceTree = "<group>"; };
+		4CB9221DABD0055F8247E5D435332EED /* VIMVideoDRMFiles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDRMFiles.m; sourceTree = "<group>"; };
 		4CE7BA32ADED23C7C5F3EB5779963319 /* Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4CFA606A383C992A4AD2F0E0297CB568 /* VIMSoundtrack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSoundtrack.m; sourceTree = "<group>"; };
-		4E4202A8073C443FB9D8BD532B4A7BC5 /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DDCCFCA74DCB70FC8304247A43E7A5C /* NSURLSessionConfiguration+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURLSessionConfiguration+Extensions.swift"; sourceTree = "<group>"; };
 		4F2055B085CBA6061EBDB466203383F0 /* Pods-VimeoNetworkingExample-tvOSTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOSTests-frameworks.sh"; sourceTree = "<group>"; };
-		4F34FEADA1EA0CF060F7EBD86CA8204C /* Request+Soundtrack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Soundtrack.swift"; sourceTree = "<group>"; };
 		4FEA2176BCBF0B053CA62178B6E8BE31 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-tvOS-umbrella.h"; sourceTree = "<group>"; };
-		50A0AA5B2D4E05972B4F2ACD8A14D6B9 /* VIMUploadQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUploadQuota.m; sourceTree = "<group>"; };
-		51406E890E759FA65CED3449833C35E5 /* VIMThumbnailUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMThumbnailUploadTicket.m; sourceTree = "<group>"; };
-		517155516D8B9E4AC1FF2AD324D8F03D /* VIMMappable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMMappable.h; sourceTree = "<group>"; };
-		534E14F2B03338A7A344281334105191 /* VIMNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotification.m; sourceTree = "<group>"; };
-		54F45BAC7FFA5FCFA7AFACF9AB1D0F12 /* NSURLSessionConfiguration+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSURLSessionConfiguration+Extensions.swift"; sourceTree = "<group>"; };
-		5500F221D922DA37348F1AA7E091F17E /* VIMUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadTicket.h; sourceTree = "<group>"; };
-		5538B95260F5A16330F27CC496C0E64B /* Request+Channel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Channel.swift"; sourceTree = "<group>"; };
-		564E30C21468FA8DACA24A8E768A2C3B /* VIMComment.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMComment.m; sourceTree = "<group>"; };
+		50BEE65EABAF41C071B0A356203532E4 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		523151A937F41DC5B653894FDB9D448D /* Request+Configs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Configs.swift"; sourceTree = "<group>"; };
+		52AE2B99F1B20F4EB550846F1E35CE66 /* VIMVideoDASHFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDASHFile.h; sourceTree = "<group>"; };
+		53568F3F8B42860E008F52E55F6FB90F /* PinCodeInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PinCodeInfo.swift; sourceTree = "<group>"; };
+		5573FA464AE0A0FCFFD01F9295F2E398 /* VIMThumbnailUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMThumbnailUploadTicket.h; sourceTree = "<group>"; };
+		55A341CD7CF9827C5AC2227A045BBC91 /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
 		56C397664C4ACDEA5C3543FFFF98C440 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		584F81421BAA557AF945BBA1D8D9AB6C /* VimeoClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoClient.swift; sourceTree = "<group>"; };
+		586604445A393AD884FD7F6DE0B33773 /* VIMVODConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODConnection.m; sourceTree = "<group>"; };
+		5A2A35780B8623B82634E47027FFED61 /* VIMPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPreference.h; sourceTree = "<group>"; };
+		5B140EF76317A6BC8E805C42E8D7C32A /* VIMVideoHLSFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoHLSFile.h; sourceTree = "<group>"; };
+		5B1D926D49D146EA24B31A59FA01AC9D /* VIMGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMGroup.h; sourceTree = "<group>"; };
+		5BDE55D4C67FCFD91DF2D54641523FE1 /* Request+Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Category.swift"; sourceTree = "<group>"; };
 		5CB0DBE67EE0E5DBCC57752F1FAF702E /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
-		5EF23B1E2D740197B2808DB8BAD1E680 /* VimeoNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VimeoNetworking-tvOS.xcconfig"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
+		5F562F610CF6498DF3ACC32CA8B717A3 /* VIMUserBadge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUserBadge.m; sourceTree = "<group>"; };
 		5FC1C7CCCD8E4917FA797C889FC9A9CD /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
-		61199E51D666ABD1754E7146E219AEFE /* VIMPrivacy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPrivacy.h; sourceTree = "<group>"; };
-		627D6A4C038285A0976237937BDF0752 /* VIMVideoUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoUtils.h; sourceTree = "<group>"; };
+		6259AB2BD4828E47BBDE327788AC3F48 /* AFNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AFNetworking-tvOS-dummy.m"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
+		62A5F7B9659356AA141A193B05FE7FDC /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		6382A439939118026F6A5383D18BF5AC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../VimeoNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
+		6394F7D67FC3782A07ACFCE8E622E768 /* Request+Channel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Channel.swift"; sourceTree = "<group>"; };
 		656FBEC4C6308C4F5F0873C5E6B787F4 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
-		669BE8F834243C35434C4FB5ED83D6DF /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
-		66F9A4D52E090ADB6875D0781DA849D8 /* VIMAppeal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAppeal.m; sourceTree = "<group>"; };
 		67BBFCD72D381FBD52E17B6B00433608 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
-		684CAAA7E1F06FFB876478090C3C8DD3 /* Request+ProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+ProgrammedContent.swift"; sourceTree = "<group>"; };
-		69BE65117389447A238073067BF67BB8 /* PlayProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlayProgress.swift; sourceTree = "<group>"; };
-		69F5994649FBA3A14B23B23D3FCA85A2 /* VimeoClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoClient.swift; sourceTree = "<group>"; };
-		6A9C4FDB9A3DDA23335A7D6032EFED9F /* AFNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "AFNetworking-iOS.modulemap"; sourceTree = "<group>"; };
+		67F42C82756B35668B825044435C6698 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		690975C455446102C3B73BE1B60D3FD7 /* KeychainStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
+		6909CDE156096B54AD70B70F2A1ED784 /* Request+Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Authentication.swift"; sourceTree = "<group>"; };
+		69C308F741B8317EDC1D9DA106084966 /* VimeoSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoSessionManager.swift; sourceTree = "<group>"; };
 		6C1846EF380E8486B4A1F6C9AC4C8A1E /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
-		6E2706D82A1741A66D809C2297C6CB56 /* VIMInteraction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMInteraction.h; sourceTree = "<group>"; };
-		6E298AAB2BEC7F6549699CECD0035E11 /* VIMActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMActivity.h; sourceTree = "<group>"; };
-		6F058A9C6F09801FADC5C803AA4CC25E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../VimeoNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
+		6CEFF5FE44CD9018B27A0AE71C24D457 /* VIMVideo+SVOD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VIMVideo+SVOD.m"; sourceTree = "<group>"; };
+		6CF722C1ECE5F7A8B7D42C4D9A3B1DA1 /* VimeoNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VimeoNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
+		6E677F784833BF969753B402CD57F22C /* VIMPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPreference.m; sourceTree = "<group>"; };
 		6F85721083E51F60E38313582585534E /* Pods-VimeoNetworkingExample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		700303B0A4E880011AFA42F555F78B6D /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
-		7011A73F3E0BF3B5467B0308C532EC85 /* ResponseCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseCache.swift; sourceTree = "<group>"; };
-		70DBC77E4281BD8A9FCF17C27BC6645D /* VimeoSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoSessionManager.swift; sourceTree = "<group>"; };
-		71EBA73783D5283183880498238D59B1 /* AFNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
+		70F18FFB1D81E5EE980E46CBD03773F6 /* VIMSeason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSeason.h; sourceTree = "<group>"; };
+		71F370F20A1F53D9EF7C866FA840F2A7 /* VIMUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUser.m; sourceTree = "<group>"; };
+		72011EB002491733A4DDC5E1D15191D2 /* VIMVODConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODConnection.h; sourceTree = "<group>"; };
 		723BC0803DB25CED4A33055244E1F0CF /* Pods-VimeoNetworkingExample-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
-		734BC714BD7883E229A749D5FCD959BD /* VIMVODItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODItem.h; sourceTree = "<group>"; };
-		736B2CF0F0A0E1460A1987D420D301BE /* VIMPictureCollection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPictureCollection.m; sourceTree = "<group>"; };
+		736190EDBD464ACE8CECBBD6E25B8746 /* VIMGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMGroup.m; sourceTree = "<group>"; };
 		737AF7F9A1C09E38A4225A0EAD753152 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
-		771137F242745FA7174D18F6B2B55E36 /* SubscriptionCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionCollection.swift; sourceTree = "<group>"; };
-		773E651333ED23356F5B6B4A2C74BF6E /* VIMSizeQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSizeQuota.h; sourceTree = "<group>"; };
-		798C71B67EC392EADE04DAB73BD406D9 /* VIMTrigger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTrigger.m; sourceTree = "<group>"; };
-		7A68E5D954E9C3C2E6092B1B67A3E1E6 /* String+Parameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "String+Parameters.swift"; sourceTree = "<group>"; };
-		7A74725B0AAC035A5400A2E634928DF0 /* VIMVideoDASHFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDASHFile.m; sourceTree = "<group>"; };
-		7D42FD5CB528446DC9EB56EC4C5850A5 /* VimeoNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VimeoNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
+		74AF20740335B0044F97B0D2732847AF /* VIMCredit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCredit.h; sourceTree = "<group>"; };
+		776387159FB71B2AFDD480EC17E9C7A4 /* Request+ProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+ProgrammedContent.swift"; sourceTree = "<group>"; };
+		78430A2F58C85F8471B830042D3A9DE6 /* VIMComment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMComment.h; sourceTree = "<group>"; };
+		7900BBC9F776E494AF9162DFE4650222 /* VIMInteraction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMInteraction.h; sourceTree = "<group>"; };
+		79BE7D2FA110F5E62D9B974A2F2433F1 /* ErrorCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorCode.swift; sourceTree = "<group>"; };
+		7BAC228038CF9F33A74FE227474AB51D /* VimeoNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VimeoNetworking-tvOS.xcconfig"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
+		7DB80FFC555378A2C0315A7D1CE27704 /* VIMTrigger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTrigger.h; sourceTree = "<group>"; };
 		7E0A850621EF8DB7A95C3AEDE9B54CB3 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; path = "digicert-sha2.cer"; sourceTree = "<group>"; };
-		7E5671B2CEB95051F846F78E494E50D7 /* VIMAppeal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMAppeal.h; sourceTree = "<group>"; };
-		7F1410805711F5C3B8C5349F7A54B879 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
-		7FEE4B5B94BDCC7698C47FA8B8F1F676 /* VIMAccount.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAccount.m; sourceTree = "<group>"; };
-		805AA9E647399745D11A6706FC5DD81A /* Request+Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Authentication.swift"; sourceTree = "<group>"; };
-		80C5471E78D64BF02F17B063DBA3F77C /* VIMVideoDRMFiles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDRMFiles.m; sourceTree = "<group>"; };
-		82B7210BF3175AE9477B1365623B889C /* NSError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Extensions.swift"; sourceTree = "<group>"; };
+		7E1640A6DAB4920E2BD4CC2D26003AD0 /* VIMPrivacy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPrivacy.m; sourceTree = "<group>"; };
+		7EDC471AA7714F97A8DED01B8E900FAF /* AFNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
+		838F6464C6A34E1C64562753D651AE6F /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		839E964A6942F7C2DC01F73329271649 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
 		849165C70CC16C8010F9F30DCE04674C /* Pods-VimeoNetworkingExample-iOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-iOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		84D516F4EBA47242E0D9760E4F7C1353 /* VIMPicture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPicture.h; sourceTree = "<group>"; };
+		85D0C751EB315EAC791F044CCB3D40BF /* VIMInteraction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMInteraction.m; sourceTree = "<group>"; };
 		867A2281FD6A8F9EA8A5D1921C98E8C5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		87AF35296C8C00D637F4BB34E969A220 /* Request+Video.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Video.swift"; sourceTree = "<group>"; };
-		88A73E1F60C716DFE7022B504B586624 /* VIMTrigger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTrigger.h; sourceTree = "<group>"; };
+		8AABD0DD2B17A67950A4DF876C96C1A9 /* Request+Comment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Comment.swift"; sourceTree = "<group>"; };
+		8C16DECC5A73FEBA05CB46E44850CD0C /* VimeoNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		8C88F775ECF0360B05F98B42449EB724 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		8D06DF72635F680385E75F3C97399EB0 /* VIMVideo+VOD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VIMVideo+VOD.m"; sourceTree = "<group>"; };
+		8D83909308A593C42FF7DBF5381052C3 /* VIMVideoPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPreference.m; sourceTree = "<group>"; };
 		8E0C2D0BD32AB407DEC37B20F7D4296E /* Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
-		8E7E3623C60B3CEA68419632CE9D7CBD /* VIMUploadQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadQuota.h; sourceTree = "<group>"; };
-		8F47636C468189B8FE0647F6112D5464 /* VIMQuantityQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMQuantityQuota.m; sourceTree = "<group>"; };
-		91872B936AE6EE73A9B644B3EA3F715A /* Request+Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Cache.swift"; sourceTree = "<group>"; };
+		91DFD9B4663434957354444113757AEB /* ExceptionCatcher+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ExceptionCatcher+Swift.swift"; sourceTree = "<group>"; };
 		92181A66EF3261CA0DEB9B10D1D053F7 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		923177D7128CCE52104C1C609BE2D261 /* VimeoNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VimeoNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
-		936C6D8DA5D4BEFE2939FFBF42346516 /* AFNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		93D09E94BEF337DFC92D742834825936 /* VimeoResponseSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoResponseSerializer.swift; sourceTree = "<group>"; };
-		93F0CECD6330DF68A6916A638FD98AB5 /* VIMRecommendation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMRecommendation.m; sourceTree = "<group>"; };
-		943C2B437428D28F13EE2D269C913619 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AFNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
-		948D643DF3F7192C27FF5E8BD7064A4F /* AFNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-umbrella.h"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
-		95EC74ACA9F3D08C480F9F6283A0CF2A /* Spatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Spatial.swift; sourceTree = "<group>"; };
-		95FDBB9E62BC08809CFDF4FB13603EFB /* VIMConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMConnection.h; sourceTree = "<group>"; };
-		9639109B9B7D36BF609DEF55AD42327C /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		93F3BC3A65FB1B196F662670C0DBB455 /* Request+Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Cache.swift"; sourceTree = "<group>"; };
+		93FABF6EB294DF08E450BF31F8B6C32C /* VIMAppeal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMAppeal.h; sourceTree = "<group>"; };
+		940AF774431B71336D974C4817FC68D3 /* VIMVideoPlayRepresentation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayRepresentation.m; sourceTree = "<group>"; };
+		96AB198755E9562EB7B876CB0F0774CE /* VIMObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMObjectMapper.h; sourceTree = "<group>"; };
+		96C8C6F8BCE7ACAAAF67CB6CA7FDCD0D /* VIMUploadQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadQuota.h; sourceTree = "<group>"; };
+		982732C79018F5203BE6E7E685A7107C /* VIMVideoFairPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFairPlayFile.m; sourceTree = "<group>"; };
 		98BA449E3BEC28EB49FD113A1CB20F1F /* Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		98D415A26C2C8901948B30CC37B4F5EF /* AuthenticationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthenticationController.swift; sourceTree = "<group>"; };
+		994B41DA9BA49B07FADDF4A326863DE6 /* VIMAccount.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAccount.m; sourceTree = "<group>"; };
+		995E2A4882A91722B328223AE1907399 /* Request+Purchasing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Purchasing.swift"; sourceTree = "<group>"; };
+		9A19D957B49D3BD3CABBB7A1FB15AC26 /* VIMActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMActivity.h; sourceTree = "<group>"; };
 		9A82DAFF1C309F67512EA3FCDFC21A55 /* Pods-VimeoNetworkingExample-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		9E11A064A120789D57ACC2CB6EDA9526 /* VimeoSessionManager+Constructors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VimeoSessionManager+Constructors.swift"; sourceTree = "<group>"; };
-		A11BA8F5452BE7B50EDC5D2EB708DD68 /* VIMModelObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMModelObject.m; sourceTree = "<group>"; };
-		A15C52D1C0A52BA6B67D7DC20D50AAFD /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BA6108B999C05BAF20B545FAAA0D26A /* VIMVideo+VOD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VIMVideo+VOD.m"; sourceTree = "<group>"; };
+		9CBA7569FDD87D5E66E0D710A69A73E2 /* VIMVideoPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayFile.h; sourceTree = "<group>"; };
+		A16296BB028B9E535A1456AFF995004E /* Request+Video.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Video.swift"; sourceTree = "<group>"; };
+		A1C2B241368B5431C8350C437E5C4C37 /* VIMNotificationsConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotificationsConnection.h; sourceTree = "<group>"; };
 		A3EDEFD098DD3AA769689319A8DAF72A /* Pods-VimeoNetworkingExample-iOSTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-iOSTests-umbrella.h"; sourceTree = "<group>"; };
-		A46E9E13DF7CF574AE8BE912A1937CBA /* VIMVODItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODItem.m; sourceTree = "<group>"; };
-		A4B37124BF2D0C922CE03CB58867A210 /* Request+Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Category.swift"; sourceTree = "<group>"; };
-		A5846E2F640947CD77BB63D0426AC635 /* VIMCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCategory.h; sourceTree = "<group>"; };
-		A6154623B4613F057480E0DBFB7FF50C /* ErrorCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorCode.swift; sourceTree = "<group>"; };
-		A73C6BBEAB94BD69D956C03A91FE3CDE /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A7D534D18281F270EBBA2C5AD2E2C783 /* VIMPictureCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPictureCollection.h; sourceTree = "<group>"; };
-		A7F658D9E363552377641D391AEABBDE /* Mappable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mappable.swift; sourceTree = "<group>"; };
+		A7B43ED7F71FBA6AF0A283986F36F523 /* VIMCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCategory.h; sourceTree = "<group>"; };
+		A8B4FA8C0590BAC5B34E0FB918C588A3 /* VIMActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMActivity.m; sourceTree = "<group>"; };
 		A9C6788456E3C6CB1F9496329863213F /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9DE93C3508744C0B946E029444C969B /* Pods-VimeoNetworkingExample-iOSTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-iOSTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		AA4DB6F852A348D5C4B9DFE151885233 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
 		AA7B59BB14C734DC3B6D4AB6914BB83C /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
-		AA7BC91BD8CF44D1DFED22B6399DFDA6 /* VIMObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMObjectMapper.h; sourceTree = "<group>"; };
-		AAEDBD81DC147A4E5C253DA14C56613B /* VIMNotificationsConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotificationsConnection.m; sourceTree = "<group>"; };
 		AB2A74E2CFE665FB523939FAFB3B9B0F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AC4307A32427BDE785689408CDF1FFB4 /* VimeoResponseSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoResponseSerializer.swift; sourceTree = "<group>"; };
 		AD287BBA14C09C83412FE6DBA1ADBE5D /* Pods-VimeoNetworkingExample-iOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOSTests-dummy.m"; sourceTree = "<group>"; };
-		ADA8F0D740690B50CD675C7534F3D3F9 /* VIMTag.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTag.m; sourceTree = "<group>"; };
-		ADE6546E0C59DB3C0BAA64D0C2EA01A6 /* Request+Configs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Configs.swift"; sourceTree = "<group>"; };
-		AEE6392E7EFC3AEFCC28B5CBA1ED892E /* VimeoNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "VimeoNetworking-iOS.modulemap"; sourceTree = "<group>"; };
-		B05862F2CFC1FC063F0681CF0AED0205 /* VIMVideoPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPreference.h; sourceTree = "<group>"; };
+		AE094AC51A1EB5C25F33C21CAD250647 /* ResponseCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseCache.swift; sourceTree = "<group>"; };
+		AE42D8F1DD5BCD1CD58E7CEE1EA571AE /* VIMUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadTicket.h; sourceTree = "<group>"; };
+		AF9F9C2F781B6DDC1E880839E796BFF5 /* VIMComment.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMComment.m; sourceTree = "<group>"; };
 		B0D8653FC50F48DA48C7463CA718E52A /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		B1BE9F49C799214FE09C3A414BF863F2 /* VIMVideoFairPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFairPlayFile.h; sourceTree = "<group>"; };
+		B213A61E0B596B45EABF35247CF6280B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B2C1673169E3D04DC71FFCED7531DF18 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		B31B2C5A0269172047F18AD00F5AC373 /* VIMVideoPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPreference.m; sourceTree = "<group>"; };
 		B36ADD33E9C0EBB3DBD3F8EFBDDFD940 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		B3EAC33181285B8B24E63F3B5AF614CC /* AFNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
-		B45352B75935A1039A3343B2CA62C4E3 /* AFNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AFNetworking-tvOS-dummy.m"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
-		B4E985479470294B3B4F3403C0D3B565 /* VIMPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPreference.h; sourceTree = "<group>"; };
-		B5DC7D5950400DB7546EECE5B0D4D25F /* Request+PolicyDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+PolicyDocument.swift"; sourceTree = "<group>"; };
-		B60BA00D92FEEAB4E64F76F7B3929F7A /* VIMVideo+VOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+VOD.h"; sourceTree = "<group>"; };
+		B3DD258FEA974E858B769890622478AB /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
+		B4657CB2ADE8C4AF346AEA36B72FEC77 /* AFNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-umbrella.h"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
+		B4DFD744814E9D8AE3BF951576FCE3B8 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B605A075268FF4892F0C9D9D6F620FFD /* VIMMappable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMMappable.h; sourceTree = "<group>"; };
 		B65F4C85EAE645695940E0000D595E8F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B6A5CCEF03C0068F60B7C4E65E52B274 /* VIMVideoFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFile.h; sourceTree = "<group>"; };
+		B69E8AE4E8E09DEFBF3A2BBF52787052 /* VIMRecommendation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMRecommendation.m; sourceTree = "<group>"; };
 		B709135B1BD723CE4E556F80667457AD /* Pods-VimeoNetworkingExample-tvOSTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOSTests-resources.sh"; sourceTree = "<group>"; };
-		B78AA4DA3641A1ADD28EAD3146817CE5 /* VimeoNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VimeoNetworking-tvOS-dummy.m"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
+		B73FC9797518500A1A7D836707CE7D78 /* VIMVideoFairPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFairPlayFile.h; sourceTree = "<group>"; };
 		B7E8145278825D2B77107418074D1494 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		B875C52E8E384150B35899F656FFC0B2 /* Request+Trigger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Trigger.swift"; sourceTree = "<group>"; };
 		B892065F8B8B671D848DFBCBD400E53D /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		BA6A3DB838C85A5F887BC3BE2954FD56 /* VIMUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUploadTicket.m; sourceTree = "<group>"; };
 		BB188794E997CD5840FBBAFC4196F89C /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		BBF70D980EA19B9847F04EF52848C471 /* VIMPrivacy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPrivacy.h; sourceTree = "<group>"; };
 		BC8021A583156BB7081B084C7EEAB39A /* Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		BC8B0F8D06B6963AFA613D5540B20448 /* VIMCredit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCredit.h; sourceTree = "<group>"; };
-		BCB980BE9981DC8E5A295C5D0027B0FE /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCFC3340D44487494021D17F1B0032D9 /* VIMInteraction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMInteraction.m; sourceTree = "<group>"; };
 		BD0E3E063250CDEE712CB6FED2FA284E /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		BE52AC625BF69C2302B6063E1EB9D46E /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
+		BF6C3BDC1B1BAECB9607F1398C161C08 /* VimeoNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VimeoNetworking.h; sourceTree = "<group>"; };
 		BF705D78E63B097754F307899D4353CA /* Pods-VimeoNetworkingExample-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-VimeoNetworkingExample-iOS.modulemap"; sourceTree = "<group>"; };
-		C4FB75AF1632C64351A746EBE8143C71 /* ExceptionCatcher+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ExceptionCatcher+Swift.swift"; sourceTree = "<group>"; };
+		C18B361F0105107F7CD7ED3369F060B7 /* Objc_ExceptionCatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Objc_ExceptionCatcher.m; sourceTree = "<group>"; };
+		C22F7F712B8A00EAACAF907A56AB3615 /* Notification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		C2C44652A24A9876E7DBB90AB443932E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AFNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
+		C333D8536784D7F8F7AA9E27E467448C /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4A170AE2F7C9BA8AC627713514A2F68 /* VIMNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotification.h; sourceTree = "<group>"; };
+		C4C886C806158CE045537B8268BDD40A /* VIMVideoDASHFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDASHFile.m; sourceTree = "<group>"; };
 		C51E8DCB0A3028D70E54707B8709D914 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C5317EBE4C20F0CC5B737A04AC6CF084 /* VIMVODItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODItem.h; sourceTree = "<group>"; };
 		C59A9F1DF1A65D69106D04DC07FEB3C9 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		C5ABDE60B47B2CFCC904788D43005C7C /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		C5C4635386CED75377DB6612716F497B /* VIMPicture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPicture.h; sourceTree = "<group>"; };
-		C875B420A7A550346F838025CD450223 /* VIMChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMChannel.m; sourceTree = "<group>"; };
-		C8A8A93EEAFBD89D838AA09D6801E832 /* VIMVideoFairPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFairPlayFile.m; sourceTree = "<group>"; };
-		CA69700735E40098B99A3BAF6585DABC /* VIMVideoPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayFile.h; sourceTree = "<group>"; };
-		CAFF6DA4FE0A11F64E7BEE3F1A5E801C /* VIMVideoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoUtils.m; sourceTree = "<group>"; };
+		C85333BEEAE2F31305F9A10ABB399E04 /* VIMModelObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMModelObject.h; sourceTree = "<group>"; };
+		C946B4B13BD1FC7135CED9E3639BD3E6 /* VIMPictureCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPictureCollection.h; sourceTree = "<group>"; };
+		CA058F48C0461AC00354C9BDE962A4CA /* AFNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-prefix.pch"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
+		CA65C7C00A605BB2802D8F203E4D8110 /* VIMTrigger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTrigger.m; sourceTree = "<group>"; };
 		CB807534B72C9B0F02A22174CE2DFF1B /* Pods-VimeoNetworkingExample-iOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-frameworks.sh"; sourceTree = "<group>"; };
-		CBEE62B26CD90E5B64946B696500786C /* AccountStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccountStore.swift; sourceTree = "<group>"; };
-		CC3594508BA6BE964CCC7EA7ACE831F4 /* VIMCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCategory.m; sourceTree = "<group>"; };
 		CC4C3E2EFBF9FFCAAE40290EDBCCB3ED /* Pods-VimeoNetworkingExample-iOSTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOSTests-frameworks.sh"; sourceTree = "<group>"; };
-		CDD62B04AC526CAF7F714450BD320599 /* VIMVideoPlayRepresentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayRepresentation.h; sourceTree = "<group>"; };
-		CE65005CFBE682C530A83C14F4149BDB /* VimeoReachability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoReachability.swift; sourceTree = "<group>"; };
+		CD40B1BB905107488280C57B0EA65FC6 /* NSError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSError+Extensions.swift"; sourceTree = "<group>"; };
+		CE9571AAD3AFA5A25E5CE60FB3DA4065 /* VIMVideoDRMFiles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDRMFiles.h; sourceTree = "<group>"; };
 		CEF43F8D96E8E27A17F1D6DE44F3BE4C /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
 		CF46D31AE82B7E6D80A18A5E1FA4E20D /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
-		D13AFDE4971226993D6B394BB494A1BF /* KeychainStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
-		D2B09820A935CEE6EC9658C595DE1F8D /* VIMObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMObjectMapper.m; sourceTree = "<group>"; };
-		D3D1305DB0B10B92F5CA211649C7F867 /* VIMVideoHLSFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoHLSFile.h; sourceTree = "<group>"; };
+		CF65E1AADC01DEF3C1642483C3F990D2 /* VIMTag.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTag.m; sourceTree = "<group>"; };
+		CF8354F04605CD9749E74E18A8F35425 /* VIMProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMProgrammedContent.swift; sourceTree = "<group>"; };
+		D626EFF0C0BE215902014B2985EB2D54 /* VIMVideo+SVOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+SVOD.h"; sourceTree = "<group>"; };
 		D6728C4328B91A5E3A7EEFCF5F10A4A2 /* Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D7B0A8437B102DB9AC47F5E104762B97 /* VIMPrivacy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPrivacy.m; sourceTree = "<group>"; };
 		D89E36C92FEB6E79957F0DF9A7147DD1 /* Pods-VimeoNetworkingExample-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOS-dummy.m"; sourceTree = "<group>"; };
-		D8E671C023C7983DC6DEFF18A3ECE49C /* Scope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scope.swift; sourceTree = "<group>"; };
 		D92C6DC78822CA3DB419E2F0F7813740 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
-		D94F7CC0224824E9546F4B501DB03573 /* Request+Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Notifications.swift"; sourceTree = "<group>"; };
-		D989F47CA4089C24A674C2F080D701B5 /* VIMCredit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCredit.m; sourceTree = "<group>"; };
+		D9D389417470062CD360290BE2A7FF74 /* VIMVideoUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoUtils.h; sourceTree = "<group>"; };
 		DC0EC285BFAAC685CB438808A8A89D55 /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-tvOSTests-umbrella.h"; sourceTree = "<group>"; };
-		DD0B00BEFE4EC4A6D4169CB2D857FAFE /* VimeoNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-umbrella.h"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
-		DD4317F045FE3314AEAC78685D8905E5 /* VIMVideoFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFile.m; sourceTree = "<group>"; };
+		DCBD1FF411F252BAEDE0AE5DE8BF864F /* VIMVideoPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayFile.m; sourceTree = "<group>"; };
 		DE58CE542373B68EA97653A0A3B2E2E0 /* Pods-VimeoNetworkingExample-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-iOS-umbrella.h"; sourceTree = "<group>"; };
 		DEFE6F9B852E6B533E166938D98B2011 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
-		DF6AA5001AC39CF18E85E71CECF418D0 /* VIMSeason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSeason.h; sourceTree = "<group>"; };
-		E035D94411FF23FBDF847FD809A0EECF /* VIMPicture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPicture.m; sourceTree = "<group>"; };
-		E1297CBCCBC0690C1047F1991E1B5B40 /* VIMSoundtrack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSoundtrack.h; sourceTree = "<group>"; };
-		E19789298FED6865966EEF863826646C /* VIMSizeQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSizeQuota.m; sourceTree = "<group>"; };
-		E21215A1A7453B914B49A163844FF5A2 /* VIMVODConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODConnection.m; sourceTree = "<group>"; };
-		E4F5400D264F3C9259F38D027C580269 /* VIMTag.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTag.h; sourceTree = "<group>"; };
-		E57337F0D36ED5168C08442B531F5C09 /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
-		E6938D1F58272D3B69F54B79AD04D861 /* VIMVideoDASHFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDASHFile.h; sourceTree = "<group>"; };
-		E6CE1860B2693ADDE6451AFD7D93C2BF /* VIMSeason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSeason.m; sourceTree = "<group>"; };
+		E05B84759072C50968313917642DF417 /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E158346041ED7D2756E0BABCE3359180 /* VIMConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMConnection.h; sourceTree = "<group>"; };
+		E35790B480E77599EB94E272BD2455ED /* Request+Picture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Picture.swift"; sourceTree = "<group>"; };
+		E36E3423CDCBB8AF3475113DF69DE836 /* VimeoNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-prefix.pch"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
+		E4908E6209B0874E069635BA3305A278 /* VIMVideo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideo.h; sourceTree = "<group>"; };
+		E4D4A1BB8E751CC6AD00D5E512C8E0AD /* VIMQuantityQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMQuantityQuota.m; sourceTree = "<group>"; };
 		E8632641A85F1E3BFF24373979525E28 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
 		E8747CDC6A5178FA30CF966D34F38BBC /* Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
-		E8ECCC343EB76513F98BCE43E3C62A63 /* AppConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		E9849BB6928A5B6C987569BECB73F85D /* VIMUserBadge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUserBadge.m; sourceTree = "<group>"; };
+		E96440544E7AE1DACD14D44B11AAB1E2 /* VIMUserBadge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUserBadge.h; sourceTree = "<group>"; };
+		E982102FDBF3A7B8E676EE912FB73697 /* VIMAccount.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMAccount.h; sourceTree = "<group>"; };
+		E9DCB3176AEDC01F983620ECC07D12E3 /* AppConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		EA174A361D33358C1B6FBAABEDCFA3E1 /* Pods-VimeoNetworkingExample-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		EB986F5DCE12497A6EEA8957FF17B63B /* VIMVideoFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFile.h; sourceTree = "<group>"; };
 		ED9B36114E382B77369B6A4EDEF93E63 /* Pods-VimeoNetworkingExample-iOSTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-VimeoNetworkingExample-iOSTests.modulemap"; sourceTree = "<group>"; };
-		EE223A37C992831E3A1F99385B800676 /* VIMChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMChannel.h; sourceTree = "<group>"; };
+		EE2A1362958BB9EA1461DD137B8AC56D /* VIMChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMChannel.m; sourceTree = "<group>"; };
 		EFAA64EDB405E880BEC5AF34EF8AE334 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		F124A50F309625B2C3F86D1520F14A49 /* VIMThumbnailUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMThumbnailUploadTicket.h; sourceTree = "<group>"; };
-		F1DE65342B0FE267B3D2E83243AE4EB2 /* VIMPolicyDocument.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPolicyDocument.m; sourceTree = "<group>"; };
-		F476E42ECF336A8587D662E6BB7CC91B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F50A97C60AC05E295ADA9C3A95333BE1 /* AFNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "AFNetworking-tvOS.modulemap"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
-		F582EEBB44C65E57F5CD07F5251643F5 /* VIMVideoDRMFiles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDRMFiles.h; sourceTree = "<group>"; };
-		F6C9C1826B251AF90151E9157195F473 /* PinCodeInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PinCodeInfo.swift; sourceTree = "<group>"; };
+		F1AF5084E99C0F4553041BE57E768059 /* VIMVODItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODItem.m; sourceTree = "<group>"; };
+		F26D6C88FF5CFB1FB47860D56F3DB453 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2C48F19556B7A419C08AD20108343A2 /* Scope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scope.swift; sourceTree = "<group>"; };
+		F35A94430D3B9BC1D0E8575FC6FD6A68 /* VIMAppeal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAppeal.m; sourceTree = "<group>"; };
+		F3B50CA5DBD3C703633433A24E0BA3E9 /* AFNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "AFNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
+		F3C44EB0245A9263C02C1DE892254EF1 /* VIMObjectMapper+Generic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VIMObjectMapper+Generic.swift"; sourceTree = "<group>"; };
+		F3D8EADD112B72372D01930045B40D07 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		F42093CF175056BE79EA7548EF1134CA /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F49888AA2998709A179E549F965BDFAF /* VIMModelObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMModelObject.m; sourceTree = "<group>"; };
+		F5DBD3F7E349B96289AE20E9F2A78799 /* VIMRecommendation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMRecommendation.h; sourceTree = "<group>"; };
+		F681471295C53EB9E733E1E9F7C704E5 /* VimeoNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VimeoNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
+		F69F76DBD9E65B40AD472672DE92C4B9 /* VimeoRequestSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VimeoRequestSerializer.swift; sourceTree = "<group>"; };
+		F6E293EF1A0B5647FA0964FC336CDD7F /* VIMPicture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPicture.m; sourceTree = "<group>"; };
 		F713551893DD24923ADD2D70432FD08C /* Pods-VimeoNetworkingExample-tvOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-tvOSTests-dummy.m"; sourceTree = "<group>"; };
-		F8176C5051EFDE888C571B411FFC422D /* Request+User.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+User.swift"; sourceTree = "<group>"; };
+		F7778C56F9709864691BA8462D7F9A3B /* AFNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "AFNetworking-tvOS.modulemap"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
 		F84A32F212BBB352D92213A1CAE70161 /* Pods-VimeoNetworkingExample-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-VimeoNetworkingExample-tvOS.modulemap"; sourceTree = "<group>"; };
-		F927D4B012FBD352564066F8BF470052 /* Request+Comment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Comment.swift"; sourceTree = "<group>"; };
+		F87E4E126F204E9CD8AA72F763844720 /* VIMPictureCollection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPictureCollection.m; sourceTree = "<group>"; };
 		F9AA9738D67B6EDD0C39AEF905287D26 /* Pods-VimeoNetworkingExample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		FA16B4020ADC3704EC6A8FAD916BE2A3 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9B4D21E54F7C54C3216761425A04A66 /* Request+Soundtrack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Soundtrack.swift"; sourceTree = "<group>"; };
 		FC3BD1BE67C4D36FFD477BA53C7038DA /* Pods-VimeoNetworkingExample-iOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-resources.sh"; sourceTree = "<group>"; };
-		FDB38341FA26EB67D0360778AB8263BB /* Request+Toggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+Toggle.swift"; sourceTree = "<group>"; };
+		FC758E8D30A0F1FDFB079DD305DF047F /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		FD88C84C31B6D8271B17972645BBE071 /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -790,6 +799,58 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
+		0B4069CC555C5F51AB5323FEC348F24F /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1A20FB839C88BC5EC47ACE75A5107905 /* AccountStore.swift */,
+				E9DCB3176AEDC01F983620ECC07D12E3 /* AppConfiguration.swift */,
+				04ED8340220B49DAA663FC53D924519D /* AuthenticationController.swift */,
+				F3D8EADD112B72372D01930045B40D07 /* Constants.swift */,
+				79BE7D2FA110F5E62D9B974A2F2433F1 /* ErrorCode.swift */,
+				91DFD9B4663434957354444113757AEB /* ExceptionCatcher+Swift.swift */,
+				690975C455446102C3B73BE1B60D3FD7 /* KeychainStore.swift */,
+				3BF2D208C4CC086A891F12E4C15EBFF2 /* Mappable.swift */,
+				C22F7F712B8A00EAACAF907A56AB3615 /* Notification.swift */,
+				CD40B1BB905107488280C57B0EA65FC6 /* NSError+Extensions.swift */,
+				4DDCCFCA74DCB70FC8304247A43E7A5C /* NSURLSessionConfiguration+Extensions.swift */,
+				2664FAAA28B1A8A721A7E3964648C9FB /* Objc_ExceptionCatcher.h */,
+				C18B361F0105107F7CD7ED3369F060B7 /* Objc_ExceptionCatcher.m */,
+				62A5F7B9659356AA141A193B05FE7FDC /* Request.swift */,
+				6909CDE156096B54AD70B70F2A1ED784 /* Request+Authentication.swift */,
+				93F3BC3A65FB1B196F662670C0DBB455 /* Request+Cache.swift */,
+				5BDE55D4C67FCFD91DF2D54641523FE1 /* Request+Category.swift */,
+				6394F7D67FC3782A07ACFCE8E622E768 /* Request+Channel.swift */,
+				8AABD0DD2B17A67950A4DF876C96C1A9 /* Request+Comment.swift */,
+				523151A937F41DC5B653894FDB9D448D /* Request+Configs.swift */,
+				3E7452337F7798C98A14B2BEB8B75409 /* Request+Notifications.swift */,
+				E35790B480E77599EB94E272BD2455ED /* Request+Picture.swift */,
+				4CB86906C8CB7AAC0084430ED4BC9F05 /* Request+PolicyDocument.swift */,
+				776387159FB71B2AFDD480EC17E9C7A4 /* Request+ProgrammedContent.swift */,
+				995E2A4882A91722B328223AE1907399 /* Request+Purchasing.swift */,
+				F9B4D21E54F7C54C3216761425A04A66 /* Request+Soundtrack.swift */,
+				11514B79FCE3AA78352293D67C56CCFC /* Request+Toggle.swift */,
+				B875C52E8E384150B35899F656FFC0B2 /* Request+Trigger.swift */,
+				1C1C6442502277D255EF0D73ED43EFBC /* Request+User.swift */,
+				A16296BB028B9E535A1456AFF995004E /* Request+Video.swift */,
+				FC758E8D30A0F1FDFB079DD305DF047F /* Response.swift */,
+				AE094AC51A1EB5C25F33C21CAD250647 /* ResponseCache.swift */,
+				50BEE65EABAF41C071B0A356203532E4 /* Result.swift */,
+				F2C48F19556B7A419C08AD20108343A2 /* Scope.swift */,
+				00E0D09E3E6932A763A908776E806721 /* String+Parameters.swift */,
+				584F81421BAA557AF945BBA1D8D9AB6C /* VimeoClient.swift */,
+				BF6C3BDC1B1BAECB9607F1398C161C08 /* VimeoNetworking.h */,
+				48B8BA27056712CD4A3C0F1B1E66E5A7 /* VimeoReachability.swift */,
+				F69F76DBD9E65B40AD472672DE92C4B9 /* VimeoRequestSerializer.swift */,
+				AC4307A32427BDE785689408CDF1FFB4 /* VimeoResponseSerializer.swift */,
+				69C308F741B8317EDC1D9DA106084966 /* VimeoSessionManager.swift */,
+				1ECD9DB2E90D9479010A66146E935FEE /* VimeoSessionManager+Constructors.swift */,
+				F3C44EB0245A9263C02C1DE892254EF1 /* VIMObjectMapper+Generic.swift */,
+				75980B6A08DCDBDE3209CF24ADECB798 /* Models */,
+			);
+			name = Sources;
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		0DFF87FCC56D7F4C354104A2415FBF71 /* Pods-VimeoNetworkingExample-iOSTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -843,112 +904,6 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		27FBC7EC13DBF2E5175B84BB62B80632 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				F6C9C1826B251AF90151E9157195F473 /* PinCodeInfo.swift */,
-				69BE65117389447A238073067BF67BB8 /* PlayProgress.swift */,
-				95EC74ACA9F3D08C480F9F6283A0CF2A /* Spatial.swift */,
-				40E50806D5A1AC489DED566E2B0753E7 /* Subscription.swift */,
-				771137F242745FA7174D18F6B2B55E36 /* SubscriptionCollection.swift */,
-				17664F34992B004CE69FDFFDC5A3196B /* VIMAccount.h */,
-				7FEE4B5B94BDCC7698C47FA8B8F1F676 /* VIMAccount.m */,
-				6E298AAB2BEC7F6549699CECD0035E11 /* VIMActivity.h */,
-				25AD679486A4AC3BE6AC694E2120F19E /* VIMActivity.m */,
-				7E5671B2CEB95051F846F78E494E50D7 /* VIMAppeal.h */,
-				66F9A4D52E090ADB6875D0781DA849D8 /* VIMAppeal.m */,
-				2EFF11167575460C49AB2C032A29B65C /* VIMBadge.swift */,
-				A5846E2F640947CD77BB63D0426AC635 /* VIMCategory.h */,
-				CC3594508BA6BE964CCC7EA7ACE831F4 /* VIMCategory.m */,
-				EE223A37C992831E3A1F99385B800676 /* VIMChannel.h */,
-				C875B420A7A550346F838025CD450223 /* VIMChannel.m */,
-				179C54BB1ED2F615E881E6B6F085FA8D /* VIMComment.h */,
-				564E30C21468FA8DACA24A8E768A2C3B /* VIMComment.m */,
-				95FDBB9E62BC08809CFDF4FB13603EFB /* VIMConnection.h */,
-				0FA584B5334FB72FEC2DD0A6CAF29167 /* VIMConnection.m */,
-				BC8B0F8D06B6963AFA613D5540B20448 /* VIMCredit.h */,
-				D989F47CA4089C24A674C2F080D701B5 /* VIMCredit.m */,
-				1309CB98D2B0E4D5A1581913EB681AD3 /* VIMGroup.h */,
-				461A2F51AD0136F4FBB09E77CDDF0519 /* VIMGroup.m */,
-				6E2706D82A1741A66D809C2297C6CB56 /* VIMInteraction.h */,
-				BCFC3340D44487494021D17F1B0032D9 /* VIMInteraction.m */,
-				517155516D8B9E4AC1FF2AD324D8F03D /* VIMMappable.h */,
-				2B0ED99B4A6356750583D3A9BF624DA7 /* VIMModelObject.h */,
-				A11BA8F5452BE7B50EDC5D2EB708DD68 /* VIMModelObject.m */,
-				45BAA0B58A098356105F549216E19269 /* VIMNotification.h */,
-				534E14F2B03338A7A344281334105191 /* VIMNotification.m */,
-				36EEBE5D0E88C1F7A926DF06AFEAD7D3 /* VIMNotificationsConnection.h */,
-				AAEDBD81DC147A4E5C253DA14C56613B /* VIMNotificationsConnection.m */,
-				AA7BC91BD8CF44D1DFED22B6399DFDA6 /* VIMObjectMapper.h */,
-				D2B09820A935CEE6EC9658C595DE1F8D /* VIMObjectMapper.m */,
-				C5C4635386CED75377DB6612716F497B /* VIMPicture.h */,
-				E035D94411FF23FBDF847FD809A0EECF /* VIMPicture.m */,
-				A7D534D18281F270EBBA2C5AD2E2C783 /* VIMPictureCollection.h */,
-				736B2CF0F0A0E1460A1987D420D301BE /* VIMPictureCollection.m */,
-				09203B0DF735A1912AA153068A050CAF /* VIMPolicyDocument.h */,
-				F1DE65342B0FE267B3D2E83243AE4EB2 /* VIMPolicyDocument.m */,
-				B4E985479470294B3B4F3403C0D3B565 /* VIMPreference.h */,
-				4268200039AFCC987F67F25FDB3145F9 /* VIMPreference.m */,
-				61199E51D666ABD1754E7146E219AEFE /* VIMPrivacy.h */,
-				D7B0A8437B102DB9AC47F5E104762B97 /* VIMPrivacy.m */,
-				292E0C05CA34891FE8E831B2E808809E /* VIMProgrammedContent.swift */,
-				471D33D599D075E83CF7527E467F7F1C /* VIMQuantityQuota.h */,
-				8F47636C468189B8FE0647F6112D5464 /* VIMQuantityQuota.m */,
-				1D743FD5CB60F7013F8A1B7F336B8165 /* VIMRecommendation.h */,
-				93F0CECD6330DF68A6916A638FD98AB5 /* VIMRecommendation.m */,
-				DF6AA5001AC39CF18E85E71CECF418D0 /* VIMSeason.h */,
-				E6CE1860B2693ADDE6451AFD7D93C2BF /* VIMSeason.m */,
-				773E651333ED23356F5B6B4A2C74BF6E /* VIMSizeQuota.h */,
-				E19789298FED6865966EEF863826646C /* VIMSizeQuota.m */,
-				E1297CBCCBC0690C1047F1991E1B5B40 /* VIMSoundtrack.h */,
-				4CFA606A383C992A4AD2F0E0297CB568 /* VIMSoundtrack.m */,
-				E4F5400D264F3C9259F38D027C580269 /* VIMTag.h */,
-				ADA8F0D740690B50CD675C7534F3D3F9 /* VIMTag.m */,
-				F124A50F309625B2C3F86D1520F14A49 /* VIMThumbnailUploadTicket.h */,
-				51406E890E759FA65CED3449833C35E5 /* VIMThumbnailUploadTicket.m */,
-				88A73E1F60C716DFE7022B504B586624 /* VIMTrigger.h */,
-				798C71B67EC392EADE04DAB73BD406D9 /* VIMTrigger.m */,
-				8E7E3623C60B3CEA68419632CE9D7CBD /* VIMUploadQuota.h */,
-				50A0AA5B2D4E05972B4F2ACD8A14D6B9 /* VIMUploadQuota.m */,
-				5500F221D922DA37348F1AA7E091F17E /* VIMUploadTicket.h */,
-				36BD749BDAAB6F8F73BD7F3CCC4CF61E /* VIMUploadTicket.m */,
-				08355F852018C46FA265697C2DC149C9 /* VIMUser.h */,
-				339121042BB79912B92A5DBE8757F7C2 /* VIMUser.m */,
-				281594D3591B4C4D8504EEA3CD2AA768 /* VIMUserBadge.h */,
-				E9849BB6928A5B6C987569BECB73F85D /* VIMUserBadge.m */,
-				35DF3F42E2AA53C89B5CBDEE523150A5 /* VIMVideo.h */,
-				0ED07A77DE93F9B9E08DDDC75F3EC773 /* VIMVideo.m */,
-				B60BA00D92FEEAB4E64F76F7B3929F7A /* VIMVideo+VOD.h */,
-				8D06DF72635F680385E75F3C97399EB0 /* VIMVideo+VOD.m */,
-				E6938D1F58272D3B69F54B79AD04D861 /* VIMVideoDASHFile.h */,
-				7A74725B0AAC035A5400A2E634928DF0 /* VIMVideoDASHFile.m */,
-				F582EEBB44C65E57F5CD07F5251643F5 /* VIMVideoDRMFiles.h */,
-				80C5471E78D64BF02F17B063DBA3F77C /* VIMVideoDRMFiles.m */,
-				B1BE9F49C799214FE09C3A414BF863F2 /* VIMVideoFairPlayFile.h */,
-				C8A8A93EEAFBD89D838AA09D6801E832 /* VIMVideoFairPlayFile.m */,
-				B6A5CCEF03C0068F60B7C4E65E52B274 /* VIMVideoFile.h */,
-				DD4317F045FE3314AEAC78685D8905E5 /* VIMVideoFile.m */,
-				D3D1305DB0B10B92F5CA211649C7F867 /* VIMVideoHLSFile.h */,
-				124229104F1F5A171DD89D457BFD65E4 /* VIMVideoHLSFile.m */,
-				CA69700735E40098B99A3BAF6585DABC /* VIMVideoPlayFile.h */,
-				3C18388A3250EC4C760D7512A99A466B /* VIMVideoPlayFile.m */,
-				CDD62B04AC526CAF7F714450BD320599 /* VIMVideoPlayRepresentation.h */,
-				0B5311892B58BCB246FCA8017CE6BA94 /* VIMVideoPlayRepresentation.m */,
-				B05862F2CFC1FC063F0681CF0AED0205 /* VIMVideoPreference.h */,
-				B31B2C5A0269172047F18AD00F5AC373 /* VIMVideoPreference.m */,
-				018B567BFCF88294495C99032387F716 /* VIMVideoProgressiveFile.h */,
-				037D6AED08466DC62BD3FAB79CEF1153 /* VIMVideoProgressiveFile.m */,
-				627D6A4C038285A0976237937BDF0752 /* VIMVideoUtils.h */,
-				CAFF6DA4FE0A11F64E7BEE3F1A5E801C /* VIMVideoUtils.m */,
-				2E8E2F400FB9E6F12109D8FA3D0E5E2B /* VIMVODConnection.h */,
-				E21215A1A7453B914B49A163844FF5A2 /* VIMVODConnection.m */,
-				734BC714BD7883E229A749D5FCD959BD /* VIMVODItem.h */,
-				A46E9E13DF7CF574AE8BE912A1937CBA /* VIMVODItem.m */,
-			);
-			name = Models;
-			path = Models;
-			sourceTree = "<group>";
-		};
 		3D085EE094ED7BFEEF664F3B463D4D00 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -997,12 +952,140 @@
 			path = "Target Support Files/Pods-VimeoNetworkingExample-iOS";
 			sourceTree = "<group>";
 		};
+		60F9BD7F950D89907CC1E90AB86AD7BB /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				67F42C82756B35668B825044435C6698 /* Info.plist */,
+				6382A439939118026F6A5383D18BF5AC /* Info.plist */,
+				4C63C59D1B22CBA5630ABA097BBFC83F /* VimeoNetworking-iOS.modulemap */,
+				F681471295C53EB9E733E1E9F7C704E5 /* VimeoNetworking-iOS.xcconfig */,
+				6CF722C1ECE5F7A8B7D42C4D9A3B1DA1 /* VimeoNetworking-iOS-dummy.m */,
+				8C16DECC5A73FEBA05CB46E44850CD0C /* VimeoNetworking-iOS-prefix.pch */,
+				B3DD258FEA974E858B769890622478AB /* VimeoNetworking-iOS-umbrella.h */,
+				1556C19F01E93C6B9B4911FC49EC4C49 /* VimeoNetworking-tvOS.modulemap */,
+				7BAC228038CF9F33A74FE227474AB51D /* VimeoNetworking-tvOS.xcconfig */,
+				333E74E9D12E8587F8596072434B2DC2 /* VimeoNetworking-tvOS-dummy.m */,
+				E36E3423CDCBB8AF3475113DF69DE836 /* VimeoNetworking-tvOS-prefix.pch */,
+				211708A14F8B6B0F638C9B9008F65EE3 /* VimeoNetworking-tvOS-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Pods/Target Support Files/VimeoNetworking-iOS";
+			sourceTree = "<group>";
+		};
 		641BDD347DE7B8BB81D6CA5727C6EC5A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
 				D5B76FAE4783960A76935D82DD35FD78 /* AFNetworking */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		75980B6A08DCDBDE3209CF24ADECB798 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				53568F3F8B42860E008F52E55F6FB90F /* PinCodeInfo.swift */,
+				383610F11263F07C8D784A9F10AD42A3 /* PlayProgress.swift */,
+				17F3D2845CDF2659A23B03641F8A66C1 /* Spatial.swift */,
+				3BC28F4BBBD260F1FD163C117165AB6E /* Subscription.swift */,
+				150A41B0820E472218521E2E495FD2E7 /* SubscriptionCollection.swift */,
+				E982102FDBF3A7B8E676EE912FB73697 /* VIMAccount.h */,
+				994B41DA9BA49B07FADDF4A326863DE6 /* VIMAccount.m */,
+				9A19D957B49D3BD3CABBB7A1FB15AC26 /* VIMActivity.h */,
+				A8B4FA8C0590BAC5B34E0FB918C588A3 /* VIMActivity.m */,
+				93FABF6EB294DF08E450BF31F8B6C32C /* VIMAppeal.h */,
+				F35A94430D3B9BC1D0E8575FC6FD6A68 /* VIMAppeal.m */,
+				01C748830CA64F6F99AEF35A159EA35B /* VIMBadge.swift */,
+				A7B43ED7F71FBA6AF0A283986F36F523 /* VIMCategory.h */,
+				0C07B6C47D385D9C238370F5C13AD9BE /* VIMCategory.m */,
+				3E0513C7DE2C022B3A44B2540BEA4332 /* VIMChannel.h */,
+				EE2A1362958BB9EA1461DD137B8AC56D /* VIMChannel.m */,
+				78430A2F58C85F8471B830042D3A9DE6 /* VIMComment.h */,
+				AF9F9C2F781B6DDC1E880839E796BFF5 /* VIMComment.m */,
+				E158346041ED7D2756E0BABCE3359180 /* VIMConnection.h */,
+				3071D58C5C91FF7CDCBFEC7BE4CFE200 /* VIMConnection.m */,
+				74AF20740335B0044F97B0D2732847AF /* VIMCredit.h */,
+				32E43BE43C06FE63236F981EA98FDB96 /* VIMCredit.m */,
+				5B1D926D49D146EA24B31A59FA01AC9D /* VIMGroup.h */,
+				736190EDBD464ACE8CECBBD6E25B8746 /* VIMGroup.m */,
+				7900BBC9F776E494AF9162DFE4650222 /* VIMInteraction.h */,
+				85D0C751EB315EAC791F044CCB3D40BF /* VIMInteraction.m */,
+				B605A075268FF4892F0C9D9D6F620FFD /* VIMMappable.h */,
+				C85333BEEAE2F31305F9A10ABB399E04 /* VIMModelObject.h */,
+				F49888AA2998709A179E549F965BDFAF /* VIMModelObject.m */,
+				C4A170AE2F7C9BA8AC627713514A2F68 /* VIMNotification.h */,
+				2E05FC37D99D9236704387733255F601 /* VIMNotification.m */,
+				A1C2B241368B5431C8350C437E5C4C37 /* VIMNotificationsConnection.h */,
+				347BCCB07384A61A6DA9584C80B157BE /* VIMNotificationsConnection.m */,
+				96AB198755E9562EB7B876CB0F0774CE /* VIMObjectMapper.h */,
+				466F66A73E061D9070D392689B346068 /* VIMObjectMapper.m */,
+				84D516F4EBA47242E0D9760E4F7C1353 /* VIMPicture.h */,
+				F6E293EF1A0B5647FA0964FC336CDD7F /* VIMPicture.m */,
+				C946B4B13BD1FC7135CED9E3639BD3E6 /* VIMPictureCollection.h */,
+				F87E4E126F204E9CD8AA72F763844720 /* VIMPictureCollection.m */,
+				3393CCCD8B9E11861D5344277458C2B3 /* VIMPolicyDocument.h */,
+				1007E89CB1BA9CEE28AC124F4ACB44D5 /* VIMPolicyDocument.m */,
+				5A2A35780B8623B82634E47027FFED61 /* VIMPreference.h */,
+				6E677F784833BF969753B402CD57F22C /* VIMPreference.m */,
+				BBF70D980EA19B9847F04EF52848C471 /* VIMPrivacy.h */,
+				7E1640A6DAB4920E2BD4CC2D26003AD0 /* VIMPrivacy.m */,
+				CF8354F04605CD9749E74E18A8F35425 /* VIMProgrammedContent.swift */,
+				131C00E5DAC05AB4DF652C33062FFC35 /* VIMQuantityQuota.h */,
+				E4D4A1BB8E751CC6AD00D5E512C8E0AD /* VIMQuantityQuota.m */,
+				F5DBD3F7E349B96289AE20E9F2A78799 /* VIMRecommendation.h */,
+				B69E8AE4E8E09DEFBF3A2BBF52787052 /* VIMRecommendation.m */,
+				70F18FFB1D81E5EE980E46CBD03773F6 /* VIMSeason.h */,
+				09404CBEC79FC3224ACB8B06C8D89282 /* VIMSeason.m */,
+				46302053FFBE4A1DE028AACC0E3FFAD6 /* VIMSizeQuota.h */,
+				01191A945E37E8EDE78E408AEC174BBF /* VIMSizeQuota.m */,
+				1456E82583F2E91622BF0C4CB24D8282 /* VIMSoundtrack.h */,
+				341F9599E9BB9B067C861D9E6C78CEC7 /* VIMSoundtrack.m */,
+				3B6DC63928A173B984CB141C424354D7 /* VIMTag.h */,
+				CF65E1AADC01DEF3C1642483C3F990D2 /* VIMTag.m */,
+				5573FA464AE0A0FCFFD01F9295F2E398 /* VIMThumbnailUploadTicket.h */,
+				48511DC8610B847616DBF17962816670 /* VIMThumbnailUploadTicket.m */,
+				7DB80FFC555378A2C0315A7D1CE27704 /* VIMTrigger.h */,
+				CA65C7C00A605BB2802D8F203E4D8110 /* VIMTrigger.m */,
+				96C8C6F8BCE7ACAAAF67CB6CA7FDCD0D /* VIMUploadQuota.h */,
+				436C8D5EC7EC30863563888B1C6A1472 /* VIMUploadQuota.m */,
+				AE42D8F1DD5BCD1CD58E7CEE1EA571AE /* VIMUploadTicket.h */,
+				BA6A3DB838C85A5F887BC3BE2954FD56 /* VIMUploadTicket.m */,
+				3D4B5215801D2D5C63CCDF0419672E78 /* VIMUser.h */,
+				71F370F20A1F53D9EF7C866FA840F2A7 /* VIMUser.m */,
+				E96440544E7AE1DACD14D44B11AAB1E2 /* VIMUserBadge.h */,
+				5F562F610CF6498DF3ACC32CA8B717A3 /* VIMUserBadge.m */,
+				E4908E6209B0874E069635BA3305A278 /* VIMVideo.h */,
+				04CE692A4643EC075830B8A8D2EC0892 /* VIMVideo.m */,
+				D626EFF0C0BE215902014B2985EB2D54 /* VIMVideo+SVOD.h */,
+				6CEFF5FE44CD9018B27A0AE71C24D457 /* VIMVideo+SVOD.m */,
+				00A583D9AEA48462ED7025103564EC1A /* VIMVideo+VOD.h */,
+				9BA6108B999C05BAF20B545FAAA0D26A /* VIMVideo+VOD.m */,
+				52AE2B99F1B20F4EB550846F1E35CE66 /* VIMVideoDASHFile.h */,
+				C4C886C806158CE045537B8268BDD40A /* VIMVideoDASHFile.m */,
+				CE9571AAD3AFA5A25E5CE60FB3DA4065 /* VIMVideoDRMFiles.h */,
+				4CB9221DABD0055F8247E5D435332EED /* VIMVideoDRMFiles.m */,
+				B73FC9797518500A1A7D836707CE7D78 /* VIMVideoFairPlayFile.h */,
+				982732C79018F5203BE6E7E685A7107C /* VIMVideoFairPlayFile.m */,
+				EB986F5DCE12497A6EEA8957FF17B63B /* VIMVideoFile.h */,
+				04DE9119228F4D6A30C7C5FC2161EAD4 /* VIMVideoFile.m */,
+				5B140EF76317A6BC8E805C42E8D7C32A /* VIMVideoHLSFile.h */,
+				43AFBB835F93D6364FAF476CF9B99817 /* VIMVideoHLSFile.m */,
+				9CBA7569FDD87D5E66E0D710A69A73E2 /* VIMVideoPlayFile.h */,
+				DCBD1FF411F252BAEDE0AE5DE8BF864F /* VIMVideoPlayFile.m */,
+				1F9948C38E0266C1BA795F936FD748AB /* VIMVideoPlayRepresentation.h */,
+				940AF774431B71336D974C4817FC68D3 /* VIMVideoPlayRepresentation.m */,
+				4C31C2D32930DBB30C817C1D604355C1 /* VIMVideoPreference.h */,
+				8D83909308A593C42FF7DBF5381052C3 /* VIMVideoPreference.m */,
+				55A341CD7CF9827C5AC2227A045BBC91 /* VIMVideoProgressiveFile.h */,
+				38AAF65A396A42208A8655BC9D7F529A /* VIMVideoProgressiveFile.m */,
+				D9D389417470062CD360290BE2A7FF74 /* VIMVideoUtils.h */,
+				0EA854CAD12FF6A039EE1803203DC92F /* VIMVideoUtils.m */,
+				72011EB002491733A4DDC5E1D15191D2 /* VIMVODConnection.h */,
+				586604445A393AD884FD7F6DE0B33773 /* VIMVODConnection.m */,
+				C5317EBE4C20F0CC5B737A04AC6CF084 /* VIMVODItem.h */,
+				F1AF5084E99C0F4553041BE57E768059 /* VIMVODItem.m */,
+			);
+			name = Models;
+			path = Models;
 			sourceTree = "<group>";
 		};
 		76D3F309D094199550ABEA2829344C2F /* Targets Support Files */ = {
@@ -1023,53 +1106,9 @@
 				F61223E225B848600F97E6C4CBD13D75 /* Development Pods */,
 				B03589161BFC47B9EF002EF08B913B3F /* Frameworks */,
 				641BDD347DE7B8BB81D6CA5727C6EC5A /* Pods */,
-				886F4747242E24C902B18D79D841B982 /* Products */,
+				C773D56F22E407225D39472178756752 /* Products */,
 				76D3F309D094199550ABEA2829344C2F /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		86E9F4B6B8D5248257A7C9EA08FC6210 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				6F058A9C6F09801FADC5C803AA4CC25E /* Info.plist */,
-				3C16A19E3DAB489CC04BFF254CD26AFC /* Info.plist */,
-				AEE6392E7EFC3AEFCC28B5CBA1ED892E /* VimeoNetworking-iOS.modulemap */,
-				7D42FD5CB528446DC9EB56EC4C5850A5 /* VimeoNetworking-iOS.xcconfig */,
-				923177D7128CCE52104C1C609BE2D261 /* VimeoNetworking-iOS-dummy.m */,
-				08CC97AFCA85D85BCF5C92FDF30A3E5B /* VimeoNetworking-iOS-prefix.pch */,
-				BE52AC625BF69C2302B6063E1EB9D46E /* VimeoNetworking-iOS-umbrella.h */,
-				E57337F0D36ED5168C08442B531F5C09 /* VimeoNetworking-tvOS.modulemap */,
-				5EF23B1E2D740197B2808DB8BAD1E680 /* VimeoNetworking-tvOS.xcconfig */,
-				B78AA4DA3641A1ADD28EAD3146817CE5 /* VimeoNetworking-tvOS-dummy.m */,
-				3BEF7D1145F3EC76C4FEA0953E8419AD /* VimeoNetworking-tvOS-prefix.pch */,
-				DD0B00BEFE4EC4A6D4169CB2D857FAFE /* VimeoNetworking-tvOS-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Pods/Target Support Files/VimeoNetworking-iOS";
-			sourceTree = "<group>";
-		};
-		87B87AB3F9A6E72EA79706144317FF7C /* VimeoNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				EA1335650BC9A69D19C2680F21B02C90 /* Sources */,
-			);
-			name = VimeoNetworking;
-			path = VimeoNetworking;
-			sourceTree = "<group>";
-		};
-		886F4747242E24C902B18D79D841B982 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FA16B4020ADC3704EC6A8FAD916BE2A3 /* AFNetworking.framework */,
-				15BF26706675BBA43BAC1E9F20B3C91B /* AFNetworking.framework */,
-				0106797BAE2ED118E6D8122C481FC9F9 /* Pods_VimeoNetworkingExample_iOS.framework */,
-				BCB980BE9981DC8E5A295C5D0027B0FE /* Pods_VimeoNetworkingExample_iOSTests.framework */,
-				4E4202A8073C443FB9D8BD532B4A7BC5 /* Pods_VimeoNetworkingExample_tvOS.framework */,
-				A15C52D1C0A52BA6B67D7DC20D50AAFD /* Pods_VimeoNetworkingExample_tvOSTests.framework */,
-				9639109B9B7D36BF609DEF55AD42327C /* VimeoNetworking.framework */,
-				A73C6BBEAB94BD69D956C03A91FE3CDE /* VimeoNetworking.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		A1CD90C751A82476D05AEB31EDB35BF1 /* Resources */ = {
@@ -1079,6 +1118,26 @@
 			);
 			name = Resources;
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		A3F8DA29BAF8A94C402A5A03DF760910 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				14BE0669B4AB8716AC03D24A4CD39075 /* AFNetworking-iOS.modulemap */,
+				F3B50CA5DBD3C703633433A24E0BA3E9 /* AFNetworking-iOS.xcconfig */,
+				13D39574532297EB9CBA2F2A62390B6F /* AFNetworking-iOS-dummy.m */,
+				7EDC471AA7714F97A8DED01B8E900FAF /* AFNetworking-iOS-prefix.pch */,
+				2F655D6685258FAA14B2C835CE892B04 /* AFNetworking-iOS-umbrella.h */,
+				F7778C56F9709864691BA8462D7F9A3B /* AFNetworking-tvOS.modulemap */,
+				47AD238FFE71102DE91076A285FEC92D /* AFNetworking-tvOS.xcconfig */,
+				6259AB2BD4828E47BBDE327788AC3F48 /* AFNetworking-tvOS-dummy.m */,
+				CA058F48C0461AC00354C9BDE962A4CA /* AFNetworking-tvOS-prefix.pch */,
+				B4657CB2ADE8C4AF346AEA36B72FEC77 /* AFNetworking-tvOS-umbrella.h */,
+				C2C44652A24A9876E7DBB90AB443932E /* Info.plist */,
+				B213A61E0B596B45EABF35247CF6280B /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AFNetworking-iOS";
 			sourceTree = "<group>";
 		};
 		B03589161BFC47B9EF002EF08B913B3F /* Frameworks */ = {
@@ -1095,11 +1154,26 @@
 			isa = PBXGroup;
 			children = (
 				26EB1D31BC77348BB0E84B92B64E6203 /* Resources */,
-				86E9F4B6B8D5248257A7C9EA08FC6210 /* Support Files */,
-				87B87AB3F9A6E72EA79706144317FF7C /* VimeoNetworking */,
+				60F9BD7F950D89907CC1E90AB86AD7BB /* Support Files */,
+				E3EF7BE783E074A9C3B210CDD6BD7ABF /* VimeoNetworking */,
 			);
 			name = VimeoNetworking;
 			path = ..;
+			sourceTree = "<group>";
+		};
+		C773D56F22E407225D39472178756752 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C333D8536784D7F8F7AA9E27E467448C /* AFNetworking.framework */,
+				838F6464C6A34E1C64562753D651AE6F /* AFNetworking.framework */,
+				FD88C84C31B6D8271B17972645BBE071 /* Pods_VimeoNetworkingExample_iOS.framework */,
+				E05B84759072C50968313917642DF417 /* Pods_VimeoNetworkingExample_iOSTests.framework */,
+				F42093CF175056BE79EA7548EF1134CA /* Pods_VimeoNetworkingExample_tvOS.framework */,
+				B4DFD744814E9D8AE3BF951576FCE3B8 /* Pods_VimeoNetworkingExample_tvOSTests.framework */,
+				0FFF03E2945BFCB7DDFF8DD8D8B46E44 /* VimeoNetworking.framework */,
+				F26D6C88FF5CFB1FB47860D56F3DB453 /* VimeoNetworking.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		C7DBF26A7DACB259623269D8DA67BAA6 /* Pods-VimeoNetworkingExample-tvOS */ = {
@@ -1120,26 +1194,6 @@
 			path = "Target Support Files/Pods-VimeoNetworkingExample-tvOS";
 			sourceTree = "<group>";
 		};
-		C970000798EC824E2A9DDEDBD3722918 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				6A9C4FDB9A3DDA23335A7D6032EFED9F /* AFNetworking-iOS.modulemap */,
-				01E7FC57F3D5796FAD0A58C0F557C64F /* AFNetworking-iOS.xcconfig */,
-				B3EAC33181285B8B24E63F3B5AF614CC /* AFNetworking-iOS-dummy.m */,
-				71EBA73783D5283183880498238D59B1 /* AFNetworking-iOS-prefix.pch */,
-				936C6D8DA5D4BEFE2939FFBF42346516 /* AFNetworking-iOS-umbrella.h */,
-				F50A97C60AC05E295ADA9C3A95333BE1 /* AFNetworking-tvOS.modulemap */,
-				10C9C351A7E075F52C531993712EE452 /* AFNetworking-tvOS.xcconfig */,
-				B45352B75935A1039A3343B2CA62C4E3 /* AFNetworking-tvOS-dummy.m */,
-				0E3A58D5510DD7F3F27CF8589C49D193 /* AFNetworking-tvOS-prefix.pch */,
-				948D643DF3F7192C27FF5E8BD7064A4F /* AFNetworking-tvOS-umbrella.h */,
-				F476E42ECF336A8587D662E6BB7CC91B /* Info.plist */,
-				943C2B437428D28F13EE2D269C913619 /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AFNetworking-iOS";
-			sourceTree = "<group>";
-		};
 		D5B76FAE4783960A76935D82DD35FD78 /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
@@ -1148,62 +1202,20 @@
 				023129B9A43E1D6BF3F71DADA4577489 /* Reachability */,
 				3DD095075DDEE08F0024D4E104F6C4DA /* Security */,
 				470754758B28E84B2707373AE157047C /* Serialization */,
-				C970000798EC824E2A9DDEDBD3722918 /* Support Files */,
+				A3F8DA29BAF8A94C402A5A03DF760910 /* Support Files */,
 				F7B36E73805E91170446EF6612AD2937 /* UIKit */,
 			);
 			name = AFNetworking;
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
-		EA1335650BC9A69D19C2680F21B02C90 /* Sources */ = {
+		E3EF7BE783E074A9C3B210CDD6BD7ABF /* VimeoNetworking */ = {
 			isa = PBXGroup;
 			children = (
-				CBEE62B26CD90E5B64946B696500786C /* AccountStore.swift */,
-				E8ECCC343EB76513F98BCE43E3C62A63 /* AppConfiguration.swift */,
-				98D415A26C2C8901948B30CC37B4F5EF /* AuthenticationController.swift */,
-				00FB7F79E9CBCC5B81B00434F8F8FA1C /* Constants.swift */,
-				A6154623B4613F057480E0DBFB7FF50C /* ErrorCode.swift */,
-				C4FB75AF1632C64351A746EBE8143C71 /* ExceptionCatcher+Swift.swift */,
-				D13AFDE4971226993D6B394BB494A1BF /* KeychainStore.swift */,
-				A7F658D9E363552377641D391AEABBDE /* Mappable.swift */,
-				3A375AEE2A37C0735E690CA1AC8A685C /* Notification.swift */,
-				82B7210BF3175AE9477B1365623B889C /* NSError+Extensions.swift */,
-				54F45BAC7FFA5FCFA7AFACF9AB1D0F12 /* NSURLSessionConfiguration+Extensions.swift */,
-				26B92B499A5D5B2A31470AFDFA787984 /* Objc_ExceptionCatcher.h */,
-				1D8FA677EDCA290CE81578A58D796802 /* Objc_ExceptionCatcher.m */,
-				12E4F26C178839F4809F1A26D06153A9 /* Request.swift */,
-				805AA9E647399745D11A6706FC5DD81A /* Request+Authentication.swift */,
-				91872B936AE6EE73A9B644B3EA3F715A /* Request+Cache.swift */,
-				A4B37124BF2D0C922CE03CB58867A210 /* Request+Category.swift */,
-				5538B95260F5A16330F27CC496C0E64B /* Request+Channel.swift */,
-				F927D4B012FBD352564066F8BF470052 /* Request+Comment.swift */,
-				ADE6546E0C59DB3C0BAA64D0C2EA01A6 /* Request+Configs.swift */,
-				D94F7CC0224824E9546F4B501DB03573 /* Request+Notifications.swift */,
-				0B1DF9AB6F331C77CA71DD6B7E255D9E /* Request+Picture.swift */,
-				B5DC7D5950400DB7546EECE5B0D4D25F /* Request+PolicyDocument.swift */,
-				684CAAA7E1F06FFB876478090C3C8DD3 /* Request+ProgrammedContent.swift */,
-				4F34FEADA1EA0CF060F7EBD86CA8204C /* Request+Soundtrack.swift */,
-				FDB38341FA26EB67D0360778AB8263BB /* Request+Toggle.swift */,
-				0802A3F20A40169F2385826DC8492AA9 /* Request+Trigger.swift */,
-				F8176C5051EFDE888C571B411FFC422D /* Request+User.swift */,
-				87AF35296C8C00D637F4BB34E969A220 /* Request+Video.swift */,
-				669BE8F834243C35434C4FB5ED83D6DF /* Response.swift */,
-				7011A73F3E0BF3B5467B0308C532EC85 /* ResponseCache.swift */,
-				7F1410805711F5C3B8C5349F7A54B879 /* Result.swift */,
-				D8E671C023C7983DC6DEFF18A3ECE49C /* Scope.swift */,
-				7A68E5D954E9C3C2E6092B1B67A3E1E6 /* String+Parameters.swift */,
-				69F5994649FBA3A14B23B23D3FCA85A2 /* VimeoClient.swift */,
-				48E669C24E4A5A0BA40872A681A7568F /* VimeoNetworking.h */,
-				CE65005CFBE682C530A83C14F4149BDB /* VimeoReachability.swift */,
-				1589730830A01A361F90E6967F2D67DB /* VimeoRequestSerializer.swift */,
-				93D09E94BEF337DFC92D742834825936 /* VimeoResponseSerializer.swift */,
-				70DBC77E4281BD8A9FCF17C27BC6645D /* VimeoSessionManager.swift */,
-				9E11A064A120789D57ACC2CB6EDA9526 /* VimeoSessionManager+Constructors.swift */,
-				30C952C24463AAB0C85837069ED51E33 /* VIMObjectMapper+Generic.swift */,
-				27FBC7EC13DBF2E5175B84BB62B80632 /* Models */,
+				0B4069CC555C5F51AB5323FEC348F24F /* Sources */,
 			);
-			name = Sources;
-			path = Sources;
+			name = VimeoNetworking;
+			path = VimeoNetworking;
 			sourceTree = "<group>";
 		};
 		EA1D4B2EA91A2001CE5FDA688BE516AF /* NSURLSession */ = {
@@ -1331,123 +1343,125 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7049B87CA207D9823B5A819C2B1C466E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C2D89F4FAC93BD7C08A16E3738E4052 /* Objc_ExceptionCatcher.h in Headers */,
+				5D2B70BA11DC4158D6EA6579918A1ACD /* VIMAccount.h in Headers */,
+				BF342849A1A8951FFED401FF23266433 /* VIMActivity.h in Headers */,
+				25718A6CB80EC175052A59DCD78C495D /* VIMAppeal.h in Headers */,
+				4ADECAF00F508DEDF6FB535B1C723AC0 /* VIMCategory.h in Headers */,
+				240D069658A3F857B8274F7EA67B3CCC /* VIMChannel.h in Headers */,
+				1A383D4B32F2B4CA1207C5B1BE849C4F /* VIMComment.h in Headers */,
+				5F2EF10247DB9374BD0CB9294CB0D365 /* VIMConnection.h in Headers */,
+				A5424078D239128F554ED685E3473A5D /* VIMCredit.h in Headers */,
+				8867D2940ED47BB9D46CEAEE4C2E137C /* VimeoNetworking-iOS-umbrella.h in Headers */,
+				CC788AB866FEC293C934A720A2187C2A /* VimeoNetworking.h in Headers */,
+				A3F1B72D861DC9FFCCBF2504D3A2B61F /* VIMGroup.h in Headers */,
+				4C72A34C04C343E27E3C442987A0E6B3 /* VIMInteraction.h in Headers */,
+				837C51114EDE83B70FF846CE0C35938C /* VIMMappable.h in Headers */,
+				13DFE8302344490FD08197B7C1B19D90 /* VIMModelObject.h in Headers */,
+				6CC19E53AC93DE3EF8FC23AF19B11361 /* VIMNotification.h in Headers */,
+				EE9BFE4D612B0EF2A0A484F5DAE35643 /* VIMNotificationsConnection.h in Headers */,
+				0F41AB9FD84B4638AF824B084266FD8A /* VIMObjectMapper.h in Headers */,
+				7DC0EF19CAFD463DE669FFA314A90773 /* VIMPicture.h in Headers */,
+				17B4638A0B274CADDBCE8028EC5924A9 /* VIMPictureCollection.h in Headers */,
+				7D80822A38476954EDB66A5ECE9B3B40 /* VIMPolicyDocument.h in Headers */,
+				45A5D144B01BCC04F9E3D82FFDA22C32 /* VIMPreference.h in Headers */,
+				D9A152488EA121DABF605337B3216B13 /* VIMPrivacy.h in Headers */,
+				6F65585C038B1D3E500D17EA3E4F984C /* VIMQuantityQuota.h in Headers */,
+				70A20145EFE75465C38A118E93AAFB97 /* VIMRecommendation.h in Headers */,
+				D29F5CC38020546CD4015E0E16ABC6F7 /* VIMSeason.h in Headers */,
+				1553686AA956EFA70B1B260F710BF440 /* VIMSizeQuota.h in Headers */,
+				0337FF15FAB682618D5E478C0F576E0E /* VIMSoundtrack.h in Headers */,
+				B0EA8A5832D64AF78E78963401468E52 /* VIMTag.h in Headers */,
+				BC3E54D748CD5770B404CB11C97F49A4 /* VIMThumbnailUploadTicket.h in Headers */,
+				910AE9F89C1EFA6DDD46FDFD1C7153A5 /* VIMTrigger.h in Headers */,
+				59F0D2BE21C4ADCF91396A8576F00DFF /* VIMUploadQuota.h in Headers */,
+				40AD347FF4BB155BBBBD7343C9C0F231 /* VIMUploadTicket.h in Headers */,
+				E81C76ECA26C42F8F9BB680B129158A8 /* VIMUser.h in Headers */,
+				10D3BA72E42EA8D162BDAEA36A007030 /* VIMUserBadge.h in Headers */,
+				3E76297663E04487B1C9D3E4C33CADF4 /* VIMVideo+SVOD.h in Headers */,
+				AA7A509B413506DE9C44B05C3DCAC80F /* VIMVideo+VOD.h in Headers */,
+				AD4AC0BF479A3097B2B6A412009425B1 /* VIMVideo.h in Headers */,
+				471D8301D3C8DE724E94E64BFD83EAA3 /* VIMVideoDASHFile.h in Headers */,
+				72A33279880FF20C244EA0069BBEED56 /* VIMVideoDRMFiles.h in Headers */,
+				279603356888B3B2041E2CDE50423CF3 /* VIMVideoFairPlayFile.h in Headers */,
+				19F0AF17BE426F63B5A354DC27373590 /* VIMVideoFile.h in Headers */,
+				3A6EE5B9CA6805E7D9A5A9D160365FBD /* VIMVideoHLSFile.h in Headers */,
+				747D0C3E1A4B0C78E5C7C90B28E5852C /* VIMVideoPlayFile.h in Headers */,
+				FF7B05BB285B84507BFA114FEC22157E /* VIMVideoPlayRepresentation.h in Headers */,
+				18F263C0E0DAF5D8202F23E53A305471 /* VIMVideoPreference.h in Headers */,
+				421293F489569363A6EA8461507BE8D1 /* VIMVideoProgressiveFile.h in Headers */,
+				C14D5688344FEFC33D324ADB3456D3D3 /* VIMVideoUtils.h in Headers */,
+				9E2E5481CD74924F5A8F6D7906BD9534 /* VIMVODConnection.h in Headers */,
+				8B7A222E509AC4849C2EF5CB7C8ACFEC /* VIMVODItem.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7BC8B34A0FECE2FF7013811EA1A0A6B6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEA41A6D01A2AEC8C6415C70E9188E82 /* Objc_ExceptionCatcher.h in Headers */,
+				11C4C4B213448E8E6F1A000E9F076B4A /* VIMAccount.h in Headers */,
+				9CB8505AF1BF06B190F2497F1A22CA3F /* VIMActivity.h in Headers */,
+				D8C8766A46EFE16B07589D9CB05090BE /* VIMAppeal.h in Headers */,
+				84A0ED33B6BCAC1C1E9738E92960E235 /* VIMCategory.h in Headers */,
+				ADEDCA7FFC59157A1F8E8D4BF8DC292D /* VIMChannel.h in Headers */,
+				D90A4E363C9A6E6CC9203C0C53D9E0DE /* VIMComment.h in Headers */,
+				A6BF36DBEE0930576AD51BAF917A19A4 /* VIMConnection.h in Headers */,
+				C5468F34FC6E9F58C81994AF3516E89E /* VIMCredit.h in Headers */,
+				FBA12830D8CF7CCF13B9C2CD44917448 /* VimeoNetworking-tvOS-umbrella.h in Headers */,
+				7D13135432BCC564E672803619EC85B9 /* VimeoNetworking.h in Headers */,
+				C624409EC98B15E29276012F8BE0C469 /* VIMGroup.h in Headers */,
+				46D17B4256B20D2975A12263E9BB6E8F /* VIMInteraction.h in Headers */,
+				4414C2BE5EA37A450A5FF8BBC78BF7A3 /* VIMMappable.h in Headers */,
+				907131ACBE86D6BC513A5A6A419F699B /* VIMModelObject.h in Headers */,
+				D7E7A1FEFBEC43602F4EBB393EE9BBD1 /* VIMNotification.h in Headers */,
+				5EC2569A896397A308E71A2C1A3DF219 /* VIMNotificationsConnection.h in Headers */,
+				D8849F8CCB0FE22D8A97E04455356E82 /* VIMObjectMapper.h in Headers */,
+				4DEE5F146D8FFDC27DBB40E98526BEE3 /* VIMPicture.h in Headers */,
+				DB7DB6C28957ABCC1103C650EA7A03FC /* VIMPictureCollection.h in Headers */,
+				1C68E92EB435B78038273C8AC63BC380 /* VIMPolicyDocument.h in Headers */,
+				8B1DF6CFC392DAE357840CB5984D322F /* VIMPreference.h in Headers */,
+				CD7DF9469F2EBB8AE99B74DB9BE31924 /* VIMPrivacy.h in Headers */,
+				9C0657EE5B3F82F88846CBE56F3313A6 /* VIMQuantityQuota.h in Headers */,
+				4396512027103A5A5CBB7E59C39C0F4A /* VIMRecommendation.h in Headers */,
+				2E838A982F3E9E443BBB46E3AFA9FD19 /* VIMSeason.h in Headers */,
+				6F338B1C849A84DF7D63EE4E99E37F96 /* VIMSizeQuota.h in Headers */,
+				4EFFCE0B3A801753E6779E7EF94CA58A /* VIMSoundtrack.h in Headers */,
+				439963B2C27DB6A471408D974B439F50 /* VIMTag.h in Headers */,
+				A8D2D202D4C07B7BACD6EAA2D39B2417 /* VIMThumbnailUploadTicket.h in Headers */,
+				389F2EE461219398F4EA7DF88D80B61C /* VIMTrigger.h in Headers */,
+				794BFC62C030F45F77B8BEEECCB0354B /* VIMUploadQuota.h in Headers */,
+				CC6078F2D5E91B0CE1CBA29C4978FBC5 /* VIMUploadTicket.h in Headers */,
+				9B71371B36FAB303C669C7FD78C83EC1 /* VIMUser.h in Headers */,
+				96903E8D8A907273BE333E0193BF683E /* VIMUserBadge.h in Headers */,
+				F256CE84F45C161960C84EE6FE032171 /* VIMVideo+SVOD.h in Headers */,
+				570267FEE2CF302BA3CB89C4B628952E /* VIMVideo+VOD.h in Headers */,
+				8D585CF9CC891A53EE60A45ADF57E671 /* VIMVideo.h in Headers */,
+				F3CCC66FC75B9BA44FCFC278C8E3A167 /* VIMVideoDASHFile.h in Headers */,
+				2344A881B3879979DCBF15725946DF8D /* VIMVideoDRMFiles.h in Headers */,
+				7ACCC8EE65205F97F9EA2EC0FE9B666F /* VIMVideoFairPlayFile.h in Headers */,
+				82F67AA0A0AF7C0DD82A4C017213B0D2 /* VIMVideoFile.h in Headers */,
+				470CBD3CBADA92A738ED83159487F8F8 /* VIMVideoHLSFile.h in Headers */,
+				06F54812A811BD886B505E54B2FDBC06 /* VIMVideoPlayFile.h in Headers */,
+				9EC83E495F458EFB8A02A13C56B9B52F /* VIMVideoPlayRepresentation.h in Headers */,
+				77F285F3622DE18D8E824D8C266D3268 /* VIMVideoPreference.h in Headers */,
+				3626D9D2C451F6888BB176F9478C780D /* VIMVideoProgressiveFile.h in Headers */,
+				407A8D13C01E169C0D8D007B79BA6EFA /* VIMVideoUtils.h in Headers */,
+				8F3F391C0053559FEA23F7F90BB63D73 /* VIMVODConnection.h in Headers */,
+				33B1DF181BB86C8A02497A189B93195F /* VIMVODItem.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AB3BA7D0ED92D0B1E4F1383E7163A130 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				2A7031B240241BE149403740E51DEA3E /* Pods-VimeoNetworkingExample-iOSTests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CC2979F3EF5CD1DADEAE1CB5B5A0AAE4 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FBAA0FF3E3B25AFA51A5D06756BFEE0C /* Objc_ExceptionCatcher.h in Headers */,
-				E998128ED93545DC18A05AD6DB1D6CDE /* VIMAccount.h in Headers */,
-				71CDD7C40CDF92E444CF869C6505250F /* VIMActivity.h in Headers */,
-				C7227FEF3F64B4122338A4F2A9FD6E63 /* VIMAppeal.h in Headers */,
-				F564FCEA964A0C89B96AFF7DE5553002 /* VIMCategory.h in Headers */,
-				05F98B8B879E3614D7FFDE3B78B6207E /* VIMChannel.h in Headers */,
-				DC26B35D135A0918C05958134223ED87 /* VIMComment.h in Headers */,
-				455FE5E94D7523461E557270A9719790 /* VIMConnection.h in Headers */,
-				995AB2C105128EBA13C6B120720691C0 /* VIMCredit.h in Headers */,
-				3266BCD41650DDEC344DBBE9221DD383 /* VimeoNetworking-iOS-umbrella.h in Headers */,
-				D28E06C251E250C089B3FF3372D7A215 /* VimeoNetworking.h in Headers */,
-				8970BA14107BD60EF422212476FB80C7 /* VIMGroup.h in Headers */,
-				ED1B03FC1F0E5FE0EA76EBA9D0817C90 /* VIMInteraction.h in Headers */,
-				6D7068CAB1963C91BCA0A40BEFD0B681 /* VIMMappable.h in Headers */,
-				AED1FF2D8FFD727BD1DC1D9D62889EF2 /* VIMModelObject.h in Headers */,
-				B95C715F729B507EF4E64404897971CC /* VIMNotification.h in Headers */,
-				25F5127CBD826CC9F65336B12A6FDB6D /* VIMNotificationsConnection.h in Headers */,
-				655F0E830FE980C6F6802007EE3B7626 /* VIMObjectMapper.h in Headers */,
-				8D5252EE0BDD0EE7E198A72906EC432F /* VIMPicture.h in Headers */,
-				02A60797AB2E7A22718A7D8D3212F6C7 /* VIMPictureCollection.h in Headers */,
-				13AC18EC5198FA629BE816ACA095C833 /* VIMPolicyDocument.h in Headers */,
-				DFB308FCD8896A53DE485EB962D66B25 /* VIMPreference.h in Headers */,
-				7176B1CCCE595C77FA2252FE8B74F21D /* VIMPrivacy.h in Headers */,
-				C6162B70D30979996AB8420A39FA71FF /* VIMQuantityQuota.h in Headers */,
-				2DEA5341BAE0B6C0173EF66F9FECFAC0 /* VIMRecommendation.h in Headers */,
-				9CF274DC38242FC0F7B51A4E15280033 /* VIMSeason.h in Headers */,
-				CB3240C21FEE3FCFC8E0BFFE7589DB52 /* VIMSizeQuota.h in Headers */,
-				28C5C9896C26F711C23CCDD854862FDC /* VIMSoundtrack.h in Headers */,
-				298108794F0E437EEAE03BEB93F75381 /* VIMTag.h in Headers */,
-				E4D9A13CEB074630927BDC6894F264EE /* VIMThumbnailUploadTicket.h in Headers */,
-				85E0D887455F41BD93EEFCEC6A5FBF1F /* VIMTrigger.h in Headers */,
-				2592B811150ADCC04659DF80BC04EAD5 /* VIMUploadQuota.h in Headers */,
-				1946DF32A19882421A3AA9DA6AAEBCF8 /* VIMUploadTicket.h in Headers */,
-				61811447CB13E5742F4AD326F8A77F31 /* VIMUser.h in Headers */,
-				C2C8F2263389E39FFD1F71A135F0EEDA /* VIMUserBadge.h in Headers */,
-				AABF1D3432FAAE6051C9CDC67C383316 /* VIMVideo+VOD.h in Headers */,
-				AB518EB5625691064576968E6BCBD077 /* VIMVideo.h in Headers */,
-				5C9E0B491C28464F3EDDCC014D740A12 /* VIMVideoDASHFile.h in Headers */,
-				6B597370B50EC5244FE88D90A5E9DAA4 /* VIMVideoDRMFiles.h in Headers */,
-				CCB3878B8DB7468D5D35EE841EEE60DA /* VIMVideoFairPlayFile.h in Headers */,
-				E78817B2FCA75D0553F7FCA25507C05F /* VIMVideoFile.h in Headers */,
-				A97B4234D9DE1963BCFAC21429D554A8 /* VIMVideoHLSFile.h in Headers */,
-				ACE3093CFD280280BD8D187D62004D3A /* VIMVideoPlayFile.h in Headers */,
-				C000C1219EFB19B564633205278B393C /* VIMVideoPlayRepresentation.h in Headers */,
-				F1173E7026E8AE2B280DD9511E6B1689 /* VIMVideoPreference.h in Headers */,
-				EEC61ED199D1840BDFE39B1DEB215C6F /* VIMVideoProgressiveFile.h in Headers */,
-				8141CC4C4553CE8A01C4EFF428565033 /* VIMVideoUtils.h in Headers */,
-				E8889C98EE609F6A7138C39E74F5C687 /* VIMVODConnection.h in Headers */,
-				4A20C03C1E49DA2D7FB94F5333A93232 /* VIMVODItem.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FF3DF014ED6564D123A17A1A37163CC1 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				577D706CD8A0F89A876B5E6ACAFF82DA /* Objc_ExceptionCatcher.h in Headers */,
-				245465FC3D540C6364C1540C3368FD81 /* VIMAccount.h in Headers */,
-				07BA4421114B4A2F5256C3F653D20E49 /* VIMActivity.h in Headers */,
-				407EB4FD52D53E2D608F23A8823AB1DF /* VIMAppeal.h in Headers */,
-				CE1A8711395FB0870EA8FAF66C29F1C5 /* VIMCategory.h in Headers */,
-				031BCFDD19F8FB249C754BD28A1724B1 /* VIMChannel.h in Headers */,
-				51D91DA61BC333F13018A2140B5A8371 /* VIMComment.h in Headers */,
-				C486F3898C0C886D1AF9FA21E5F83039 /* VIMConnection.h in Headers */,
-				23A2AF7EA56FBAD63F2F3EA53B984083 /* VIMCredit.h in Headers */,
-				8FFA7923EAFB15E44CE6F79BCC5C4C29 /* VimeoNetworking-tvOS-umbrella.h in Headers */,
-				FDDEB11EEFD470FE8F04BC188B48A202 /* VimeoNetworking.h in Headers */,
-				82A69DCF203117B065B1E3A01FCABAC8 /* VIMGroup.h in Headers */,
-				292C88882FBD2427CF5C9C0D310024D3 /* VIMInteraction.h in Headers */,
-				0845C2A86AA6AD4793C4229B8EF1ED7F /* VIMMappable.h in Headers */,
-				263EBA42B18AD317152F3623A508546F /* VIMModelObject.h in Headers */,
-				4590E6C1ED55D86D27BE09FCBB3E5028 /* VIMNotification.h in Headers */,
-				E78D0700D94D83F9066502E380DAFCE0 /* VIMNotificationsConnection.h in Headers */,
-				3FEB7CC8C957BD21FE80671A66247BD5 /* VIMObjectMapper.h in Headers */,
-				ECEA6C84DB129376569EC89B555CC437 /* VIMPicture.h in Headers */,
-				31F10A083FE95E039FA8F7723FFD25A5 /* VIMPictureCollection.h in Headers */,
-				0E417D2C7A2F4F6335530A6C9D6D01E9 /* VIMPolicyDocument.h in Headers */,
-				3E2F75EE7DCC3DEB5D79DCAE72016774 /* VIMPreference.h in Headers */,
-				2DD8BC202B641518FCF2B87245DF415E /* VIMPrivacy.h in Headers */,
-				5000685786C5A77370BA993BA4483707 /* VIMQuantityQuota.h in Headers */,
-				303A034795C39A131FB1E9C668E9FBAD /* VIMRecommendation.h in Headers */,
-				9083719EB79EADB8366E3C853BDB8190 /* VIMSeason.h in Headers */,
-				8BE589B4BA75F81FA335FDB898DE973F /* VIMSizeQuota.h in Headers */,
-				D409B113E9442B1EE85D090319C4979D /* VIMSoundtrack.h in Headers */,
-				A2036C720BFB0F96047AC7CEC0399C2F /* VIMTag.h in Headers */,
-				2AFE9AAC5867421AB3B667D56D7C2CE6 /* VIMThumbnailUploadTicket.h in Headers */,
-				12E6FF81A05D29B481CE753644C9F13A /* VIMTrigger.h in Headers */,
-				6E69F059A0F78B124E37C16A4B620380 /* VIMUploadQuota.h in Headers */,
-				0582EC50933C9460FC107CA251126D8F /* VIMUploadTicket.h in Headers */,
-				52ED03F2FA11B674B9B4497A5E6CEA58 /* VIMUser.h in Headers */,
-				5F13101A369895BB854EED64A5DDC822 /* VIMUserBadge.h in Headers */,
-				30BF639ABC808D4DDBE8516518180C40 /* VIMVideo+VOD.h in Headers */,
-				83DCA3621CA7D33C727CEEE4AC072497 /* VIMVideo.h in Headers */,
-				2821073DE94794AA29C18B9CC0F5458A /* VIMVideoDASHFile.h in Headers */,
-				2B0945946493F90217FE5FBD9587ADC6 /* VIMVideoDRMFiles.h in Headers */,
-				A6619736B4DC89136ABBFFDCC1904E36 /* VIMVideoFairPlayFile.h in Headers */,
-				B6C28E3D9192D909B47A1F2A27D97A45 /* VIMVideoFile.h in Headers */,
-				D1AB00B1EEAC45A854CA9BEFBD1D4A7B /* VIMVideoHLSFile.h in Headers */,
-				B0EEA40D4E1EB8BE2BF5F624FF1A2CCB /* VIMVideoPlayFile.h in Headers */,
-				BFF75E28F70D90045D1C1006997F21A5 /* VIMVideoPlayRepresentation.h in Headers */,
-				115968822ECE4190F409994D08BB918C /* VIMVideoPreference.h in Headers */,
-				BC649F571B043518F29C13F64E550CA9 /* VIMVideoProgressiveFile.h in Headers */,
-				75D0AD80CA0FDB50976525AC22732FEE /* VIMVideoUtils.h in Headers */,
-				140E1E78EE8F0BEA0899F38CD230D456 /* VIMVODConnection.h in Headers */,
-				F1C1EAA6C7C94D49A0082D6B0FD2B1CC /* VIMVODItem.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1468,7 +1482,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-tvOSTests";
 			productName = "Pods-VimeoNetworkingExample-tvOSTests";
-			productReference = A15C52D1C0A52BA6B67D7DC20D50AAFD /* Pods_VimeoNetworkingExample_tvOSTests.framework */;
+			productReference = B4DFD744814E9D8AE3BF951576FCE3B8 /* Pods_VimeoNetworkingExample_tvOSTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		3C2B22A1099362A3B44D66033C9AFA55 /* AFNetworking-tvOS */ = {
@@ -1485,16 +1499,16 @@
 			);
 			name = "AFNetworking-tvOS";
 			productName = "AFNetworking-tvOS";
-			productReference = 15BF26706675BBA43BAC1E9F20B3C91B /* AFNetworking.framework */;
+			productReference = 838F6464C6A34E1C64562753D651AE6F /* AFNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		65A499A9A590910089751AF838CEFAEF /* VimeoNetworking-tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C3702D480A1AF5E53C60E4ED7FF049B1 /* Build configuration list for PBXNativeTarget "VimeoNetworking-tvOS" */;
 			buildPhases = (
-				415B158DB907CCB0617291DD35E4A043 /* Sources */,
+				29A7452F072093DC5C8291751D071707 /* Sources */,
 				04D9DF94E020118F1E9DB262D13F4CBB /* Frameworks */,
-				FF3DF014ED6564D123A17A1A37163CC1 /* Headers */,
+				7BC8B34A0FECE2FF7013811EA1A0A6B6 /* Headers */,
 				C9F819C147E80547DAAB836004DBEC25 /* Resources */,
 			);
 			buildRules = (
@@ -1504,7 +1518,7 @@
 			);
 			name = "VimeoNetworking-tvOS";
 			productName = "VimeoNetworking-tvOS";
-			productReference = A73C6BBEAB94BD69D956C03A91FE3CDE /* VimeoNetworking.framework */;
+			productReference = 0FFF03E2945BFCB7DDFF8DD8D8B46E44 /* VimeoNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		6CEB2AA9DFB2A84E6BC4F19A4266FC37 /* AFNetworking-iOS */ = {
@@ -1521,7 +1535,7 @@
 			);
 			name = "AFNetworking-iOS";
 			productName = "AFNetworking-iOS";
-			productReference = FA16B4020ADC3704EC6A8FAD916BE2A3 /* AFNetworking.framework */;
+			productReference = C333D8536784D7F8F7AA9E27E467448C /* AFNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		6F615843116398E08AA767CFF75C55E2 /* Pods-VimeoNetworkingExample-iOSTests */ = {
@@ -1538,7 +1552,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-iOSTests";
 			productName = "Pods-VimeoNetworkingExample-iOSTests";
-			productReference = BCB980BE9981DC8E5A295C5D0027B0FE /* Pods_VimeoNetworkingExample_iOSTests.framework */;
+			productReference = E05B84759072C50968313917642DF417 /* Pods_VimeoNetworkingExample_iOSTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		82B874EF050E4D5EA9F54FD64D640971 /* Pods-VimeoNetworkingExample-iOS */ = {
@@ -1557,16 +1571,16 @@
 			);
 			name = "Pods-VimeoNetworkingExample-iOS";
 			productName = "Pods-VimeoNetworkingExample-iOS";
-			productReference = 0106797BAE2ED118E6D8122C481FC9F9 /* Pods_VimeoNetworkingExample_iOS.framework */;
+			productReference = FD88C84C31B6D8271B17972645BBE071 /* Pods_VimeoNetworkingExample_iOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		A33B0E4A31DD20D2C1A59F59507A100D /* VimeoNetworking-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E456E7B94399D03D0EF914BAB5110170 /* Build configuration list for PBXNativeTarget "VimeoNetworking-iOS" */;
 			buildPhases = (
-				31A088972C2ABA4B77C6458B102F9E69 /* Sources */,
+				CCCFC9D5AFBF9BDC545290751AE57C19 /* Sources */,
 				41A6D27B3358EDB5DE2468CF1D22F5E5 /* Frameworks */,
-				CC2979F3EF5CD1DADEAE1CB5B5A0AAE4 /* Headers */,
+				7049B87CA207D9823B5A819C2B1C466E /* Headers */,
 				0A6E85C3E4A356922EAAC20D06A14AAF /* Resources */,
 			);
 			buildRules = (
@@ -1576,7 +1590,7 @@
 			);
 			name = "VimeoNetworking-iOS";
 			productName = "VimeoNetworking-iOS";
-			productReference = 9639109B9B7D36BF609DEF55AD42327C /* VimeoNetworking.framework */;
+			productReference = F26D6C88FF5CFB1FB47860D56F3DB453 /* VimeoNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		EBA6406B2744DDA1E479453E90A537C6 /* Pods-VimeoNetworkingExample-tvOS */ = {
@@ -1595,7 +1609,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-tvOS";
 			productName = "Pods-VimeoNetworkingExample-tvOS";
-			productReference = 4E4202A8073C443FB9D8BD532B4A7BC5 /* Pods_VimeoNetworkingExample_tvOS.framework */;
+			productReference = F42093CF175056BE79EA7548EF1134CA /* Pods_VimeoNetworkingExample_tvOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1615,7 +1629,7 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 886F4747242E24C902B18D79D841B982 /* Products */;
+			productRefGroup = C773D56F22E407225D39472178756752 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1659,111 +1673,113 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		29A7452F072093DC5C8291751D071707 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4580B9B9E7AD6C55A42ACE850D6F02EA /* AccountStore.swift in Sources */,
+				CB693E0BC6006B8A172805DD3A995546 /* AppConfiguration.swift in Sources */,
+				C8A49BDC2BD2C131536053424CE2A57E /* AuthenticationController.swift in Sources */,
+				84AF828EBE67D8A70BBF07D9A6F1B650 /* Constants.swift in Sources */,
+				E5E3AE0B2F1FF86FA5D1202651EA965F /* ErrorCode.swift in Sources */,
+				C660CC774B4DB38228C63764923129B9 /* ExceptionCatcher+Swift.swift in Sources */,
+				AD23408F78611CDA5D63E894305DFBA3 /* KeychainStore.swift in Sources */,
+				9943585E131232FE86CA151B86E9F8BC /* Mappable.swift in Sources */,
+				10530E42A9D3A786B7A14B63ECBF17CD /* Notification.swift in Sources */,
+				2FCC8E89BCB2F52AC5226A69442D0A85 /* NSError+Extensions.swift in Sources */,
+				508EF7FEB0E46FD8888BD35F326C66C8 /* NSURLSessionConfiguration+Extensions.swift in Sources */,
+				65459214406E6C7668A6B7BEDC91A706 /* Objc_ExceptionCatcher.m in Sources */,
+				6A1FDB975033653489EC97F8A79EEBA5 /* PinCodeInfo.swift in Sources */,
+				9B7623D429E92D46675E6D96FF896732 /* PlayProgress.swift in Sources */,
+				2C7BE2765B134E0638392E21E22A3BA5 /* Request+Authentication.swift in Sources */,
+				050145917E0FA157F3625A3D18F2EB6B /* Request+Cache.swift in Sources */,
+				D1BAF681ED6CDC76A7DA7C4187C7DE03 /* Request+Category.swift in Sources */,
+				4DC858480DA70CC477C4D6047270E487 /* Request+Channel.swift in Sources */,
+				753FE16B4DFB90321CF4096A8D08F793 /* Request+Comment.swift in Sources */,
+				277BAEF4FF899D561B88D99AA9089042 /* Request+Configs.swift in Sources */,
+				18B6EAA62481EC3E6F4E444D336BF45D /* Request+Notifications.swift in Sources */,
+				6A5E7C7AF75702330A69A1917E85F2AA /* Request+Picture.swift in Sources */,
+				C102A69D1EF1FB15552FDE7727423EE0 /* Request+PolicyDocument.swift in Sources */,
+				FD789926F5067CFAEF5199829D7AD0A5 /* Request+ProgrammedContent.swift in Sources */,
+				B8808A2ED9F99C0CDD01F2201F436873 /* Request+Purchasing.swift in Sources */,
+				E8F765EA4CAFA7ACB19FFA30556CB88B /* Request+Soundtrack.swift in Sources */,
+				6B6F91D31027A30E42A75D170E1D9E65 /* Request+Toggle.swift in Sources */,
+				3785DD659AE39F5F91F100491CA1DB10 /* Request+Trigger.swift in Sources */,
+				358AD05968500C6F6C60C794D3D04C7C /* Request+User.swift in Sources */,
+				B97F92E47A255E435F26BF1D8274D7C9 /* Request+Video.swift in Sources */,
+				2B74AB1ED7ED992849D6B56B28FB6B6C /* Request.swift in Sources */,
+				84B3D0193916DDA38D4299CFDC30A726 /* Response.swift in Sources */,
+				C6C08B125A87FB7D49F717766D9F8676 /* ResponseCache.swift in Sources */,
+				DB8D5964D071A54B1D73C1A3FE5B79F2 /* Result.swift in Sources */,
+				E88834A3CF8AE64C89C5FC2BAC3E0E9C /* Scope.swift in Sources */,
+				8AAE3872665437F56D6C6441C3D24493 /* Spatial.swift in Sources */,
+				6016B588D7A827B954DAD8638A162392 /* String+Parameters.swift in Sources */,
+				11CBAEBB88BB65C9439C6CA281C6B3A0 /* Subscription.swift in Sources */,
+				E419A0371CA6150772C77EE1CF64F9AC /* SubscriptionCollection.swift in Sources */,
+				6F816118CEBBC6B6AE314841BDA23584 /* VIMAccount.m in Sources */,
+				781AD58BB50D3E4BE1FA91C8D0ACB544 /* VIMActivity.m in Sources */,
+				EFA1157E9B8C08C6193D8D2361400843 /* VIMAppeal.m in Sources */,
+				A13B6F9EEAC70119FA5B9738E7E0B0FB /* VIMBadge.swift in Sources */,
+				AEF621C8F1C29CDA1F6C64FCFF040193 /* VIMCategory.m in Sources */,
+				6845E89B4666D44D1B40EB21B5A9B8C1 /* VIMChannel.m in Sources */,
+				CBFFEC130063C5AA7FDCA37F379872C2 /* VIMComment.m in Sources */,
+				D542089ADB0B22AF6C79AD8E4575B2EB /* VIMConnection.m in Sources */,
+				D39E938602E0FADB1D8E514CA1DF87F6 /* VIMCredit.m in Sources */,
+				E3D2959B6447A8EDBB3D339E965B2E70 /* VimeoClient.swift in Sources */,
+				746139278E66149DD3F46A4BD9EAB027 /* VimeoNetworking-tvOS-dummy.m in Sources */,
+				A899E92FF645845235F31E2CB23488C2 /* VimeoReachability.swift in Sources */,
+				4381FCC17E10883AE56EE089D722ED12 /* VimeoRequestSerializer.swift in Sources */,
+				4767979687854F3DA71CB98920DFCDD5 /* VimeoResponseSerializer.swift in Sources */,
+				BE58DE274FC1ACBCA55703F6F34D23AC /* VimeoSessionManager+Constructors.swift in Sources */,
+				06A67749D239314447CD697F8392321D /* VimeoSessionManager.swift in Sources */,
+				AA58C040EC269B0F8A3F394FA6E3A7E5 /* VIMGroup.m in Sources */,
+				562BC5475D1790C1E3B63FB960D0CA84 /* VIMInteraction.m in Sources */,
+				C65DE79FC32FD0DBC1518C6909B10C9C /* VIMModelObject.m in Sources */,
+				50BC3C1FD3B0E8792996CFE8270E97DE /* VIMNotification.m in Sources */,
+				BF6D71B553EEAA23104D874B26E4FE7C /* VIMNotificationsConnection.m in Sources */,
+				9581978CD9797E61B4B4245BD2E4A7CC /* VIMObjectMapper+Generic.swift in Sources */,
+				A4215ABE80F276776FDF90573B14827A /* VIMObjectMapper.m in Sources */,
+				A67A524F1BDA4FE60566B342989DF8A3 /* VIMPicture.m in Sources */,
+				42DB1E96793A349DAD67890036C0DAAB /* VIMPictureCollection.m in Sources */,
+				47465988A6FD34408AD786A128335FD6 /* VIMPolicyDocument.m in Sources */,
+				47654015D628778C927D41A545BD538A /* VIMPreference.m in Sources */,
+				71F417159314926E616EF19CD6D28847 /* VIMPrivacy.m in Sources */,
+				808CAFD9B246D2F1A707DA12F72DB8AF /* VIMProgrammedContent.swift in Sources */,
+				1781B2BC0AF2765F20AC1CB63C1A82AE /* VIMQuantityQuota.m in Sources */,
+				8A199838AD3ABD57AF08647A1A91B906 /* VIMRecommendation.m in Sources */,
+				75B6B1DD3ACA837CDEEE8D88F948E6F4 /* VIMSeason.m in Sources */,
+				062305F23AEBBE6BEBE7BCF79E0F8A3D /* VIMSizeQuota.m in Sources */,
+				351C57DCBD6AC41DA2A528CA31868CE7 /* VIMSoundtrack.m in Sources */,
+				349770811D45EB26AE22AD10F840C5E7 /* VIMTag.m in Sources */,
+				2D697C6A1E02DEBFBB3096E76D1687AF /* VIMThumbnailUploadTicket.m in Sources */,
+				0ED32D890D1A269871D9527542BC54BB /* VIMTrigger.m in Sources */,
+				ACA30D3184248FF0CF90516AFB1568C9 /* VIMUploadQuota.m in Sources */,
+				174C8D335CE9E1219B422927E500B2B4 /* VIMUploadTicket.m in Sources */,
+				B494529798EE4A6367A49A1D6FCEFD0B /* VIMUser.m in Sources */,
+				8E5D1EB6D6125FC200B0EA7F8566B530 /* VIMUserBadge.m in Sources */,
+				4C5B7B7689235245C4C7549161E6F7A2 /* VIMVideo+SVOD.m in Sources */,
+				1CD55C53F8615D24BF27D373F35309AC /* VIMVideo+VOD.m in Sources */,
+				FB7E8849EA81EE3357C33D687B8F3216 /* VIMVideo.m in Sources */,
+				7598B794915D2D92F58FB481C0C5DF28 /* VIMVideoDASHFile.m in Sources */,
+				77114475B404C5F02121916B1694F92A /* VIMVideoDRMFiles.m in Sources */,
+				4C8F42808E4DA17CE4BACDE88885E5F6 /* VIMVideoFairPlayFile.m in Sources */,
+				69AAB03BC6DB451CA18DE79846EA943D /* VIMVideoFile.m in Sources */,
+				C604C615AD5891A82A9481F6815573AB /* VIMVideoHLSFile.m in Sources */,
+				46A7C7C0E22D3E37CA4DB77E06119386 /* VIMVideoPlayFile.m in Sources */,
+				3B9C697FE763738B7DBED5913B17D98D /* VIMVideoPlayRepresentation.m in Sources */,
+				0BF4A5799DFA6A339E04619ED82F2A72 /* VIMVideoPreference.m in Sources */,
+				53AB7BF5214785C7D3516CC64D984826 /* VIMVideoProgressiveFile.m in Sources */,
+				619CE60F3806F5FC18321C81B5690EEE /* VIMVideoUtils.m in Sources */,
+				D4857FF5854D312DC38C07533F828CC9 /* VIMVODConnection.m in Sources */,
+				B0FA8BB638763A081212B4CA92ECE71B /* VIMVODItem.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		29F85EE136A993CE127624C2EE427742 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BE3514DE6585828753FD3D98F75BC0B5 /* Pods-VimeoNetworkingExample-iOS-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		31A088972C2ABA4B77C6458B102F9E69 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				15304973B7661FFA03E39681178673ED /* AccountStore.swift in Sources */,
-				8CA1AD6B35BBF47EBED614338C115446 /* AppConfiguration.swift in Sources */,
-				058E91B1AA3886617456D6B5B035486F /* AuthenticationController.swift in Sources */,
-				DEAC1924A02E4F14DAA78231D503419A /* Constants.swift in Sources */,
-				02D5F6EC0061A0EB52863B7F14EC4C98 /* ErrorCode.swift in Sources */,
-				322B32268559EBAEFC01D6305C13F7C6 /* ExceptionCatcher+Swift.swift in Sources */,
-				B6511135962D026FA2D41FC3C6248233 /* KeychainStore.swift in Sources */,
-				222C199D4BD981C70AB0C0BDD41D4C75 /* Mappable.swift in Sources */,
-				117C30C843F11A99E9EF9786A6A7655C /* Notification.swift in Sources */,
-				CB37517595CAC423F6921ACE7211C78E /* NSError+Extensions.swift in Sources */,
-				786F124B93851808CE206803726509E1 /* NSURLSessionConfiguration+Extensions.swift in Sources */,
-				B5E46A80723B608B5E488FBD676D3727 /* Objc_ExceptionCatcher.m in Sources */,
-				C03BE8F1B0E61B5C577BB71A5F6819E0 /* PinCodeInfo.swift in Sources */,
-				51CBA644A87F7D5F815C782D12A3F7F4 /* PlayProgress.swift in Sources */,
-				9D2D98243C5933F819B08452D5823FD4 /* Request+Authentication.swift in Sources */,
-				2027F0DEB9A35B49812AACA06815F86B /* Request+Cache.swift in Sources */,
-				81C1D1C88BAB4552978DB636EDA6F919 /* Request+Category.swift in Sources */,
-				7CFC9B4B2F3BA8566BADA2791A82F38E /* Request+Channel.swift in Sources */,
-				1830609789A44922C8C6F1E2CEC831ED /* Request+Comment.swift in Sources */,
-				8DDA340603EAC5D83A1645A0517C329E /* Request+Configs.swift in Sources */,
-				45DBC372715FD83F2CE0C788EF42EB6D /* Request+Notifications.swift in Sources */,
-				1819D1EC00B5F34DD8DE12529CCC5A70 /* Request+Picture.swift in Sources */,
-				100221D1D5BB45A28687416656FBC1B9 /* Request+PolicyDocument.swift in Sources */,
-				F5E4110001AF7F5A92907BA40AB487DE /* Request+ProgrammedContent.swift in Sources */,
-				3855DF878994B29D1A84B21EED2F6495 /* Request+Soundtrack.swift in Sources */,
-				D1DDBF717F29D80B4BBBB4F2C92B66D3 /* Request+Toggle.swift in Sources */,
-				95B81FE8EA30C7AA436B190F9F8994F5 /* Request+Trigger.swift in Sources */,
-				57FD8C9D831FD88F46755944F85E172F /* Request+User.swift in Sources */,
-				64B5365A7E303534E00D6F4C41225316 /* Request+Video.swift in Sources */,
-				B0C7A40E1A0298D7A3BDAECD5432AF5F /* Request.swift in Sources */,
-				464D217CD9002AB9F37517309B00F579 /* Response.swift in Sources */,
-				201A60069A6182C7BD433AB1EA218722 /* ResponseCache.swift in Sources */,
-				FB1725656EBF9072D99E14E52B2D959D /* Result.swift in Sources */,
-				F94AA75025B14E2EF2786566701DFC3C /* Scope.swift in Sources */,
-				CE29B83FBAF2A81E567030AA586FFFBC /* Spatial.swift in Sources */,
-				9B501397CE6DBCD0F429119089B50015 /* String+Parameters.swift in Sources */,
-				DC4EF5BC6145725173627B8676111C0E /* Subscription.swift in Sources */,
-				574D4F20FEE227D98DCC1C529827C88D /* SubscriptionCollection.swift in Sources */,
-				FB0A40E6838E63050E8ABDF9C941A4FF /* VIMAccount.m in Sources */,
-				4B82F0596669196ED2BA3FA100D3425D /* VIMActivity.m in Sources */,
-				AA60314EC9AA305715FF49E69E60687E /* VIMAppeal.m in Sources */,
-				2EB1232A651A2552C351F852320C6762 /* VIMBadge.swift in Sources */,
-				4F52E3ACDF979F439590609D309EA457 /* VIMCategory.m in Sources */,
-				1FB22E70D190645B26B1F0BC92E1CCDF /* VIMChannel.m in Sources */,
-				9B0C720A6B769D9BC04C35ED835B59DB /* VIMComment.m in Sources */,
-				82A6A3D6B8FD3EDE1F49CB262B9CE44F /* VIMConnection.m in Sources */,
-				146612F56E89AEA20516389E1E97BF91 /* VIMCredit.m in Sources */,
-				5C32CE5F88F45247288766384AE9CE5D /* VimeoClient.swift in Sources */,
-				036605CE55A074714314FD2FEF5983C9 /* VimeoNetworking-iOS-dummy.m in Sources */,
-				2D99BFB92138465C854AD3C5384D6A75 /* VimeoReachability.swift in Sources */,
-				0006266C44A6C58EAD4032169F6D9A57 /* VimeoRequestSerializer.swift in Sources */,
-				E03638779639ED6E81D96E6BABB6152A /* VimeoResponseSerializer.swift in Sources */,
-				1504470FE94783C6049BFD44B47925FF /* VimeoSessionManager+Constructors.swift in Sources */,
-				6C34DC7801F7246417633D5E29E93AD4 /* VimeoSessionManager.swift in Sources */,
-				E90973CE9DD7CFF7689D914655115C93 /* VIMGroup.m in Sources */,
-				93C5DDAD2D2BF508DEC653C50CEEE0C1 /* VIMInteraction.m in Sources */,
-				F982426A719895E299E753E07E63E416 /* VIMModelObject.m in Sources */,
-				B58D4D6E1CC96BAD08BC807C6A2E4795 /* VIMNotification.m in Sources */,
-				4830B2E7A8067EB3F107582F4D4B3E48 /* VIMNotificationsConnection.m in Sources */,
-				4AC651A094079C72BC176FB29DE21B2F /* VIMObjectMapper+Generic.swift in Sources */,
-				0B996EFCB302003B448F6BD1C3DA980D /* VIMObjectMapper.m in Sources */,
-				49A8F1A96FA359CCAF34BDFF67754BE1 /* VIMPicture.m in Sources */,
-				B70CAB4AD407CF277EB53C72073B15E8 /* VIMPictureCollection.m in Sources */,
-				F47412D3769D21E5F845607454B76108 /* VIMPolicyDocument.m in Sources */,
-				2C8976A22F21DD1B0354AEE2BFEF52B0 /* VIMPreference.m in Sources */,
-				9DBBFA368AC396198066247066F6E52B /* VIMPrivacy.m in Sources */,
-				1C0294A1385E9857BB86FA1B35DAABB0 /* VIMProgrammedContent.swift in Sources */,
-				D833DDC5DBFEA3CB360E564E4B487111 /* VIMQuantityQuota.m in Sources */,
-				B49190D8E31D20ACB6B9F27C9ADA6451 /* VIMRecommendation.m in Sources */,
-				40973460F8DD37CD1D0989FCF848439F /* VIMSeason.m in Sources */,
-				4663D81DE5B993B40529369D21B657E1 /* VIMSizeQuota.m in Sources */,
-				8E2AC23055C05A41096F25E567C661A9 /* VIMSoundtrack.m in Sources */,
-				0873AB02BC05BDF8CAA155C1CD206B9C /* VIMTag.m in Sources */,
-				37C582939B5F7DC57834CE49FE56DBE6 /* VIMThumbnailUploadTicket.m in Sources */,
-				A07E57598ABB781C51F717C54FD0B7EF /* VIMTrigger.m in Sources */,
-				19953558576AADEB3917F2E3272659A1 /* VIMUploadQuota.m in Sources */,
-				5895781244B1CE73F8CC81A53A6F41AC /* VIMUploadTicket.m in Sources */,
-				02EDE0EFDD1B36E5A6C45C95DFC7C933 /* VIMUser.m in Sources */,
-				FAC2E673E46BF682E4E01C2D45327F81 /* VIMUserBadge.m in Sources */,
-				9778E8A25EE1F2F2C7D6AA2DD51195B7 /* VIMVideo+VOD.m in Sources */,
-				08C597630C6D082FC8EBDA042F0F4F7E /* VIMVideo.m in Sources */,
-				6D626350217F9FB359C4086BF65A7683 /* VIMVideoDASHFile.m in Sources */,
-				90E5B69E9DA9968C585400998C7215E2 /* VIMVideoDRMFiles.m in Sources */,
-				03F6A5681601B109067376CBA944C060 /* VIMVideoFairPlayFile.m in Sources */,
-				4BB7780199EBCB61A791DD1E13AE126F /* VIMVideoFile.m in Sources */,
-				14C27DA867F7BBCDDBC1034CC74D9A00 /* VIMVideoHLSFile.m in Sources */,
-				3186A7ED24DD708275431B9B598AFA8A /* VIMVideoPlayFile.m in Sources */,
-				E0A4618A17DF9FFAF36B3C1503E487D6 /* VIMVideoPlayRepresentation.m in Sources */,
-				E1238B29910205070D736EE3D713BCFB /* VIMVideoPreference.m in Sources */,
-				94BC8F01979CDDE388262BC05FEC4FDA /* VIMVideoProgressiveFile.m in Sources */,
-				6B299CC8783E85DA94E1117C56A72B5A /* VIMVideoUtils.m in Sources */,
-				C97FA1BD01FF8502006FA3B899DD7455 /* VIMVODConnection.m in Sources */,
-				2338A11765CAA409BE4120ED8F6A3D26 /* VIMVODItem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1787,106 +1803,6 @@
 				105BC7B62FD47A2281D6F6F3F100B5F0 /* UIProgressView+AFNetworking.m in Sources */,
 				646094043F88EC0F6CBF6ABCF6F6B108 /* UIRefreshControl+AFNetworking.m in Sources */,
 				A38045A5825E3B7DE0DC4578D5B06746 /* UIWebView+AFNetworking.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		415B158DB907CCB0617291DD35E4A043 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3F8F2DCA2B62902AC6B0679585ED1C73 /* AccountStore.swift in Sources */,
-				A2B019CC61891672D2DAAB0304EBBCAC /* AppConfiguration.swift in Sources */,
-				531A00EEBD3B8318444B041626CD304C /* AuthenticationController.swift in Sources */,
-				D9B3C4268A0DE915980F7E4A27B9E949 /* Constants.swift in Sources */,
-				C2CA6BF49034EA9AC3F33A02F9B9CEB8 /* ErrorCode.swift in Sources */,
-				A93B5764082E991201F5E88CD6A8AB01 /* ExceptionCatcher+Swift.swift in Sources */,
-				DD62436125756BB4BF0C7638953E6BC3 /* KeychainStore.swift in Sources */,
-				925FC087967213BFD500A2E05178D8FB /* Mappable.swift in Sources */,
-				42CAEF3BA70168EB177BF63AC4FD00FD /* Notification.swift in Sources */,
-				F843EA39AF1F66F168112A3C5C6280DF /* NSError+Extensions.swift in Sources */,
-				9BAA801FDC7DBFB3543302853CF59650 /* NSURLSessionConfiguration+Extensions.swift in Sources */,
-				F6BB5D7A7C569953E236938A8525B306 /* Objc_ExceptionCatcher.m in Sources */,
-				B71CBDF592000379AF7CC7F245D237DC /* PinCodeInfo.swift in Sources */,
-				9B473AF317E4D657CC9342D888F9772E /* PlayProgress.swift in Sources */,
-				4C8486DFFDF221453DE0ABC3876AEA21 /* Request+Authentication.swift in Sources */,
-				1B396CBCBD5D185A47DE0F0FFA84BCD8 /* Request+Cache.swift in Sources */,
-				59DBAE90AFE5BA827F27BEF93951A2BF /* Request+Category.swift in Sources */,
-				40BE1F38750259412E6F6A769BC3F188 /* Request+Channel.swift in Sources */,
-				81EA11EB01DCA8D04F99DEBBDF737E24 /* Request+Comment.swift in Sources */,
-				FB95F38D9289F9A11D24428B362BC9FC /* Request+Configs.swift in Sources */,
-				C685087A2147E4DDFBFB6ADAE3E0D68C /* Request+Notifications.swift in Sources */,
-				642ED818A9477FD2AB367325D1485649 /* Request+Picture.swift in Sources */,
-				A78E8102501345127C538D43630F5A6B /* Request+PolicyDocument.swift in Sources */,
-				5C2F630EE801A0DF2EA50F366A233B89 /* Request+ProgrammedContent.swift in Sources */,
-				49A228D9A776D7655EEA89E4AA8E1574 /* Request+Soundtrack.swift in Sources */,
-				D8CCE8DE7BA9756C7EC54CD77FE04BA4 /* Request+Toggle.swift in Sources */,
-				6CE6F3808CD7BD4F766770669C17FEEE /* Request+Trigger.swift in Sources */,
-				FB449A9A92A00880703C67B0EAA09455 /* Request+User.swift in Sources */,
-				11B0ABB4732024E56D85DA5CE35A717E /* Request+Video.swift in Sources */,
-				10F2CCF00FCBF6815E490F5BF1554AE4 /* Request.swift in Sources */,
-				EF01D047ABFD34F4378A7BAC7D209410 /* Response.swift in Sources */,
-				74F2F27A57D4DD80CE12E38D17859981 /* ResponseCache.swift in Sources */,
-				8E66BE8B9E7509A2078D6A148F687FAB /* Result.swift in Sources */,
-				242E754F39362643C3C7CB9763BF4B14 /* Scope.swift in Sources */,
-				EE98D11C9D7F5313D0FBEE74D03A1185 /* Spatial.swift in Sources */,
-				06343579E029D3BDC558031DBAD57168 /* String+Parameters.swift in Sources */,
-				E80D774238007901F37560BC452AF2BC /* Subscription.swift in Sources */,
-				05DFBF0E17065C691921E2DACEC74306 /* SubscriptionCollection.swift in Sources */,
-				DE450C40B04A7D4B1EA505BA7D2E8081 /* VIMAccount.m in Sources */,
-				8B18FB8D93938576C1184F639FB58C9C /* VIMActivity.m in Sources */,
-				50DF7F0693D5E5447ECF55EC28471EC5 /* VIMAppeal.m in Sources */,
-				2F11BC1B1C2369ED61721940DF3B8502 /* VIMBadge.swift in Sources */,
-				E742710537CED7F7EFFEEBC9A1701ACF /* VIMCategory.m in Sources */,
-				442AA267CCF949E75F356C3758CB6255 /* VIMChannel.m in Sources */,
-				4F0DC1F46032BDD53E61FA2DDC33247F /* VIMComment.m in Sources */,
-				5F26EA8E41C3079E66B063F1450195D4 /* VIMConnection.m in Sources */,
-				B01D31927069BA39228C29AA522CABA7 /* VIMCredit.m in Sources */,
-				77371F847DB67642899DD595D6EA60E7 /* VimeoClient.swift in Sources */,
-				BAC3CA0A821A667444E71F332134263E /* VimeoNetworking-tvOS-dummy.m in Sources */,
-				B601CD20F42F70422635A7367BE22A79 /* VimeoReachability.swift in Sources */,
-				880E3CDEBA40B53033719AA0E64C5D2F /* VimeoRequestSerializer.swift in Sources */,
-				688B39E39786B905B219FF39B60FBAFF /* VimeoResponseSerializer.swift in Sources */,
-				359354D8A6FE7403C281E6E16C27B3FC /* VimeoSessionManager+Constructors.swift in Sources */,
-				7DA13F718DE3FF2AC4CFECE68CBB92E6 /* VimeoSessionManager.swift in Sources */,
-				8E8261555B4F3C397051DE725BACAE60 /* VIMGroup.m in Sources */,
-				C35CC60ABB51CD318ED154D8A22A23C3 /* VIMInteraction.m in Sources */,
-				CC484BEBDF1320DD3445B43AA9BA8BDB /* VIMModelObject.m in Sources */,
-				7E717256B6DE6B1B0E908703D101987E /* VIMNotification.m in Sources */,
-				08F37278851D249E9A53DCEDEE6BF7EB /* VIMNotificationsConnection.m in Sources */,
-				E61DD78C2BE9792592BCE0BC197DDC56 /* VIMObjectMapper+Generic.swift in Sources */,
-				2FC1A85B3A509019A065796054419835 /* VIMObjectMapper.m in Sources */,
-				1837566A4F054C2AE34A680EAFA841C2 /* VIMPicture.m in Sources */,
-				37D93C09E94BD28158D8CE96127098D5 /* VIMPictureCollection.m in Sources */,
-				55FA63E5735FD016716E63F331634BC8 /* VIMPolicyDocument.m in Sources */,
-				8E402650A756F2E94B7C1879F2750D10 /* VIMPreference.m in Sources */,
-				9B48B748D0F20BD3E7F9DFC880CEC0DA /* VIMPrivacy.m in Sources */,
-				6C2CFDC9328CC48088F2529F1095F51E /* VIMProgrammedContent.swift in Sources */,
-				8699E1CBDD0FDDBFEA3F13C3FCC8AD97 /* VIMQuantityQuota.m in Sources */,
-				5AF9BBFF3291790C31C333DA4C6E380A /* VIMRecommendation.m in Sources */,
-				B91B7EFBB65A985786AD41D97E1CC4A2 /* VIMSeason.m in Sources */,
-				B5F025475C62E9285585FB45A67D20B5 /* VIMSizeQuota.m in Sources */,
-				A83988DEADA8DCDCC052D20F16754EC6 /* VIMSoundtrack.m in Sources */,
-				45704AFD0CCE70E89337F284CF753B98 /* VIMTag.m in Sources */,
-				88EBCC3ABB0121AE65385DE423E17C81 /* VIMThumbnailUploadTicket.m in Sources */,
-				0200FB7BB157828827A03357698A8F38 /* VIMTrigger.m in Sources */,
-				8CF0CE27E670EEA4E7C8875DCF1B1D09 /* VIMUploadQuota.m in Sources */,
-				C2DEDE9FE77F4C1FBA644D0D511A358C /* VIMUploadTicket.m in Sources */,
-				44D451688916D2C9484F6D36F841CB0D /* VIMUser.m in Sources */,
-				B08138657BFE04DCB7B73A0A4E4F2C43 /* VIMUserBadge.m in Sources */,
-				975A9C53CF43DB62C7B97EFE3F3B0D2C /* VIMVideo+VOD.m in Sources */,
-				A681D2D8F578B32E6C6A8E59BA15E472 /* VIMVideo.m in Sources */,
-				4382084F7BA5EFCA056EC4F6BDF5EF62 /* VIMVideoDASHFile.m in Sources */,
-				EF54F90FAEAF820269C1E932A8D8D185 /* VIMVideoDRMFiles.m in Sources */,
-				13A26B0F01FA7588C5F9BEA706FB6FA1 /* VIMVideoFairPlayFile.m in Sources */,
-				B2E35AE04E999C089CDBE8C0091D4CAA /* VIMVideoFile.m in Sources */,
-				2181111AD9D59DD00A288E59DEAA39F5 /* VIMVideoHLSFile.m in Sources */,
-				4135FC0BAFAA1BB626C5DDAE7296E17F /* VIMVideoPlayFile.m in Sources */,
-				5E14747DDA8AB00385668026C59F23DA /* VIMVideoPlayRepresentation.m in Sources */,
-				34B814BB73BB87795190564A2E2D2DD6 /* VIMVideoPreference.m in Sources */,
-				CB72AE92F5068EA3F4A984365DDC2B93 /* VIMVideoProgressiveFile.m in Sources */,
-				248B23125A054D05958316FFA0F175BB /* VIMVideoUtils.m in Sources */,
-				2417EE870CBC38AD24587E3050E3176D /* VIMVODConnection.m in Sources */,
-				FC2DAF48659FA83C97B30DB9A7F57169 /* VIMVODItem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1918,6 +1834,108 @@
 				104E6876B90B4D50379E4A9A99779FE8 /* UIProgressView+AFNetworking.m in Sources */,
 				6B85FCDF20F6D88B46A33C0CAE76B7DE /* UIRefreshControl+AFNetworking.m in Sources */,
 				07A838805D75951F0C07DFE532F807F7 /* UIWebView+AFNetworking.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCCFC9D5AFBF9BDC545290751AE57C19 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE2E101BE6E02092E3852E9E5FA27EAE /* AccountStore.swift in Sources */,
+				84380A223BD139C9DFFAD3A6E6734964 /* AppConfiguration.swift in Sources */,
+				171A42864B310DE68C8FF95C31EEEC53 /* AuthenticationController.swift in Sources */,
+				F56E9CB98F24BB0C6B814FB75AFCF987 /* Constants.swift in Sources */,
+				C4E216A301F5D2B7C849813B5116155E /* ErrorCode.swift in Sources */,
+				72A4AA6395495E579526A7269F1D111C /* ExceptionCatcher+Swift.swift in Sources */,
+				270DB404580B9C2AE704B82E6BF02C1A /* KeychainStore.swift in Sources */,
+				2A976BB0F0DF361849B79F41B20AC328 /* Mappable.swift in Sources */,
+				02B61471DF8C004F50C48117B354F1D8 /* Notification.swift in Sources */,
+				ED5BB5B55CC9684839A61CECC262311A /* NSError+Extensions.swift in Sources */,
+				802DD040F72B5B0139A6812F7BE91CB4 /* NSURLSessionConfiguration+Extensions.swift in Sources */,
+				C567D1A819CE1C5B880D38F1C5EE734E /* Objc_ExceptionCatcher.m in Sources */,
+				C0485CBD42BFA3F43ACFDA2F84981CDC /* PinCodeInfo.swift in Sources */,
+				E43B9D0A70B0BB3547EB57B2474EC200 /* PlayProgress.swift in Sources */,
+				01C16C6919B93E479D94677F13864DE4 /* Request+Authentication.swift in Sources */,
+				4FBBCF4AA1F767BDD2F028133E8E7411 /* Request+Cache.swift in Sources */,
+				885E89D934793567CA90F84DB4676F36 /* Request+Category.swift in Sources */,
+				07F080B82C14CD3C9D13546FEDA1FD2E /* Request+Channel.swift in Sources */,
+				3E9398865F07736F00AF474DA6519885 /* Request+Comment.swift in Sources */,
+				DBBF767DEDC946F8AC1055B1A7CC9B15 /* Request+Configs.swift in Sources */,
+				AF3AD02F4DD36724B5E662B159EB3804 /* Request+Notifications.swift in Sources */,
+				8FA6D7E4522531133BD1D87D334CA26E /* Request+Picture.swift in Sources */,
+				B6EF3249BA4270C859231F0E24FAC030 /* Request+PolicyDocument.swift in Sources */,
+				EA41C7DA7E5A6BCEB01FA60C7DC4793A /* Request+ProgrammedContent.swift in Sources */,
+				689405D16A5F2C57FCB4576DE10C8154 /* Request+Purchasing.swift in Sources */,
+				221AFD6E11E93254DBA95C7A0427F125 /* Request+Soundtrack.swift in Sources */,
+				F3456F97563F696719D1042E42C728E2 /* Request+Toggle.swift in Sources */,
+				8F80D42848D697E9AE3788A74F6F2317 /* Request+Trigger.swift in Sources */,
+				E7E861D127FA5ED1673C71DD85EAC591 /* Request+User.swift in Sources */,
+				072DD28304E57C0C1B97746E24385F8A /* Request+Video.swift in Sources */,
+				4DE310D9D6DCEF9F95A9937B1CA083DE /* Request.swift in Sources */,
+				6FE507CA6D1CFC53DCC348D8EFB126DE /* Response.swift in Sources */,
+				B3D6E132309F583CCDEB298A6FF48397 /* ResponseCache.swift in Sources */,
+				1BDC7D8F6165CE05A525D51A4BAAC19C /* Result.swift in Sources */,
+				5CDC0CB47AA501BC4435745945FED12B /* Scope.swift in Sources */,
+				EF2404EDC083DA329102FFEA0F2427CB /* Spatial.swift in Sources */,
+				D9C08C1F997787C073D5F671A41229F7 /* String+Parameters.swift in Sources */,
+				A1E1BA14295271BDBADA5085C6504E72 /* Subscription.swift in Sources */,
+				C3170A46191D74997616A1373C6F5EC5 /* SubscriptionCollection.swift in Sources */,
+				F8C3C4F239C59B6C53388A512D0F9EA3 /* VIMAccount.m in Sources */,
+				0D7127BEBD5D3FF944FB142581E64149 /* VIMActivity.m in Sources */,
+				B670217329A7B9989B747ECDDDDF4F81 /* VIMAppeal.m in Sources */,
+				C71E810C647D91CF00CDFB44457BB920 /* VIMBadge.swift in Sources */,
+				C408CFA7BD4ACE0F27863A78A73999C8 /* VIMCategory.m in Sources */,
+				A8DE16E0E7CAF5A7EF82F815F000A5CC /* VIMChannel.m in Sources */,
+				B44BE43A0C091A760504774D6551F5AF /* VIMComment.m in Sources */,
+				5B2C1647A65300DE829DF3DE2897F53C /* VIMConnection.m in Sources */,
+				A78788A0495DABD2829651F7E6391C65 /* VIMCredit.m in Sources */,
+				4DBB41B04D00DA027E5CD2D152C4BADE /* VimeoClient.swift in Sources */,
+				2D2537D525D90C2C1954B7AE20AB6C32 /* VimeoNetworking-iOS-dummy.m in Sources */,
+				E30F51998DC9368FEDB88B2BD022508B /* VimeoReachability.swift in Sources */,
+				751FA6D8D63237F3C3F632560B3B1284 /* VimeoRequestSerializer.swift in Sources */,
+				F3934A6D54B97CC5066CDB0E6CE495D5 /* VimeoResponseSerializer.swift in Sources */,
+				24A8683CB767D39DA29DAD19C066ED9A /* VimeoSessionManager+Constructors.swift in Sources */,
+				AF044584400F136AC2802B1019690678 /* VimeoSessionManager.swift in Sources */,
+				3471E83B817D18AA2122EC844A626E39 /* VIMGroup.m in Sources */,
+				46077B8950E9D08134A414AA2E2F031A /* VIMInteraction.m in Sources */,
+				A395D1071C702CC601592BF100D7F156 /* VIMModelObject.m in Sources */,
+				291CBE9393FB930B45DA941CDE9D82F5 /* VIMNotification.m in Sources */,
+				BFA6BFB26B0B13E985AFFD82C8C67736 /* VIMNotificationsConnection.m in Sources */,
+				6820B239B89F20FEF3BE3FD8AAA81848 /* VIMObjectMapper+Generic.swift in Sources */,
+				CDAF6041E9CC3B34E86288AB8D526D99 /* VIMObjectMapper.m in Sources */,
+				F0304524C51108ECFF0CFC8BC5E67201 /* VIMPicture.m in Sources */,
+				4D5C86FF587706B016555A5791370C97 /* VIMPictureCollection.m in Sources */,
+				68AE584196FA61BA8CBECDA29A7A4F82 /* VIMPolicyDocument.m in Sources */,
+				34C0DA8DE2088E9775D93C1DB8C715E5 /* VIMPreference.m in Sources */,
+				60F922552B4B1E9EDE238F8C9F1BEC37 /* VIMPrivacy.m in Sources */,
+				86C69476A2BC7A7834CB0D2619AB118A /* VIMProgrammedContent.swift in Sources */,
+				ED55C6DDB30EF9B937BE3A1C83045058 /* VIMQuantityQuota.m in Sources */,
+				B402F18717AB6016348F51E2847D68BE /* VIMRecommendation.m in Sources */,
+				A504311D188FAE18FDA214B2D42DC4FF /* VIMSeason.m in Sources */,
+				ACEF2BEE2A6017072523A8424A25AE39 /* VIMSizeQuota.m in Sources */,
+				A711DBA42FB9611FBBEFA07DD18BBAB3 /* VIMSoundtrack.m in Sources */,
+				7DB79FBF2D77644954876F1849703C62 /* VIMTag.m in Sources */,
+				9E21712763B90A76733BE3A373F209C3 /* VIMThumbnailUploadTicket.m in Sources */,
+				73422A4A5AEE4C2A96D31C38AF68F4D0 /* VIMTrigger.m in Sources */,
+				32BC10A002B552CE4020E962FB7BBD5B /* VIMUploadQuota.m in Sources */,
+				22C1F9752CBDCE28BDD4D32C4FD52B80 /* VIMUploadTicket.m in Sources */,
+				CC62B311C4828883FF056B506D1FBE3A /* VIMUser.m in Sources */,
+				92FC328F61FF58E53A2655E052365317 /* VIMUserBadge.m in Sources */,
+				AF27ABC93C5B8070FBEA54251D468223 /* VIMVideo+SVOD.m in Sources */,
+				B65E217EF1F8BB2125A9153CAF5DA5BE /* VIMVideo+VOD.m in Sources */,
+				3F1747447AA3F3AAB21FE9BC7DD0D54D /* VIMVideo.m in Sources */,
+				51770D0B5C43A7D3BDCD31F0D7BD6107 /* VIMVideoDASHFile.m in Sources */,
+				DBCE9BFAEB06DADB0E529833E6273658 /* VIMVideoDRMFiles.m in Sources */,
+				51CA54E2DA27E556CB2E22F65551ED3C /* VIMVideoFairPlayFile.m in Sources */,
+				BE3D8403216071CFE1887687C823458A /* VIMVideoFile.m in Sources */,
+				682F9F1CDB41659C2B5508AF487C7A84 /* VIMVideoHLSFile.m in Sources */,
+				C86311A709F14155020EDFDBF689DFE6 /* VIMVideoPlayFile.m in Sources */,
+				77147384B212D47FB5479E0A47582152 /* VIMVideoPlayRepresentation.m in Sources */,
+				404A63F81D690AFC955DB96DB0CC8124 /* VIMVideoPreference.m in Sources */,
+				3D43BFB25134DE82F1314E9743891D8F /* VIMVideoProgressiveFile.m in Sources */,
+				CAD6530EA2DC2AE22C66037E9205D719 /* VIMVideoUtils.m in Sources */,
+				E073608831BF049AC622540E3A85984D /* VIMVODConnection.m in Sources */,
+				CE3E04511A82712A10DFE475CAF5EEC8 /* VIMVODItem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2009,7 +2027,7 @@
 		};
 		0989E37FA1108D8E191E604CA4752C0E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 01E7FC57F3D5796FAD0A58C0F557C64F /* AFNetworking-iOS.xcconfig */;
+			baseConfigurationReference = F3B50CA5DBD3C703633433A24E0BA3E9 /* AFNetworking-iOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2154,7 +2172,7 @@
 		};
 		54290913DBECCFF7185C273806E39B14 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7D42FD5CB528446DC9EB56EC4C5850A5 /* VimeoNetworking-iOS.xcconfig */;
+			baseConfigurationReference = F681471295C53EB9E733E1E9F7C704E5 /* VimeoNetworking-iOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2304,7 +2322,7 @@
 		};
 		71A6F363EA80A8BB0FE08B32BBB42349 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10C9C351A7E075F52C531993712EE452 /* AFNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = 47AD238FFE71102DE91076A285FEC92D /* AFNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2372,7 +2390,7 @@
 		};
 		B9D65C1F71C9F4A950820691833FA825 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7D42FD5CB528446DC9EB56EC4C5850A5 /* VimeoNetworking-iOS.xcconfig */;
+			baseConfigurationReference = F681471295C53EB9E733E1E9F7C704E5 /* VimeoNetworking-iOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2404,7 +2422,7 @@
 		};
 		C59E02176078D13F7BCAD40B70DAF184 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EF23B1E2D740197B2808DB8BAD1E680 /* VimeoNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = 7BAC228038CF9F33A74FE227474AB51D /* VimeoNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2511,7 +2529,7 @@
 		};
 		DE0876860445B774BCACDB315A276901 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10C9C351A7E075F52C531993712EE452 /* AFNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = 47AD238FFE71102DE91076A285FEC92D /* AFNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2543,7 +2561,7 @@
 		};
 		EDA26C6B061961CD3CC00D41EEB3651C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 01E7FC57F3D5796FAD0A58C0F557C64F /* AFNetworking-iOS.xcconfig */;
+			baseConfigurationReference = F3B50CA5DBD3C703633433A24E0BA3E9 /* AFNetworking-iOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2575,7 +2593,7 @@
 		};
 		F7BD5C47D9B05824DD50ACC2252571F4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EF23B1E2D740197B2808DB8BAD1E680 /* VimeoNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = 7BAC228038CF9F33A74FE227474AB51D /* VimeoNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";

--- a/Pods/Target Support Files/VimeoNetworking-iOS/VimeoNetworking-iOS-umbrella.h
+++ b/Pods/Target Support Files/VimeoNetworking-iOS/VimeoNetworking-iOS-umbrella.h
@@ -34,6 +34,7 @@
 #import "VIMUploadTicket.h"
 #import "VIMUser.h"
 #import "VIMUserBadge.h"
+#import "VIMVideo+SVOD.h"
 #import "VIMVideo+VOD.h"
 #import "VIMVideo.h"
 #import "VIMVideoDASHFile.h"

--- a/Pods/Target Support Files/VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h
+++ b/Pods/Target Support Files/VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h
@@ -34,6 +34,7 @@
 #import "VIMUploadTicket.h"
 #import "VIMUser.h"
 #import "VIMUserBadge.h"
+#import "VIMVideo+SVOD.h"
 #import "VIMVideo+VOD.h"
 #import "VIMVideo.h"
 #import "VIMVideoDASHFile.h"

--- a/VimeoNetworking/Sources/Request+Purchasing.swift
+++ b/VimeoNetworking/Sources/Request+Purchasing.swift
@@ -1,0 +1,49 @@
+//
+//  Request+Purchasing.swift
+//  VimeoNetworkingExample-iOS
+//
+//  Created by Westendorf, Mike on 4/5/17.
+//  Copyright © 2016 Vimeo. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// `Request` to validate an IAP.  Returns the updated VIMUser object after the purchased item has been unlocked.
+public typealias PurchaseRequest = Request<VIMUser>
+
+public extension Request
+{
+    /**
+     Create a `Request` to validate an IAP receipt and unlock the purchased product (Vimeo internal use only)
+     
+     - parameter productURI: the URI of the product to unlock
+     - parameter storeReceipt: the Apple Store receipt
+     - parameter retryPolicy: the retry policy to use for this request.  Defaults to SingleAttempt.
+     
+     - returns: a new `Request`
+     */
+    static func validatePurchaseRequest(productURI productURI: String, storeReceipt: String, retryPolicy: RetryPolicy? = .SingleAttempt) -> Request
+    {
+        let parameters = ["receipt": storeReceipt]
+        
+        return Request(method: .PUT, path: productURI, parameters: parameters, retryPolicy: retryPolicy)
+    }
+}

--- a/VimeoNetworking/Sources/Response.swift
+++ b/VimeoNetworking/Sources/Response.swift
@@ -83,17 +83,17 @@ import Foundation
      
      - returns: an initialized `Response`
      */
-    init(model: ModelType,
-         json: VimeoClient.ResponseDictionary,
-         isCachedResponse: Bool = false,
-         isFinalResponse: Bool = true,
-         totalCount: Int? = nil,
-         page: Int? = nil,
-         itemsPerPage: Int? = nil,
-         nextPageRequest: Request<ModelType>? = nil,
-         previousPageRequest: Request<ModelType>? = nil,
-         firstPageRequest: Request<ModelType>? = nil,
-         lastPageRequest: Request<ModelType>? = nil)
+    public init(model: ModelType,
+             json: VimeoClient.ResponseDictionary,
+             isCachedResponse: Bool = false,
+             isFinalResponse: Bool = true,
+             totalCount: Int? = nil,
+             page: Int? = nil,
+             itemsPerPage: Int? = nil,
+             nextPageRequest: Request<ModelType>? = nil,
+             previousPageRequest: Request<ModelType>? = nil,
+             firstPageRequest: Request<ModelType>? = nil,
+             lastPageRequest: Request<ModelType>? = nil)
     {
         self.model = model
         self.json = json

--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -38,6 +38,9 @@ public enum Scope: String
         /// View Vimeo On Demand purchase history
     case Purchased = "purchased"
     
+        /// App can send purchase receipts to Vimeo server to unlock products
+    case Purchase = "purchase"
+    
         /// Create new videos, groups, albums, etc.
     case Create = "create"
     

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -61,7 +61,13 @@ final public class VimeoClient
         /// The path of the request
         public let path: String?
         
-        private let task: NSURLSessionDataTask?
+        public let task: NSURLSessionDataTask?
+
+        public init(path: String?, task: NSURLSessionDataTask?)
+        {
+            self.path = path
+            self.task = task
+        }
         
         /**
          Cancel the request


### PR DESCRIPTION
#### Ticket
[AF-28](https://vimean.atlassian.net/browse/AF-28)
[TVOS-719](https://vimean.atlassian.net/browse/TVOS-719)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- This PR adds a new extension to the Request structure for generating purchase requests to unlock IAP items.  It also adds a new scope for granting purchasing permissions to the app.  A couple of things were made public, which was necessary in order to create mock objects in the client apps for testing purposes.

#### Implementation Summary

- Request+Purchasing - The new Request extension.  It creates a new request for unlocking purchased items by taking in a uri for the product to unlock and the Apple app store receipt for validation.

- Scope - added a new scope for "purchase"

- Response - made the initializer public so we can create Response objects in mock / testing code.

- VimeoClient - made RequestToken fully public so we can create one in mock / testing code in the client app.

#### Reviewer Tips

- Review this code in the order listed in the Implementation summary above.

#### How to Test

- Needs to be tested in the context of the app changes that will be made to address TVOS-719.