### PR TITLE
TVOS-732: Cachekey

### DIFF
--- a/VimeoNetworking.xcworkspace/xcshareddata/VimeoNetworking.xcscmblueprint
+++ b/VimeoNetworking.xcworkspace/xcshareddata/VimeoNetworking.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "C3D71035A96924D900556ABAF7AF12CFE47E2A44",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "C3D71035A96924D900556ABAF7AF12CFE47E2A44" : 9223372036854775807,
+    "46A27ADFCE516C0BE2A99EB615FE0DF976CA40FC" : 9223372036854775807
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "0658EF35-AF12-4359-8927-015EAC095B38",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "C3D71035A96924D900556ABAF7AF12CFE47E2A44" : "VimeoNetworking\/",
+    "46A27ADFCE516C0BE2A99EB615FE0DF976CA40FC" : ".."
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "VimeoNetworking",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "VimeoNetworking.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.vimeows.com\/MobileApps\/Vimeo-tvOS.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "46A27ADFCE516C0BE2A99EB615FE0DF976CA40FC"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:vimeo\/VimeoNetworking.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "C3D71035A96924D900556ABAF7AF12CFE47E2A44"
+    }
+  ]
+}

--- a/VimeoNetworking/Sources/Dictionary+Extension.swift
+++ b/VimeoNetworking/Sources/Dictionary+Extension.swift
@@ -34,4 +34,17 @@ extension Dictionary
             self[key] = value
         }
     }
+
+    // `toQueryString` transforms a dictionary to a queryString
+    public var toQueryString: String {
+        
+        var output: String = ""
+        
+        for (_, dictionary) in self.enumerated()
+        {
+            output += "&\(dictionary.key)=\(dictionary.value)"
+        }
+
+        return output
+    }
 }

--- a/VimeoNetworking/Sources/Request+Cache.swift
+++ b/VimeoNetworking/Sources/Request+Cache.swift
@@ -32,12 +32,10 @@ public extension Request
     /// Generates a unique cache key for a request, taking into account endpoint and parameters
     var cacheKey: String
     {
-        var cacheKey = "cached" + self.path
+        let url = NSURL(string: self.path)
+        let urlPath = url?.path ?? ""
         
-        if let description = (self.parameters as? CustomStringConvertible)?.description
-        {
-            cacheKey = cacheKey + "." + String(description.hashValue)
-        }
+        var cacheKey = "cached" + urlPath + "." + String(self.path.hashValue)
         
         cacheKey = cacheKey.replacingOccurrences(of: "/", with: ".")
         

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		966F0F0E1E09D5740066DCF0 /* VimeoNetworkingExample_tvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966F0F0D1E09D5740066DCF0 /* VimeoNetworkingExample_tvOSTests.swift */; };
 		A7D414481E2E6FC500B68B14 /* VimeoClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D414471E2E6FC500B68B14 /* VimeoClientTests.swift */; };
 		B6315CBCEC56CC56CDD852C3 /* Pods_VimeoNetworkingExample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAFB88210DDF0B7DB12C7F1D /* Pods_VimeoNetworkingExample_tvOS.framework */; };
+		BEC0E7AA1EA522B70067F100 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC0E7A91EA522B70067F100 /* RequestTests.swift */; };
 		CC22A6749CADF4DA91D73F04 /* Pods_VimeoNetworkingExample_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D22A36411CC71C284010480 /* Pods_VimeoNetworkingExample_iOSTests.framework */; };
 		DEB396A3F44BBFBE9A602F1A /* Pods_VimeoNetworkingExample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46114AFA04898F979611854A /* Pods_VimeoNetworkingExample_iOS.framework */; };
 /* End PBXBuildFile section */
@@ -102,6 +103,7 @@
 		A7D414471E2E6FC500B68B14 /* VimeoClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VimeoClientTests.swift; sourceTree = "<group>"; };
 		AAA8BDDF1F5FAC07D5EBE694 /* Pods-VimeoNetworkingExample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		B922437EFB7C0E4240397B12 /* Pods-VimeoNetworking tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworking tvOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworking tvOS/Pods-VimeoNetworking tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		BEC0E7A91EA522B70067F100 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		C91C8608AAEE4CC821051413 /* Pods_VimeoNetworking_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworking_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAFB88210DDF0B7DB12C7F1D /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF211DD5EBB6830618D3328B /* Pods-VimeoNetworkingExample-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-tvOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 		018B9FAF1C9B34050054650E /* VimeoNetworkingExample-iOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				BEC0E7A91EA522B70067F100 /* RequestTests.swift */,
 				3C6F88821D999878006A24F4 /* programmed_cinema.json */,
 				018B9FB21C9B34050054650E /* Info.plist */,
 				3C6F88831D999878006A24F4 /* FakeDataSource.swift */,
@@ -647,6 +650,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEC0E7AA1EA522B70067F100 /* RequestTests.swift in Sources */,
 				01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */,
 				0C7364351DFF4871000C3585 /* NSErrorExtensionTests.swift in Sources */,
 				3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */,

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
@@ -17,7 +17,7 @@ class RequestTests: XCTestCase
         let cacheKeyFirstPageURI = "/channels/staffpicks/videos"
         let request = Request<VIMNullResponse>(path: cacheKeyFirstPageURI)
         
-        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.4799450059874646413", "")
+        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.5286765347155622285", "")
     }
     
     func testCacheKeyNextPage()
@@ -26,6 +26,6 @@ class RequestTests: XCTestCase
         let cacheKeyNextPageURI = "/channels/staffpicks/videos?fields=uri%2Cresource_key%2Cname%2Cdescription%2Ccreated_time%2Crelease_time%2Cduration%2Cplay.status%2Cplay.hls%2Cplay.drm%2Cplay.progressive%2Cwidth%2Cheight%2Clink%2Cpictures.sizes.width%2Cpictures.sizes.link%2Cstatus%2Cprivacy.view%2Cprivacy.comments%2Ccategories.uri%2Cmetadata.interactions%2Cmetadata.connections.comments%2Cmetadata.connections.likes%2Cmetadata.connections.related%2Cmetadata.connections.recommendations%2Cmetadata.connections.ondemand%2Cmetadata.connections.trailer%2Cstats%2Cpassword%2Ccontent_rating%2Cbadge%2Cspatial%2Cuser.uri%2Cuser.name%2Cuser.badge.type%2Cuser.badge.text%2Cuser.bio%2Cuser.account%2Cuser.location%2Cuser.pictures.uri%2Cuser.pictures.sizes.width%2Cuser.pictures.sizes.link%2Cuser.upload_quota%2Cuser.metadata.interactions%2Cuser.metadata.connections.pictures%2Cuser.metadata.connections.likes%2Cuser.metadata.connections.following%2Cuser.metadata.connections.followers%2Cuser.metadata.connections.videos%2Cuser.metadata.connections.watchlater%2Cuser.created_time&page=9&sort=default"
         let request = Request<VIMNullResponse>(path: cacheKeyNextPageURI)
         
-        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.4799450060866235427", "")
+        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.7451360055660162083", "")
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
@@ -1,0 +1,31 @@
+//
+//  RequestTests.swift
+//  VimeoNetworkingExample-iOS
+//
+//  Created by Lim, Jennifer on 4/17/17.
+//  Copyright © 2017 Vimeo. All rights reserved.
+//
+
+import XCTest
+
+@testable import VimeoNetworkingExample_iOS
+
+class RequestTests: XCTestCase
+{
+    func testCacheKeyFirstPage()
+    {
+        let cacheKeyFirstPageURI = "/channels/staffpicks/videos"
+        let request = Request<VIMNullResponse>(path: cacheKeyFirstPageURI)
+        
+        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.4799450059874646413", "")
+    }
+    
+    func testCacheKeyNextPage()
+    {
+        /// That test ensure that for a URI with filters the url Path remains `/channels/staffpicks/videos`.
+        let cacheKeyNextPageURI = "/channels/staffpicks/videos?fields=uri%2Cresource_key%2Cname%2Cdescription%2Ccreated_time%2Crelease_time%2Cduration%2Cplay.status%2Cplay.hls%2Cplay.drm%2Cplay.progressive%2Cwidth%2Cheight%2Clink%2Cpictures.sizes.width%2Cpictures.sizes.link%2Cstatus%2Cprivacy.view%2Cprivacy.comments%2Ccategories.uri%2Cmetadata.interactions%2Cmetadata.connections.comments%2Cmetadata.connections.likes%2Cmetadata.connections.related%2Cmetadata.connections.recommendations%2Cmetadata.connections.ondemand%2Cmetadata.connections.trailer%2Cstats%2Cpassword%2Ccontent_rating%2Cbadge%2Cspatial%2Cuser.uri%2Cuser.name%2Cuser.badge.type%2Cuser.badge.text%2Cuser.bio%2Cuser.account%2Cuser.location%2Cuser.pictures.uri%2Cuser.pictures.sizes.width%2Cuser.pictures.sizes.link%2Cuser.upload_quota%2Cuser.metadata.interactions%2Cuser.metadata.connections.pictures%2Cuser.metadata.connections.likes%2Cuser.metadata.connections.following%2Cuser.metadata.connections.followers%2Cuser.metadata.connections.videos%2Cuser.metadata.connections.watchlater%2Cuser.created_time&page=9&sort=default"
+        let request = Request<VIMNullResponse>(path: cacheKeyNextPageURI)
+        
+        XCTAssertTrue(request.cacheKey == "cached.channels.staffpicks.videos.4799450060866235427", "")
+    }
+}

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/RequestTests.swift
@@ -22,7 +22,7 @@ class RequestTests: XCTestCase
     
     func testCacheKeyNextPage()
     {
-        /// That test ensure that for a URI with filters the url Path remains `/channels/staffpicks/videos`.
+        // That test ensure that for a URI with filters the url Path remains `/channels/staffpicks/videos`.
         let cacheKeyNextPageURI = "/channels/staffpicks/videos?fields=uri%2Cresource_key%2Cname%2Cdescription%2Ccreated_time%2Crelease_time%2Cduration%2Cplay.status%2Cplay.hls%2Cplay.drm%2Cplay.progressive%2Cwidth%2Cheight%2Clink%2Cpictures.sizes.width%2Cpictures.sizes.link%2Cstatus%2Cprivacy.view%2Cprivacy.comments%2Ccategories.uri%2Cmetadata.interactions%2Cmetadata.connections.comments%2Cmetadata.connections.likes%2Cmetadata.connections.related%2Cmetadata.connections.recommendations%2Cmetadata.connections.ondemand%2Cmetadata.connections.trailer%2Cstats%2Cpassword%2Ccontent_rating%2Cbadge%2Cspatial%2Cuser.uri%2Cuser.name%2Cuser.badge.type%2Cuser.badge.text%2Cuser.bio%2Cuser.account%2Cuser.location%2Cuser.pictures.uri%2Cuser.pictures.sizes.width%2Cuser.pictures.sizes.link%2Cuser.upload_quota%2Cuser.metadata.interactions%2Cuser.metadata.connections.pictures%2Cuser.metadata.connections.likes%2Cuser.metadata.connections.following%2Cuser.metadata.connections.followers%2Cuser.metadata.connections.videos%2Cuser.metadata.connections.watchlater%2Cuser.created_time&page=9&sort=default"
         let request = Request<VIMNullResponse>(path: cacheKeyNextPageURI)
         


### PR DESCRIPTION
#### Ticket

[TVOS-732](https://vimean.atlassian.net/browse/TVOS-732)

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

- When requesting a paginated result (!= firstPage), the cacheKey generated was wrong. That results by retrieving this issue:

`ResponseDiskCache could not store object`

#### Implementation Summary

- Updated the way we generate the cacheKey in `Request+Cache.swift`

- What happen before is that for the first request results: the `pathURI` didn't contain any `queryItems`: So the cacheKey generated for the first page was always correct. Although, for a request paginated, the `pathURI` contained the `queryItems`. Because, we were concatenated `cached` with the `pathURI`: We got a super long cacheKey.

The fix was to:
1 - create a `NSURL` object with `pathURI`. So that we can only retrieve the real `path` without the filters.

2 - Instead of getting a hashValue for the `parameters`, get the hashValue of the `pathURI` which will be always unique.

#### Reviewer Tips

- In `ResponseCache.swift` file, that method `private func setResponseDictionary(responseDictionary: VimeoClient.ResponseDictionary, forKey key: String)`:
-> Add some logs:
```
do
                {
                    if !fileManager.fileExistsAtPath(directoryPath)
                    {
                        try fileManager.createDirectoryAtPath(directoryPath, withIntermediateDirectories: true, attributes: nil)
                    }
                    
                    let success = fileManager.createFileAtPath(filePath, contents: data, attributes: nil)
                    
                    if !success
                    {
                        print("ResponseDiskCache could not store object\(filePath)")
                    }
                    else
                    {
                        print("yeayyyy\(filePath)")
                    }
                }
```

You'll notice that before the changes, requesting a `nextPage` will always reach the error: `ResponseDiskCache could not store object`.

#### How to Test

- Go to explore, and scroll to request another page. See that in the console, there is no error logs.
- Make sure, retrieving cache still works on both platform.