### PR TITLE
removing a guard statememnt and replacing it with default values for …

### DIFF
--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -352,14 +352,9 @@ final public class VimeoClient
             
             if let pagingDictionary = responseDictionary[Constants.PagingKey] as? ResponseDictionary
             {
-                
-                guard let totalCount = responseDictionary[Constants.TotalKey] as? Int,
-                    let currentPage = responseDictionary[Constants.PageKey] as? Int,
-                    let itemsPerPage = responseDictionary[Constants.PerPageKey] as? Int else
-                {
-                    assertionFailure("Total count, current page, or items per page did not exist as expected.")
-                    return
-                }
+                let totalCount = responseDictionary[Constants.TotalKey] as? Int ?? 0
+                let currentPage = responseDictionary[Constants.PageKey] as? Int ?? 0
+                let itemsPerPage = responseDictionary[Constants.PerPageKey] as? Int ?? 0
                 
                 var nextPageRequest: Request<ModelType>? = nil
                 var previousPageRequest: Request<ModelType>? = nil


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Some API endpoints don't always return all of the expected paging information.  For instance, the /me/feed endpoint can't return the total number of items so there is no "total" key in the JSON response.  Currently these requests are causing the app to assert because we are expecting that the data will always be there.  This PR removes a guard statement looking for the data and replaces it with default values for when the data is missing.

#### Implementation Summary

- VimeoClient - removed the guard statement checking for totalCount, currentPage, and itemsPerPage and replaced it with a default value of 0 if any of those keys are missing from the JSON response.

#### Reviewer Tips

n/a

#### How to Test

1. Make sure the Feed is accessible in the tvOS app.
