### PR TITLE
[CRI-108] Singleton for VimeoClient

### DIFF
--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -82,13 +82,19 @@ final public class AuthenticationController
      
      - returns: a new `AuthenticationController`
      */
-    public init(client: VimeoClient)
+    public init?(client: VimeoClient)
     {
-        self.configuration = client.configuration
-        self.client = client
-        self.accountStore = AccountStore(configuration: client.configuration)
+        guard let configuration = client.configuration else
+        {
+            assertionFailure("VimeoClient argument cannot contain nil configuration")
+            return nil
+        }
         
-        self.authenticatorClient = VimeoClient(appConfiguration: client.configuration)
+        self.configuration = configuration
+        self.client = client
+        self.accountStore = AccountStore(configuration: configuration)
+        
+        self.authenticatorClient = VimeoClient(appConfiguration: configuration)
     }
     
     // MARK: - Public Saved Accounts

--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -82,15 +82,9 @@ final public class AuthenticationController
      
      - returns: a new `AuthenticationController`
      */
-    public init?(client: VimeoClient)
+    public init(client: VimeoClient, appConfiguration: AppConfiguration)
     {
-        guard let configuration = client.configuration else
-        {
-            assertionFailure("VimeoClient argument cannot contain nil configuration")
-            return nil
-        }
-        
-        self.configuration = configuration
+        self.configuration = appConfiguration
         self.client = client
         self.accountStore = AccountStore(configuration: configuration)
         

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -87,7 +87,7 @@ final public class VimeoClient
     // MARK: -
     
         /// Session manager handles the http session data tasks and request/response serialization
-    private let sessionManager: VimeoSessionManager
+    fileprivate var sessionManager: VimeoSessionManager? = nil
     
         /// response cache handles all memory and disk caching of response dictionaries
     private let responseCache = ResponseCache()
@@ -119,18 +119,22 @@ final public class VimeoClient
         self.init(appConfiguration: appConfiguration, sessionManager: VimeoSessionManager.defaultSessionManager(appConfiguration: appConfiguration))
     }
     
-    public init(appConfiguration: AppConfiguration, sessionManager: VimeoSessionManager)
+    public init(appConfiguration: AppConfiguration?, sessionManager: VimeoSessionManager?)
     {
-        self.configuration = appConfiguration
-        self.sessionManager = sessionManager
-        
-        VimeoReachability.beginPostingReachabilityChangeNotifications()
+        if let appConfiguration = appConfiguration,
+            let sessionManager = sessionManager
+        {
+            self.configuration = appConfiguration
+            self.sessionManager = sessionManager
+            
+            VimeoReachability.beginPostingReachabilityChangeNotifications()
+        }
     }
     
     // MARK: - Configuration
     
-        /// The client's configuration, as set on initialization
-    public let configuration: AppConfiguration
+    /// The client's configuration
+    public fileprivate(set) var configuration: AppConfiguration? = nil
     
     // MARK: - Authentication
     
@@ -141,11 +145,11 @@ final public class VimeoClient
         {
             if let authenticatedAccount = self.currentAccount
             {
-                self.sessionManager.clientDidAuthenticate(with: authenticatedAccount)
+                self.sessionManager?.clientDidAuthenticate(with: authenticatedAccount)
             }
             else
             {
-                self.sessionManager.clientDidClearAccount()
+                self.sessionManager?.clientDidClearAccount()
             }
             
             self.notifyObserversAccountChanged(forAccount: self.currentAccount, previousAccount: oldValue)
@@ -263,15 +267,15 @@ final public class VimeoClient
         switch request.method
         {
         case .GET:
-            task = self.sessionManager.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
+            task = self.sessionManager?.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
         case .POST:
-            task = self.sessionManager.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
+            task = self.sessionManager?.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
         case .PUT:
-            task = self.sessionManager.put(path, parameters: parameters, success: success, failure: failure)
+            task = self.sessionManager?.put(path, parameters: parameters, success: success, failure: failure)
         case .PATCH:
-            task = self.sessionManager.patch(path, parameters: parameters, success: success, failure: failure)
+            task = self.sessionManager?.patch(path, parameters: parameters, success: success, failure: failure)
         case .DELETE:
-            task = self.sessionManager.delete(path, parameters: parameters, success: success, failure: failure)
+            task = self.sessionManager?.delete(path, parameters: parameters, success: success, failure: failure)
         }
         
         guard let requestTask = task else
@@ -482,3 +486,34 @@ final public class VimeoClient
     }
 }
 
+
+extension VimeoClient
+{
+    /// Singleton instance for VimeoClient. Applications must call configure(client:, withAppConfiguration appConfiguration:, sessionManager:)
+    /// before it can be accessed.
+    public static var sharedClient: VimeoClient
+    {
+        guard let _ = self._sharedClient.configuration,
+            let _ = self._sharedClient.sessionManager else
+        {
+            assertionFailure("VimeoClient.sharedClient must be configured before accessing")
+            return self._sharedClient
+        }
+        
+        return self._sharedClient
+    }
+    private static let _sharedClient = VimeoClient(appConfiguration: nil, sessionManager: nil)
+    
+    /// Configures the singleton sharedClient instance. This function allows applications to provide
+    /// client specific app configurations at start time.
+    ///
+    /// - Parameters:
+    ///   - appConfiguration: An AppConfiguration instance
+    public static func configureSharedClient(withAppConfiguration appConfiguration: AppConfiguration)
+    {
+        self._sharedClient.configuration = appConfiguration
+        self._sharedClient.sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: appConfiguration)
+        
+        VimeoReachability.beginPostingReachabilityChangeNotifications()
+    }
+}

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -489,7 +489,7 @@ final public class VimeoClient
 
 extension VimeoClient
 {
-    /// Singleton instance for VimeoClient. Applications must call configure(client:, withAppConfiguration appConfiguration:, sessionManager:)
+    /// Singleton instance for VimeoClient. Applications must call configureSharedClient(withAppConfiguration appConfiguration:)
     /// before it can be accessed.
     public static var sharedClient: VimeoClient
     {

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/AppDelegate.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         
         // Starting the authentication process
         
-        let authenticationController = AuthenticationController(client: VimeoClient.defaultClient)
+        let authenticationController = AuthenticationController(client: VimeoClient.defaultClient, appConfiguration: AppConfiguration.defaultConfiguration)
         
         // First, we try to load a preexisting account
         
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         // If your app isn't opening after you accept permissions on Vimeo, check that your app has the correct URL scheme registered.
         // See the README for more information.
         
-        AuthenticationController(client: VimeoClient.defaultClient).codeGrant(responseURL: url) { result in
+        AuthenticationController(client: VimeoClient.defaultClient, appConfiguration: AppConfiguration.defaultConfiguration).codeGrant(responseURL: url) { result in
             
             switch result
             {

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
@@ -155,7 +155,7 @@ class MasterViewController: UITableViewController
         // If the user is logged in, the button logs them out.
         // If the user is logged out, the button launches the code grant authorization page.
         
-        let authenticationController = AuthenticationController(client: VimeoClient.defaultClient)
+        let authenticationController = AuthenticationController(client: VimeoClient.defaultClient, appConfiguration: AppConfiguration.defaultConfiguration)
         if VimeoClient.defaultClient.currentAccount?.isAuthenticatedWithUser() == true
         {
             do

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/VimeoClient+Shared.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/VimeoClient+Shared.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 /// Extend app configuration to provide a default configuration
-private extension AppConfiguration
+extension AppConfiguration
 {
     /// The default configuration to use for this application, populate your client key, secret, and scopes.
     /// Also, don't forget to set up your application to receive the code grant authentication redirect, see the README for details.


### PR DESCRIPTION
#### Ticket

[CRI-108](https://vimean.atlassian.net/browse/CRI-108)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Since internal frameworks rely on a previously extracted singleton instance, we needed to add a way for clients to configure the singleton instance

#### Implementation Summary

- Made AppConfiguration and VimeoSessionManager on VimeoClient optional
- Add static methods for singleton and singleton configuration
