### PR TITLE
CI-439 Disable pod cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ dependencies:
         - bundle install
     cache_directories:
         - "~/.cocoapods"
-        - "Pods"
         - "vendor/bundle"
 
 test:


### PR DESCRIPTION
This PR disable pod caching which puts the build environment in an undetermined state since Pods are checked into the repo.