### PR TITLE
AF-XXX: Make Date Formatter in Object Mapper a Singleton

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMModelObject.m
+++ b/VimeoNetworking/Sources/Models/VIMModelObject.m
@@ -44,9 +44,16 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
 
 + (NSDateFormatter *)dateFormatter
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZZZZZ";
+    static NSDateFormatter *dateFormatter;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+
+        dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZZZZZ";
+        
+    });
     
     return dateFormatter;
 }

--- a/VimeoNetworking/Sources/Models/VIMModelObject.m
+++ b/VimeoNetworking/Sources/Models/VIMModelObject.m
@@ -48,11 +48,9 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
     static dispatch_once_t onceToken;
 
     dispatch_once(&onceToken, ^{
-
         dateFormatter = [[NSDateFormatter alloc] init];
         dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZZZZZ";
-        
     });
     
     return dateFormatter;


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced

#### Issue Summary

- We were formerly creating a new date formatter for each use, which is very expensive. This PR changes this date formatter to be a singleton.

#### Implementation Summary

- Wrapped existing date formatter in a singleton pattern to ensure only one instance is created.

#### How to Test

N/A