### PR TITLE
[CRI-34] Badges property on VIMVideo now required outside of TV_OS. A…

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -126,12 +126,10 @@ NSString *VIMContentRating_Safe = @"safe";
         return [VIMVideoPlayRepresentation class];
     }
     
-    #if TARGET_OS_TV
     if ([key isEqualToString:@"badge"])
     {
         return [VIMBadge class];
     }
-    #endif
     
     if ([key isEqualToString:@"spatial"])
     {


### PR DESCRIPTION
#### Ticket

[CRI-34](https://vimean.atlassian.net/browse/CRI-34)

#### Issue Summary

- Badges property on VIMVideo now required outside of TV_OS. API team has enabled badge property in iOS’s json response which is required to properly handle logic to display badge if video is staff picked. 

#### Implementation Summary

- Affected file(s): VIMVideo.m