### PR TITLE
AF-XXX: Added more unit tests for VimeoSessionManager

### DIFF
--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
@@ -115,4 +115,55 @@ class VimeoSessionManagerTests: XCTestCase
         task = sessionManager.delete(testPath, parameters: nil, success: nil, failure: nil)
         XCTAssertEqual(task?.currentRequest?.url, testUrl)
     }
+    
+    func test_VimeoSessionManager_handleClientDidAuthenticate_setsCorrectTokenOnRequestSerializer()
+    {
+        let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
+                                             clientSecret: "{TEST CLIENT SECRET}",
+                                             scopes: [.Public, .Private, .Purchased, .Create, .Edit, .Delete, .Interact, .Upload],
+                                             keychainService: "com.vimeo.keychain_service",
+                                             apiVersion: "3.3")
+        
+        let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration)
+        
+        let testAccount = VIMAccount()
+        testAccount.accessToken = "TestAccessToken"
+        
+        sessionManager.clientDidAuthenticate(with: testAccount)
+        
+        guard let requestSerializer = sessionManager.requestSerializer as? VimeoRequestSerializer else
+        {
+            XCTFail("Incorrect request serializer")
+            return
+        }
+        
+        XCTAssertEqual(requestSerializer.accessTokenProvider?(), testAccount.accessToken)
+        
+    }
+    
+    func test_VimeoSessionManager_handleClientDidClearAccount_clearsTokenOnRequestSerializer()
+    {
+        let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
+                                             clientSecret: "{TEST CLIENT SECRET}",
+                                             scopes: [.Public, .Private, .Purchased, .Create, .Edit, .Delete, .Interact, .Upload],
+                                             keychainService: "com.vimeo.keychain_service",
+                                             apiVersion: "3.3")
+        
+        let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration)
+        
+        let testAccount = VIMAccount()
+        testAccount.accessToken = "TestAccessToken"
+        
+        guard let requestSerializer = sessionManager.requestSerializer as? VimeoRequestSerializer else
+        {
+            XCTFail("Incorrect request serializer")
+            return
+        }
+        
+        sessionManager.clientDidAuthenticate(with: testAccount)
+        XCTAssertNotNil(requestSerializer.accessTokenProvider)
+        
+        sessionManager.clientDidClearAccount()
+        XCTAssertNil(requestSerializer.accessTokenProvider)
+    }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-
 import XCTest
 @testable import VimeoNetworking
 

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/VimeoSessionManagerTests.swift
@@ -137,7 +137,6 @@ class VimeoSessionManagerTests: XCTestCase
         }
         
         XCTAssertEqual(requestSerializer.accessTokenProvider?(), testAccount.accessToken)
-        
     }
     
     func test_VimeoSessionManager_handleClientDidClearAccount_clearsTokenOnRequestSerializer()


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Added two new unit tests to check functionality of VimeoSessionManager account handling methods.

#### Implementation Summary

- VimeoSessionManagerTests - added a unit test to verify that the session manager properly sets the accessTokenProvider on the request serializer from a VIMAccount and a test that verifies it's properly removed.

#### How to Test

- Run the unit tests