### PR TITLE
AF-XXX: set the default branch to develop for the codecov dashboard

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+# Change the default branch in the codecov.io dashboard to develop instead of master
+codecov:
+  branch: develop


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Change the default branch to develop in the codecov dashboard.

#### Implementation Summary

- codecov.yml - added a yaml file to configure the default branch.
