### PR TITLE
Jam: Replace “let _ =“ with “_ =“

### DIFF
--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -385,7 +385,7 @@ final public class AuthenticationController
     {
         let infoRequest = PinCodeRequest.getPinCodeRequest(forScopes: self.configuration.scopes)
         
-        let _ = self.authenticatorClient.request(infoRequest) { result in
+        _ = self.authenticatorClient.request(infoRequest) { result in
             switch result
             {
             case .success(let result):
@@ -496,7 +496,7 @@ final public class AuthenticationController
         }
         
         let deleteTokensRequest = Request<VIMNullResponse>.deleteTokensRequest()
-        let _ = self.client.request(deleteTokensRequest) { (result) in
+        _ = self.client.request(deleteTokensRequest) { (result) in
             switch result
             {
             case .success:
@@ -528,7 +528,7 @@ final public class AuthenticationController
     
     private func authenticate(with client: VimeoClient, request: AuthenticationRequest, completion: @escaping AuthenticationCompletion)
     {
-        let _ = client.request(request) { result in
+        _ = client.request(request) { result in
             
             let handledResult = self.handleAuthenticationResult(result)
             

--- a/VimeoNetworking/Sources/Request+Notifications.swift
+++ b/VimeoNetworking/Sources/Request+Notifications.swift
@@ -72,7 +72,7 @@ public extension Request
     public static func markNotificationsAsSeenRequest(forNotifications notifications: [VIMNotification], notificationsURI: String) -> Request
     {
         var parameters: [ParameterDictionary] = []
-        let _ = notifications.map { (notification: VIMNotification) -> Void in
+        _ = notifications.map { (notification: VIMNotification) -> Void in
             if let uri = notification.uri
             {
                 parameters.append([

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -439,7 +439,7 @@ final public class VimeoClient
             
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(initialDelay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC))
             {
-                let _ = self.request(retryRequest, completionQueue: completionQueue, completion: completion)
+                _ = self.request(retryRequest, completionQueue: completionQueue, completion: completion)
             }
         }
         
@@ -448,7 +448,7 @@ final public class VimeoClient
             var cacheRequest = request
             cacheRequest.cacheFetchPolicy = .cacheOnly
             
-            let _ = self.request(cacheRequest, completionQueue: completionQueue, completion: completion)
+            _ = self.request(cacheRequest, completionQueue: completionQueue, completion: completion)
             
             return
         }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS/MasterViewController.swift
@@ -89,7 +89,7 @@ class MasterViewController: UITableViewController
                 request = Request<[VIMVideo]>(path: "/channels/staffpicks/videos")
             }
             
-            let _ = VimeoClient.defaultClient.request(request) { [weak self] result in
+            _ = VimeoClient.defaultClient.request(request) { [weak self] result in
                 
                 guard let strongSelf = self else
                 {
@@ -106,7 +106,7 @@ class MasterViewController: UITableViewController
                     {
                         print("starting next page request")
                         
-                        let _ = VimeoClient.defaultClient.request(nextPageRequest) { [weak self] result in
+                        _ = VimeoClient.defaultClient.request(nextPageRequest) { [weak self] result in
                             
                             guard let strongSelf = self else
                             {


### PR DESCRIPTION
A lightweight change that came from a discussion around a recent pull request (for which I've lost the link, sorry). The idea was to make it even more clear when assigning to an unused variable.

If these changes are acceptable we'll update the style guide as well. 