### PR TITLE
VIM-XXX: tvOS User Agent Fix

### DIFF
--- a/VimeoNetworking/Sources/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoRequestSerializer.swift
@@ -200,6 +200,10 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
             // So, on tvOS the User Agent will only specify the framework. System information might be something we want to add 
             // in the future if AFNetworking isn't providing it. [ghking] 6/19/17
             
+            #if !os(tvOS)
+                assertionFailure("An existing user agent was not found")
+            #endif
+            
             request.setValue(frameworkString, forHTTPHeaderField: Constants.UserAgentKey)
 
             return request

--- a/VimeoNetworking/Sources/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoRequestSerializer.swift
@@ -197,8 +197,8 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
         guard let existingUserAgent = request.value(forHTTPHeaderField: Constants.UserAgentKey) else
         {
             // DISCUSSION: AFNetworking doesn't set a User Agent for tvOS (look at the init method in AFHTTPRequestSerializer.m).
-            // So, on tvOS the User Agent will only specify the framework. The lack of system information hasn't been a problem 
-            // in the past but it might be something we want to add in the future. [ghking] 6/19/17
+            // So, on tvOS the User Agent will only specify the framework. System information might be something we want to add 
+            // in the future if AFNetworking isn't providing it. [ghking] 6/19/17
             
             request.setValue(frameworkString, forHTTPHeaderField: Constants.UserAgentKey)
 

--- a/VimeoNetworking/Sources/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoRequestSerializer.swift
@@ -196,8 +196,10 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
         
         guard let existingUserAgent = request.value(forHTTPHeaderField: Constants.UserAgentKey) else
         {
-            assertionFailure("No existing user agent")
-
+            // DISCUSSION: AFNetworking doesn't set a User Agent for tvOS (look at the init method in AFHTTPRequestSerializer.m).
+            // So, on tvOS the User Agent will only specify the framework. The lack of system information hasn't been a problem 
+            // in the past but it might be something we want to add in the future. [ghking] 6/19/17
+            
             request.setValue(frameworkString, forHTTPHeaderField: Constants.UserAgentKey)
 
             return request


### PR DESCRIPTION
#### Ticket

N/A

#### Issue Summary

We were hitting an assert on tvOS when constructing the user agent on requests.

#### Implementation Summary

AFNetworking doesn't set a User Agent for tvOS. This was tripping the `assertionFailure`. See the comment in the code for more deetz.

#### How to Test

Make sure request construction works on tvOS.