### PR TITLE
VIM-5494: Authenticate with Vimeo Backend

### DIFF
--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -519,12 +519,18 @@ final public class AuthenticationController
         try self.accountStore.removeAccount(ofType: .user)
     }
     
-    // MARK: - Private
-    
-    private func authenticate(with request: AuthenticationRequest, completion: @escaping AuthenticationCompletion)
+    /**
+     Executes the specified authentication request, then the specified completion.
+     
+        - request: A request to fetch a VIMAccount.
+        - completion: A closure to handle the VIMAccount or error received.
+     */
+    public func authenticate(with request: AuthenticationRequest, completion: @escaping AuthenticationCompletion)
     {
         self.authenticate(with: self.authenticatorClient, request: request, completion: completion)
     }
+    
+    // MARK: - Private
     
     private func authenticate(with client: VimeoClient, request: AuthenticationRequest, completion: @escaping AuthenticationCompletion)
     {

--- a/VimeoNetworking/Sources/Request+Authentication.swift
+++ b/VimeoNetworking/Sources/Request+Authentication.swift
@@ -26,6 +26,8 @@
 
 import Foundation
 
+public typealias AuthenticationRequest = Request<VIMAccount>
+
 private let GrantTypeKey = "grant_type"
 private let ScopeKey = "scope"
 private let CodeKey = "code"
@@ -55,12 +57,9 @@ private let AuthenticationPathPinCode = "oauth/device"
 private let AuthenticationPathPinCodeAuthorize = "oauth/device/authorize"
 private let AuthenticationPathAppTokenExchange = "oauth/appexchange"
 
-
 // MARK: -
 
 private let AuthenticationPathTokens = "/tokens"
-
-typealias AuthenticationRequest = Request<VIMAccount>
 
 extension Request where ModelType: VIMAccount
 {


### PR DESCRIPTION
### Ticket

[VIM-5494](https://vimean.atlassian.net/browse/VIM-5494)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- We needed to add 2 new requests to our backend in order to login or join using a third party derived token. Instead of adding them here, where they won't be usable by non-Vimeo consumers, some api was made public so that clients consuming VimeoNetworking can more easily do that within their project. 

#### Implementation Summary

- made `authenticateWithRequest` publicly accessible
- made typealias `AuthenticationRequest` publicly accessible

#### How to Test

- N/A
