### PR TITLE
VIM-5610: Adds a convenience method to check if live object exists

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -112,16 +112,16 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (NSInteger)commentsCount;
 
 /**
- Checks for the existence of a Spatial object on this VIMVideo and returns `true` if it exists.
+ Checks for the existence of a Spatial object on this VIMVideo and returns `true` if one exists.
  
- @return Returns true is a Spatial object exists for this VIMVideo.
+ @return Returns `true` is a Spatial object exists for this VIMVideo.
  */
 - (BOOL)is360;
 
 /**
- Checks for the existence of a VIMLive object on this VIMVideo and returns `true` if it exists.
+ Checks for the existence of a VIMLive object on this VIMVideo and returns `true` if one exists.
 
- @return Returns true is a VIMLive object exists for this VIMVideo.
+ @return Returns `true` is a VIMLive object exists for this VIMVideo.
  */
 - (BOOL)isLive;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -110,7 +110,19 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isDRMProtected;
 - (NSInteger)likesCount;
 - (NSInteger)commentsCount;
+
+/**
+ Checks for the existence of a Spatial object on this VIMVideo and returns `true` if it exists.
+ 
+ @return Returns true is a Spatial object exists for this VIMVideo.
+ */
 - (BOOL)is360;
+
+/**
+ Checks for the existence of a VIMLive object on this VIMVideo and returns `true` if it exists.
+
+ @return Returns true is a VIMLive object exists for this VIMVideo.
+ */
 - (BOOL)isLive;
 
 - (void)setIsLiked:(BOOL)isLiked;

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -112,16 +112,16 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (NSInteger)commentsCount;
 
 /**
- Checks for the existence of a Spatial object on this VIMVideo and returns `true` if one exists.
+ Checks for the existence of a Spatial object on this VIMVideo and returns @p true if one exists.
  
- @return Returns `true` is a Spatial object exists for this VIMVideo.
+ @return Returns @p true is a Spatial object exists for this VIMVideo.
  */
 - (BOOL)is360;
 
 /**
- Checks for the existence of a VIMLive object on this VIMVideo and returns `true` if one exists.
+ Checks for the existence of a VIMLive object on this VIMVideo and returns @p true if one exists.
 
- @return Returns `true` is a VIMLive object exists for this VIMVideo.
+ @return Returns @p true is a VIMLive object exists for this VIMVideo.
  */
 - (BOOL)isLive;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -111,6 +111,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (NSInteger)likesCount;
 - (NSInteger)commentsCount;
 - (BOOL)is360;
+- (BOOL)isLive;
 
 - (void)setIsLiked:(BOOL)isLiked;
 - (void)setIsWatchLater:(BOOL)isWatchLater;

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -501,4 +501,9 @@ NSString *VIMContentRating_Safe = @"safe";
     return self.spatial != nil;
 }
 
+- (BOOL)isLive
+{
+    return self.live != nil;
+}
+
 @end

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -1,0 +1,34 @@
+//
+//  VIMVideoTests.swift
+//  VimeoNetworkingExample-iOS
+//
+//  Copyright © 2017 Vimeo. All rights reserved.
+//
+
+import XCTest
+@testable import VimeoNetworking
+
+class VIMVideoTests: XCTestCase
+{
+    func test_isLive_returnsTrue_whenLiveObjectExists()
+    {
+        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date()]
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLive())
+    }
+    
+    func test_isLive_returnsFalse_whenLiveObjectDoesNotExist()
+    {
+        let videoDictionary: [String: Any] = ["link": "vimeo.com"]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertFalse(testVideoObject.isLive())
+    }
+}

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -4,6 +4,24 @@
 //
 //  Copyright © 2017 Vimeo. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import XCTest
 @testable import VimeoNetworking

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBEF61CEB9C100093DDF4 /* ModelObjectValidationTests.swift */; };
 		01FD38A71CC9289200326408 /* VimeoNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01FD38A61CC9289200326408 /* VimeoNetworking.framework */; };
 		0C7364351DFF4871000C3585 /* NSErrorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7364331DFF4871000C3585 /* NSErrorExtensionTests.swift */; };
+		0CF362E21F62E90400B22589 /* VIMVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF362E11F62E90400B22589 /* VIMVideoTests.swift */; };
 		234B183FA295853A0F735D3F /* Pods_VimeoNetworkingExample_tvOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2F770DEBD4E467F7F728F84 /* Pods_VimeoNetworkingExample_tvOSTests.framework */; };
 		3C0DCFBB1ECA775700960774 /* Request+CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0DCFBA1ECA775700960774 /* Request+CategoryTests.swift */; };
 		3C0DCFBC1ECA775700960774 /* Request+CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0DCFBA1ECA775700960774 /* Request+CategoryTests.swift */; };
@@ -95,6 +96,7 @@
 		097D1643FEAE7486DB0CB7D6 /* Pods-VimeoNetworkingExample-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSTests/Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		0C7364331DFF4871000C3585 /* NSErrorExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSErrorExtensionTests.swift; sourceTree = "<group>"; };
 		0CAAF25B1E0201F1003C5CBA /* VimeoNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VimeoNetworking.framework; path = "../../../Library/Developer/Xcode/DerivedData/VimeoNetworking-eybwmmbikpeubpbxrlpwzwxtbzfr/Build/Products/Debug-iphonesimulator/VimeoNetworking/VimeoNetworking.framework"; sourceTree = "<group>"; };
+		0CF362E11F62E90400B22589 /* VIMVideoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VIMVideoTests.swift; path = VimeoNetworkingCommonTests/VIMVideoTests.swift; sourceTree = "<group>"; };
 		128A8B3EE78B0F2F924E5E24 /* Pods-VimeoNetworkingExample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		1CFBEA4F42A23D881BD1C3E2 /* Pods-VimeoNetworking tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworking tvOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworking tvOSTests/Pods-VimeoNetworking tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1F636AC05A37694455DCD282 /* Pods-VimeoNetworking tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworking tvOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworking tvOS/Pods-VimeoNetworking tvOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -290,11 +292,12 @@
 			children = (
 				3C0DCFC31ECA818900960774 /* Object Mapping */,
 				3C0DCFB91ECA771300960774 /* Requests */,
-				3C0DCFC01ECA7F5D00960774 /* ScopeTests.swift */,
 				3CE06F991ED30D80007A1AFE /* Dictionary+ExtensionTests.swift */,
 				3CE06F9C1ED31200007A1AFE /* ExceptionCatcherTests.swift */,
 				3CE06F9F1ED3AE5F007A1AFE /* ResponseCacheTests.swift */,
+				3C0DCFC01ECA7F5D00960774 /* ScopeTests.swift */,
 				3CE06FA21ED5B49A007A1AFE /* VimeoSessionManagerTests.swift */,
+				0CF362E11F62E90400B22589 /* VIMVideoTests.swift */,
 			);
 			name = VimeoNetworkingCommonTests;
 			sourceTree = "<group>";
@@ -758,6 +761,7 @@
 				3C1F8E051F14397A00A062D3 /* VIMQuantityQuota+Tests.swift in Sources */,
 				3C0DCFBE1ECA790200960774 /* RequestTestUtilities.swift in Sources */,
 				3C0DCFBB1ECA775700960774 /* Request+CategoryTests.swift in Sources */,
+				0CF362E21F62E90400B22589 /* VIMVideoTests.swift in Sources */,
 				3CE06FA31ED5B49A007A1AFE /* VimeoSessionManagerTests.swift in Sources */,
 				01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */,
 				3CE06F9D1ED31200007A1AFE /* ExceptionCatcherTests.swift in Sources */,


### PR DESCRIPTION
#### Ticket
[VIM-5610](https://vimean.atlassian.net/browse/VIM-5610)

#### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary
Create an easy way to determine whether or not a VIMVideo object has a live video associated with it.

#### Implementation Summary
Added a new `isLive` convenience method to look for the existence of a VIMLive object. This was to match the existing behavior for `is360`. Also added a couple tests to verify that the new method worked as expected. 

#### How to Test
- Build and run unit tests.