### PR TITLE
VIM-5585: Update VIMLive and VIMVideo

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -28,12 +28,12 @@ import Foundation
 
 /// The streaming status of a live video.
 ///
-/// - unavailable: the RTMP link is visible but not yet able to receive the stream.
+/// - unavailable: The RTMP link is visible but not yet able to receive the stream.
 /// - pending: Vimeo is working on setting up the connection.
-/// - ready: the RTMP's URL is ready to receive video content.
-/// - streamingPreview: the stream is in a "preview" state. It will be accessible to the public when you transition to "streaming".
+/// - ready: The RTMP's URL is ready to receive video content.
+/// - streamingPreview: The stream is in a "preview" state. It will be accessible to the public when you transition to "streaming".
 /// - streaming: The stream is open and receiving content.
-/// - streamingError: The stream has been terminated by Vimeo.
+/// - streamingError: The stream has failed due to an error relating to the broadcaster; They may have reached their monthly broadcast limit, for example.
 /// - done: The stream has been ended intentionally by the end-user.
 public enum LiveStreamingStatus: String
 {
@@ -50,12 +50,25 @@ public enum LiveStreamingStatus: String
 /// a `clip` response.
 public class VIMLive: VIMModelObject
 {
+    /// The RTMP link is visible but not yet able to receive the stream.
     public static let LiveStreamStatusUnavailable = "unavailable"
+    
+    /// Vimeo is working on setting up the connection.
     public static let LiveStreamStatusPending = "pending"
+    
+    /// The RTMP's URL is ready to receive video content.
     public static let LiveStreamStatusReady = "ready"
+    
+    /// The stream is in a "preview" state. It will be accessible to the public when you transition to "streaming".
     public static let LiveStreamStatusStreamingPreview = "streaming_preview"
+    
+    /// The stream is open and receiving content.
     public static let LiveStreamStatusStreaming = "streaming"
+    
+    /// The stream has failed due to an error relating to the broadcaster; They may have reached their monthly broadcast limit, for example.
     public static let LiveStreamStatusStreamingError = "streaming_error"
+    
+    /// The stream has been ended intentionally by the end-user.
     public static let LiveStreamStatusDone = "done"
     
     /// An RTMP link used to host a live stream.

--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -43,7 +43,7 @@ public enum LiveStreamingStatus: String
     case streamingPreview = "streaming_preview"
     case streaming = "streaming"
     case streamingError = "streaming_error"
-    case ended = "ended"
+    case done = "done"
 }
 
 /// An object that represents the `live` field in

--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -43,7 +43,7 @@ public enum LiveStreamingStatus: String
     case streamingPreview = "streaming_preview"
     case streaming = "streaming"
     case streamingError = "streaming_error"
-    case done = "done"
+    case ended = "ended"
 }
 
 /// An object that represents the `live` field in

--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -56,7 +56,7 @@ public class VIMLive: VIMModelObject
     public static let LiveStreamStatusStreamingPreview = "streaming_preview"
     public static let LiveStreamStatusStreaming = "streaming"
     public static let LiveStreamStatusStreamingError = "streaming_error"
-    public static let LiveStreamStatusEnded = "ended"
+    public static let LiveStreamStatusDone = "done"
     
     /// An RTMP link used to host a live stream.
     public private(set) var link: String?

--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -50,6 +50,14 @@ public enum LiveStreamingStatus: String
 /// a `clip` response.
 public class VIMLive: VIMModelObject
 {
+    public static let LiveStreamStatusUnavailable = "unavailable"
+    public static let LiveStreamStatusPending = "pending"
+    public static let LiveStreamStatusReady = "ready"
+    public static let LiveStreamStatusStreamingPreview = "streaming_preview"
+    public static let LiveStreamStatusStreaming = "streaming"
+    public static let LiveStreamStatusStreamingError = "streaming_error"
+    public static let LiveStreamStatusEnded = "ended"
+    
     /// An RTMP link used to host a live stream.
     public private(set) var link: String?
     

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -125,6 +125,27 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
  */
 - (BOOL)isLive;
 
+/**
+ <#Description#>
+
+ @return <#return value description#>
+ */
+- (BOOL)isPreBroadcast;
+
+/**
+ <#Description#>
+
+ @return <#return value description#>
+ */
+- (BOOL)isMidBroadcast;
+
+/**
+ <#Description#>
+
+ @return <#return value description#>
+ */
+- (BOOL)isPostBroadcast;
+
 - (void)setIsLiked:(BOOL)isLiked;
 - (void)setIsWatchLater:(BOOL)isWatchLater;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -126,23 +126,23 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isLive;
 
 /**
- <#Description#>
+ Determines whether the current video represents a live video and whether or not the broadcast has started.
 
- @return <#return value description#>
+ @return Returns @p true if the live video's broadcast has not begun.
  */
 - (BOOL)isPreBroadcast;
 
 /**
- <#Description#>
+ Determines whether the current video represents a live video and if the broadcast is underway.
 
- @return <#return value description#>
+ @return Returns @p true when the live video's broadcast is underway.
  */
 - (BOOL)isMidBroadcast;
 
 /**
- <#Description#>
+ Determines whether the current video represents a live video  and whether or not the broadcast has ended.
 
- @return <#return value description#>
+ @return Returns @p true when the live video's broadcast has ended.
  */
 - (BOOL)isPostBroadcast;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -506,4 +506,19 @@ NSString *VIMContentRating_Safe = @"safe";
     return self.live != nil;
 }
 
+- (BOOL)isPreBroadcast
+{
+    return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusUnavailable] || [self.live.status isEqual: VIMLive.LiveStreamStatusReady] || [self.live.status isEqual: VIMLive.LiveStreamStatusPending]);
+}
+
+- (BOOL)isMidBroadcast
+{
+    return self.isLive && [self.live.status isEqual: VIMLive.LiveStreamStatusStreaming];
+}
+
+- (BOOL)isPostBroadcast
+{
+    return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusDone] || [self.live.status isEqual: VIMLive.LiveStreamStatusStreamingError]);
+}
+
 @end

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -518,7 +518,7 @@ NSString *VIMContentRating_Safe = @"safe";
 
 - (BOOL)isPostBroadcast
 {
-    return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusDone] || [self.live.status isEqual: VIMLive.LiveStreamStatusStreamingError]);
+    return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusDone]);
 }
 
 @end


### PR DESCRIPTION
#### Ticket

[VIM-5585](https://vimean.atlassian.net/browse/VIM-5585)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Implementation Summary
- Added constants to VIMLive to mirror the status enum, because the enum is not available via Objective-C.
- Added convenience methods to return whether or not a live video is pre, mid, or post broadcast.