### PR TITLE
Improve Compile Time for Subscription.swift

### DIFF
--- a/VimeoNetworking/Sources/Models/Subscription.swift
+++ b/VimeoNetworking/Sources/Models/Subscription.swift
@@ -50,7 +50,7 @@ public class Subscription: VIMModelObject
     /// Represents the Subscription object as a Dictionary
     public var toDictionary: [AnyHashable: Any]
     {
-        let dictionary = ["comment": self.comment ?? false,
+        let dictionary: [String: Any] = ["comment": self.comment ?? false,
                           "credit": self.credit ?? false,
                           "like": self.like ?? false,
                           "mention": self.mention ?? false,

--- a/VimeoNetworking/Sources/Models/Subscription.swift
+++ b/VimeoNetworking/Sources/Models/Subscription.swift
@@ -50,16 +50,16 @@ public class Subscription: VIMModelObject
     /// Represents the Subscription object as a Dictionary
     public var toDictionary: [AnyHashable: Any]
     {
-        let dictionary: [String: Any] = ["comment": self.comment ?? false,
-                          "credit": self.credit ?? false,
-                          "like": self.like ?? false,
-                          "mention": self.mention ?? false,
-                          "reply": self.reply ?? false,
-                          "follow": self.follow ?? false,
-                          "vod_preorder_available": self.vodPreorderAvailable ?? false,
-                          "video_available": self.videoAvailable ?? false,
-                          "share": self.share ?? false,
-                          "followed_user_video_available": self.followedUserVideoAvailable ?? false]
+        let dictionary: [AnyHashable: Any] = ["comment": self.comment ?? false,
+                                              "credit": self.credit ?? false,
+                                              "like": self.like ?? false,
+                                              "mention": self.mention ?? false,
+                                              "reply": self.reply ?? false,
+                                              "follow": self.follow ?? false,
+                                              "vod_preorder_available": self.vodPreorderAvailable ?? false,
+                                              "video_available": self.videoAvailable ?? false,
+                                              "share": self.share ?? false,
+                                              "followed_user_video_available": self.followedUserVideoAvailable ?? false]
         
         return dictionary
     }


### PR DESCRIPTION
Significantly improve the compile time of the library by specifying the type of the dictionary which saves the compiler from having to figure it out.

#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Subscription.swift had a very long compile time in Xcode 9. (> 10s)

#### Implementation Summary

By specifying the dictionary type we can reduce the compile time to a few milliseconds.

#### How to Test

If the project compiles then the test is complete.