### PR TITLE
VIM-5658: Update VIMVideo and VIMLive for API version 3.3.13

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMLive.swift
+++ b/VimeoNetworking/Sources/Models/VIMLive.swift
@@ -34,6 +34,7 @@ import Foundation
 /// - streamingPreview: The stream is in a "preview" state. It will be accessible to the public when you transition to "streaming".
 /// - streaming: The stream is open and receiving content.
 /// - streamingError: The stream has failed due to an error relating to the broadcaster; They may have reached their monthly broadcast limit, for example.
+/// - archiving: The stream has finished, and the video is in the process of being archived, but is not ready to play yet.
 /// - done: The stream has been ended intentionally by the end-user.
 public enum LiveStreamingStatus: String
 {
@@ -43,6 +44,7 @@ public enum LiveStreamingStatus: String
     case streamingPreview = "streaming_preview"
     case streaming = "streaming"
     case streamingError = "streaming_error"
+    case archiving = "archiving"
     case done = "done"
 }
 
@@ -67,6 +69,9 @@ public class VIMLive: VIMModelObject
     
     /// The stream has failed due to an error relating to the broadcaster; They may have reached their monthly broadcast limit, for example.
     public static let LiveStreamStatusStreamingError = "streaming_error"
+    
+    /// The stream has finished, and the video is in the process of being archived, but is not ready to play yet.
+    public static let LiveStreamStatusArchiving = "archiving"
     
     /// The stream has been ended intentionally by the end-user.
     public static let LiveStreamStatusDone = "done"

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -46,6 +46,7 @@ extern NSString * __nonnull VIMContentRating_Unrated;
 extern NSString * __nonnull VIMContentRating_Safe;
 
 typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
+    VIMVideoProcessingStatusUnavailable,
     VIMVideoProcessingStatusAvailable,
     VIMVideoProcessingStatusUploading,
     VIMVideoProcessingStatusTranscodeStarting, // New state added to API 11/18/2015 with in-app support added 2/11/2016 [AH]

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -140,6 +140,13 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isMidBroadcast;
 
 /**
+ Determines whether the current video represents a live video that is in the process of being archived.
+
+ @return Returns @p true when the live video's broadcast has ended and is being archived.
+ */
+- (BOOL)isArchivingBroadcast;
+
+/**
  Determines whether the current video represents a live video  and whether or not the broadcast has ended.
 
  @return Returns @p true when the live video's broadcast has ended.

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -516,6 +516,11 @@ NSString *VIMContentRating_Safe = @"safe";
     return self.isLive && [self.live.status isEqual: VIMLive.LiveStreamStatusStreaming];
 }
 
+- (BOOL)isArchivingBroadcast
+{
+    return self.isLive && [self.live.status isEqualToString:VIMLive.LiveStreamStatusArchiving];
+}
+
 - (BOOL)isPostBroadcast
 {
     return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusDone]);

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -314,6 +314,7 @@ NSString *VIMContentRating_Safe = @"safe";
 - (void)setVideoStatus
 {
     NSDictionary *statusDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+                                      [NSNumber numberWithInt:VIMVideoProcessingStatusUnavailable], @"unavailable",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusAvailable], @"available",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusUploading], @"uploading",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusTranscoding], @"transcoding",


### PR DESCRIPTION
#### Ticket

[VIM-5658](https://vimean.atlassian.net/browse/VIM-5658)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary
Update VIMVideo and VIMLive object to handle changes from Vimeo API version 3.3.13.

#### Implementation Summary
- Added the `archiving` status to **VIMLive**.
- Added the `unavailable` status to the dictionary of valid video statuses for **VIMVideo**.
