### PR TITLE
VIM-5563: Add isLiveEventInProgress convenience method

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -120,36 +120,42 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)is360;
 
 /**
- Checks for the existence of a VIMLive object on this VIMVideo and returns @p true if one exists.
+ Checks for the existence of a VIMLive object on this VIMVideo and returns @p true if one exists, but does not check the state of the live event.
 
  @return Returns @p true is a VIMLive object exists for this VIMVideo.
  */
 - (BOOL)isLive;
 
 /**
- Determines whether the current video represents a live video and whether or not the broadcast has started.
+ Determines whether the current video represents a live event and if the event is in the pre, mid, or archiving state indicating that a live event is currently underway.
+
+ @return Returns @p true if the live video's broadcast is about to begin, is underway, or is being archived. Returns @p false if the live video's broadcast has already been archived.
+ */
 - (BOOL)isLiveEventInProgress;
+
+/**
+ Determines whether the current video represents a live event and whether or not the broadcast has started.
 
  @return Returns @p true if the live video's broadcast has not begun.
  */
 - (BOOL)isPreBroadcast;
 
 /**
- Determines whether the current video represents a live video and if the broadcast is underway.
+ Determines whether the current video represents a live event and if the broadcast is underway.
 
  @return Returns @p true when the live video's broadcast is underway.
  */
 - (BOOL)isMidBroadcast;
 
 /**
- Determines whether the current video represents a live video that is in the process of being archived.
+ Determines whether the current video represents a live event that is in the process of being archived.
 
  @return Returns @p true when the live video's broadcast has ended and is being archived.
  */
 - (BOOL)isArchivingBroadcast;
 
 /**
- Determines whether the current video represents a live video, whether the live event has ended, and if an archive of the broadcast is ready for playback.
+ Determines whether the current video represents a live event, whether it has ended, and if an archive of the broadcast is ready for playback.
 
  @return Returns @p true when the live video event has ended and an archive of the broadcast is available.
  */

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -128,6 +128,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 
 /**
  Determines whether the current video represents a live video and whether or not the broadcast has started.
+- (BOOL)isLiveEventInProgress;
 
  @return Returns @p true if the live video's broadcast has not begun.
  */

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -148,9 +148,9 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isArchivingBroadcast;
 
 /**
- Determines whether the current video represents a live video  and whether or not the broadcast has ended.
+ Determines whether the current video represents a live video, whether the live event has ended, and if an archive of the broadcast is ready for playback.
 
- @return Returns @p true when the live video's broadcast has ended.
+ @return Returns @p true when the live video event has ended and an archive of the broadcast is available.
  */
 - (BOOL)isPostBroadcast;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -115,14 +115,14 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 /**
  Checks for the existence of a Spatial object on this VIMVideo and returns @p true if one exists.
  
- @return Returns @p true is a Spatial object exists for this VIMVideo.
+ @return Returns @p true if a Spatial object exists for this VIMVideo.
  */
 - (BOOL)is360;
 
 /**
  Checks for the existence of a VIMLive object on this VIMVideo and returns @p true if one exists, but does not check the state of the live event.
 
- @return Returns @p true is a VIMLive object exists for this VIMVideo.
+ @return Returns @p true if a VIMLive object exists for this VIMVideo.
  */
 - (BOOL)isLive;
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -509,7 +509,7 @@ NSString *VIMContentRating_Safe = @"safe";
 
 - (BOOL)isLiveEventInProgress
 {
-    return self.live != nil && (self.isPreBroadcast == YES || self.isMidBroadcast == YES || self.isArchivingBroadcast == YES);
+    return self.live != nil && (self.isPreBroadcast || self.isMidBroadcast || self.isArchivingBroadcast);
 }
 
 - (BOOL)isPreBroadcast

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -507,6 +507,11 @@ NSString *VIMContentRating_Safe = @"safe";
     return self.live != nil;
 }
 
+- (BOOL)isLiveEventInProgress
+{
+    return self.live != nil && (self.isPreBroadcast == YES || self.isMidBroadcast == YES || self.isArchivingBroadcast == YES);
+}
+
 - (BOOL)isPreBroadcast
 {
     return self.isLive && ([self.live.status isEqual: VIMLive.LiveStreamStatusUnavailable] || [self.live.status isEqual: VIMLive.LiveStreamStatusReady] || [self.live.status isEqual: VIMLive.LiveStreamStatusPending]);

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -73,7 +73,7 @@ class VIMVideoTests: XCTestCase
         XCTAssertTrue(testVideoObject.isLiveEventInProgress())
     }
     
-    func test_isLiveEventInProgress_returnsTrue_whenEventIsInMidBroadcastState()
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInReadyPreBroadcastState()
     {
         liveDictionary["status"] = "ready"
         let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -85,6 +85,18 @@ class VIMVideoTests: XCTestCase
         XCTAssertTrue(testVideoObject.isLiveEventInProgress())
     }
     
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInMidBroadcastState()
+    {
+        liveDictionary["status"] = "streaming"
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLiveEventInProgress())
+    }
+    
     func test_isLiveEventInProgress_returnsTrue_whenEventIsInArchivingState()
     {
         liveDictionary["status"] = "archiving"

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -28,11 +28,11 @@ import XCTest
 
 class VIMVideoTests: XCTestCase
 {
+    private var liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date()]
+    
     func test_isLive_returnsTrue_whenLiveObjectExists()
     {
-        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date()]
         let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
-        
         let videoDictionary: [String: Any] = ["live": testLiveObject]
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         
@@ -45,16 +45,14 @@ class VIMVideoTests: XCTestCase
     {
         let videoDictionary: [String: Any] = ["link": "vimeo.com"]
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
-        
         XCTAssertNotNil(testVideoObject)
         XCTAssertFalse(testVideoObject.isLive())
     }
     
-    func test_isLiveEventInProgress_returnsTrue_whenEventIsInMidBroadcastState()
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInUnavailablePreBroadcastState()
     {
-        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "ready"]
+        liveDictionary["status"] = "unavailable"
         let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
-        
         let videoDictionary: [String: Any] = ["live": testLiveObject]
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         
@@ -63,11 +61,34 @@ class VIMVideoTests: XCTestCase
         XCTAssertTrue(testVideoObject.isLiveEventInProgress())
     }
     
-    func test_isLiveEventInProgress_returnsTrue_whenEventIsInPreBroadcastState()
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInPendingPreBroadcastState()
     {
-        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "archiving"]
+        liveDictionary["status"] = "pending"
         let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLiveEventInProgress())
+    }
+    
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInMidBroadcastState()
+    {
+        liveDictionary["status"] = "ready"
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLiveEventInProgress())
+    }
+    
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInArchivingState()
+    {
+        liveDictionary["status"] = "archiving"
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
         let videoDictionary: [String: Any] = ["live": testLiveObject]
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         
@@ -78,14 +99,25 @@ class VIMVideoTests: XCTestCase
     
     func test_isLiveEventInProgress_returnsFalse_whenEventIsInPostBroadcastState()
     {
-        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "done"]
+        liveDictionary["status"] = "done"
         let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
-        
         let videoDictionary: [String: Any] = ["live": testLiveObject]
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         
         XCTAssertNotNil(testLiveObject)
         XCTAssertNotNil(testVideoObject)
         XCTAssertFalse(testVideoObject.isLiveEventInProgress())
+    }
+    
+    func test_isPostBroadcast_returnsTrue_whenEventIsInDoneState()
+    {
+        liveDictionary["status"] = "done"
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isPostBroadcast())
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -49,4 +49,43 @@ class VIMVideoTests: XCTestCase
         XCTAssertNotNil(testVideoObject)
         XCTAssertFalse(testVideoObject.isLive())
     }
+    
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInMidBroadcastState()
+    {
+        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "ready"]
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLiveEventInProgress())
+    }
+    
+    func test_isLiveEventInProgress_returnsTrue_whenEventIsInPreBroadcastState()
+    {
+        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "archiving"]
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertTrue(testVideoObject.isLiveEventInProgress())
+    }
+    
+    func test_isLiveEventInProgress_returnsFalse_whenEventIsInPostBroadcastState()
+    {
+        let liveDictionary: [String: Any] = ["link": "vimeo.com", "key": "abcdefg", "activeTime": Date(), "endedTime": Date(), "archivedTime": Date(), "status": "done"]
+        let testLiveObject = VIMLive(keyValueDictionary: liveDictionary)!
+        
+        let videoDictionary: [String: Any] = ["live": testLiveObject]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        
+        XCTAssertNotNil(testLiveObject)
+        XCTAssertNotNil(testVideoObject)
+        XCTAssertFalse(testVideoObject.isLiveEventInProgress())
+    }
 }


### PR DESCRIPTION
#### Ticket

[VIM-5563](https://vimean.atlassian.net/browse/VIM-5563)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary
It was cumbersome to check all live event states individually and made sense to create a new method that could check for these related states in one easy interface. 

#### Implementation Summary
Instead of checking for each individual live event state except for post-broadcast we've add a new `isLiveEventInProgress` convenience method that encompasses these checks. 

Added tests to validate the logic in `isLiveEventInProgress`.

Improved and clarified documentation.

#### How to Test
Build and run unit tests.