### PR TITLE
VIM-XXX: Add “unavailable” status to VIMVideo status dictionary

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -46,6 +46,7 @@ extern NSString * __nonnull VIMContentRating_Unrated;
 extern NSString * __nonnull VIMContentRating_Safe;
 
 typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
+    VIMVideoProcessingStatusUnavailable,
     VIMVideoProcessingStatusAvailable,
     VIMVideoProcessingStatusUploading,
     VIMVideoProcessingStatusTranscodeStarting, // New state added to API 11/18/2015 with in-app support added 2/11/2016 [AH]

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -314,6 +314,7 @@ NSString *VIMContentRating_Safe = @"safe";
 - (void)setVideoStatus
 {
     NSDictionary *statusDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+                                      [NSNumber numberWithInt:VIMVideoProcessingStatusUnavailable], @"unavailable",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusAvailable], @"available",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusUploading], @"uploading",
                                       [NSNumber numberWithInt:VIMVideoProcessingStatusTranscoding], @"transcoding",


### PR DESCRIPTION
#### Ticket

NA

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Missing new video status "unavailable" so we asserted

#### Implementation Summary

- Added new video status

#### How to Test

- See Vimeo-iOS client repo 
