### PR TITLE
Update Circle CI to use Xcode 9.0.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
     - "build/Logs"
 machine:
   xcode:
-    version: 9.0
+    version: 9.0.1
 
 dependencies:
     override:


### PR DESCRIPTION
Circle CI appears to have been updated to build with Xcode 9.0.1, while our circle.yml file specified version 9.0, producing the following error:

```
[!] Selected Xcode version doesn't match your requirement.
Expected: Xcode 9.0
Actual: 9.0.1
```

This PR updates circle.yml to specify Xcode version 9.0.1.