### PR TITLE
Remove characters warning

### DIFF
--- a/VimeoNetworking/Sources/Request.swift
+++ b/VimeoNetworking/Sources/Request.swift
@@ -169,7 +169,7 @@ public struct Request<ModelType: MappableResponse>
         {
             let queryString = AFQueryStringFromParameters(parameters)
             
-            if queryString.characters.count > 0
+            if queryString.count > 0
             {
                 components?.query = queryString
             }


### PR DESCRIPTION
#### Ticket
N/A

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

Removed deprecated `characters` to avoid the following warning:
```
'characters' is deprecated: Please use String or Substring directly
```

#### Implementation Summary

- Removed `characters`.

#### Reviewer Tips
#### How to Test
N/A