### PR TITLE
Changes VimeoBaseURL constant access back to public

### DIFF
--- a/VimeoNetworking/Sources/Constants.swift
+++ b/VimeoNetworking/Sources/Constants.swift
@@ -27,7 +27,7 @@
 import Foundation
 
  /// Base URL for the Vimeo API
-let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
+public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
 
  /// Default API version to use for requests
 let VimeoDefaultAPIVersionString = "3.2"


### PR DESCRIPTION
After some deliberation we decided to restore access to the VimeoBaseURL outside of the VimeoNetworking module 👍 