### PR TITLE
VIM-6205: Updates join requests

### DIFF
--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -292,9 +292,9 @@ final public class AuthenticationController
      - parameter password:   the new user's password
      - parameter completion: handler for authentication success or failure
      */
-    public func join(withName name: String, email: String, password: String, completion: @escaping AuthenticationCompletion)
+    public func join(withName name: String, email: String, password: String, marketingOptIn: String, completion: @escaping AuthenticationCompletion)
     {
-        let request = AuthenticationRequest.joinRequest(withName: name, email: email, password: password, scopes: self.configuration.scopes)
+        let request = AuthenticationRequest.joinRequest(withName: name, email: email, password: password, marketingOptIn: marketingOptIn, scopes: self.configuration.scopes)
         
         self.authenticate(with: request, completion: completion)
     }

--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -320,9 +320,9 @@ final public class AuthenticationController
      - parameter facebookToken: token from facebook SDK
      - parameter completion:    handler for authentication success or failure
      */
-    public func facebookJoin(withToken facebookToken: String, completion: @escaping AuthenticationCompletion)
+    public func facebookJoin(withToken facebookToken: String, marketingOptIn: String, completion: @escaping AuthenticationCompletion)
     {
-        let request = AuthenticationRequest.joinFacebookRequest(withToken: facebookToken, scopes: self.configuration.scopes)
+        let request = AuthenticationRequest.joinFacebookRequest(withToken: facebookToken, marketingOptIn: marketingOptIn, scopes: self.configuration.scopes)
         
         self.authenticate(with: request, completion: completion)
     }

--- a/VimeoNetworking/Sources/Constants.swift
+++ b/VimeoNetworking/Sources/Constants.swift
@@ -27,8 +27,7 @@
 import Foundation
 
  /// Base URL for the Vimeo API
-//public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
-public let VimeoBaseURL = URL(string: "https://api-2339-mark2-api.ci.vimeows.com")!
+public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
 
  /// Default API version to use for requests
 internal let VimeoDefaultAPIVersionString = "3.4"

--- a/VimeoNetworking/Sources/Constants.swift
+++ b/VimeoNetworking/Sources/Constants.swift
@@ -28,7 +28,7 @@ import Foundation
 
  /// Base URL for the Vimeo API
 //public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
-public let VimeoBaseURL = URL(string: "https://api-2339-mark2.ci.vimeows.com")!
+public let VimeoBaseURL = URL(string: "https://api-2339-mark2-api.ci.vimeows.com")!
 
  /// Default API version to use for requests
 internal let VimeoDefaultAPIVersionString = "3.4"

--- a/VimeoNetworking/Sources/Constants.swift
+++ b/VimeoNetworking/Sources/Constants.swift
@@ -27,7 +27,8 @@
 import Foundation
 
  /// Base URL for the Vimeo API
-public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
+//public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
+public let VimeoBaseURL = URL(string: "https://api-2339-mark2.ci.vimeows.com")!
 
  /// Default API version to use for requests
 internal let VimeoDefaultAPIVersionString = "3.4"

--- a/VimeoNetworking/Sources/Request+Authentication.swift
+++ b/VimeoNetworking/Sources/Request+Authentication.swift
@@ -171,10 +171,11 @@ extension Request where ModelType: VIMAccount
      
      - returns: a new `Request`
      */
-    static func joinFacebookRequest(withToken facebookToken: String, scopes: [Scope]) -> Request
+    static func joinFacebookRequest(withToken facebookToken: String, marketingOptIn: String, scopes: [Scope]) -> Request
     {
         let parameters = [ScopeKey: Scope.combine(scopes),
-                          TokenKey: facebookToken]
+                          TokenKey: facebookToken,
+                          MarketingOptIn: marketingOptIn]
         
         return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters)
     }

--- a/VimeoNetworking/Sources/Request+Authentication.swift
+++ b/VimeoNetworking/Sources/Request+Authentication.swift
@@ -40,6 +40,7 @@ private let TokenKey = "token"
 private let PinCodeKey = "user_code"
 private let DeviceCodeKey = "device_code"
 private let AccessTokenKey = "access_token"
+private let MarketingOptIn = "marketing_opt_in"
 
 private let GrantTypeClientCredentials = "client_credentials"
 private let GrantTypeAuthorizationCode = "authorization_code"
@@ -134,12 +135,13 @@ extension Request where ModelType: VIMAccount
      
      - returns: a new `Request`
      */
-    static func joinRequest(withName name: String, email: String, password: String, scopes: [Scope]) -> Request
+    static func joinRequest(withName name: String, email: String, password: String, marketingOptIn: String, scopes: [Scope]) -> Request
     {
         let parameters = [ScopeKey: Scope.combine(scopes),
                           DisplayNameKey: name,
                           EmailKey: email,
-                          PasswordKey: password]
+                          PasswordKey: password,
+                          MarketingOptIn: marketingOptIn]
         
         return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters)
     }


### PR DESCRIPTION
### Ticket
[VIM-6205](https://vimean.atlassian.net/browse/VIM-6205)

### Ticket Summary
Temporarily update the base URL to point to an internal CI branch: `https://api-2339-mark2.ci.vimeows.com`

### Implementation Summary
**Updated AuthenticationController:**
- Added `marketingOptIn` parameters to our join with Email, and join with Facebook methods.

**Updated Constants:**
- Temporarily commented out the normal base URL and replaced it with our work-in-progress CI branch. 🚨 We won't merge this PR until that work has been merged first.

**Updated Request+Authentication:**
- Added a new constant for the `marketing_opt_in` key.
- Updated the methods to join with Email, and join with Facebook to accept the new `marketingOptIn` parameter. Note that Google auth is handled client-side.

### Reviewer Tips
This PR will fail CircleCI until the base branch is restored. 

### How to Test
Steps for testing these changes can be found in the related iOS client PR.