### PR TITLE
Add initial support for SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,20 @@
+# Run `swiftlint rules` for a list of available rules.
+
+# Only the rules specified here will be enabled.
+whitelist_rules:
+  - trailing_newline
+  - trailing_whitespace
+
+# Paths to include during linting.
+included:
+  - ../VimeoNetworking/Sources
+
+# Paths to exclude during linting.
+excluded:
+  - Pods
+
+# Configurable rules can be customized from this configuration file,
+# binary rules can set their severity level.
+trailing_whitespace:
+  ignores_empty_lines: true
+

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,23 @@
+#  Copyright © 2018 Vimeo. All rights reserved.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
 # Run `swiftlint rules` for a list of available rules.
 
 # Only the rules specified here will be enabled.

--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ def shared_pods
 end
 
 target 'VimeoNetworkingExample-iOS' do
+    platform :ios, '8.0'
     shared_pods
 
     target 'VimeoNetworkingExample-iOSTests' do
@@ -19,6 +20,7 @@ target 'VimeoNetworkingExample-iOS' do
 end
 
 target 'VimeoNetworkingExample-tvOS' do
+    platform :tvos, '9.0'
     shared_pods
 
     target 'VimeoNetworkingExample-tvOSTests' do

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,8 @@ project 'VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj'
 
 def shared_pods
 	pod 'AFNetworking', '3.1.0'
-    pod 'VimeoNetworking', :path => '../VimeoNetworking'
+	pod 'SwiftLint', '0.25.1'
+	pod 'VimeoNetworking', :path => '../VimeoNetworking'
 end
 
 target 'VimeoNetworkingExample-iOS' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,18 +27,21 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (6.0.0)
   - OHHTTPStubs/Swift (6.0.0):
     - OHHTTPStubs/Default
+  - SwiftLint (0.25.1)
   - VimeoNetworking (3.1.0):
     - AFNetworking (= 3.1.0)
 
 DEPENDENCIES:
   - AFNetworking (= 3.1.0)
   - OHHTTPStubs/Swift (= 6.0.0)
+  - SwiftLint (= 0.25.1)
   - VimeoNetworking (from `../VimeoNetworking`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - AFNetworking
     - OHHTTPStubs
+    - SwiftLint
 
 EXTERNAL SOURCES:
   VimeoNetworking:
@@ -47,8 +50,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   OHHTTPStubs: 752f9b11fd810a15162d50f11c06ff94f8e012eb
+  SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
   VimeoNetworking: a826838fc6998122962592c3d309579ad13ab5cd
 
-PODFILE CHECKSUM: 8bc00af8cb642e1f83b3344d3caef185d1921606
+PODFILE CHECKSUM: 15308d7273e1bf844b2ad8c456612b686e9c5b45
 
 COCOAPODS: 1.5.2

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -27,18 +27,21 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (6.0.0)
   - OHHTTPStubs/Swift (6.0.0):
     - OHHTTPStubs/Default
+  - SwiftLint (0.25.1)
   - VimeoNetworking (3.1.0):
     - AFNetworking (= 3.1.0)
 
 DEPENDENCIES:
   - AFNetworking (= 3.1.0)
   - OHHTTPStubs/Swift (= 6.0.0)
+  - SwiftLint (= 0.25.1)
   - VimeoNetworking (from `../VimeoNetworking`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - AFNetworking
     - OHHTTPStubs
+    - SwiftLint
 
 EXTERNAL SOURCES:
   VimeoNetworking:
@@ -47,8 +50,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   OHHTTPStubs: 752f9b11fd810a15162d50f11c06ff94f8e012eb
+  SwiftLint: ce933681be10c3266e82576dad676fa815a602e9
   VimeoNetworking: a826838fc6998122962592c3d309579ad13ab5cd
 
-PODFILE CHECKSUM: 8bc00af8cb642e1f83b3344d3caef185d1921606
+PODFILE CHECKSUM: 15308d7273e1bf844b2ad8c456612b686e9c5b45
 
 COCOAPODS: 1.5.2

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00717F97B372A0C8177761ECE1EBFCC9 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B28FFAF92DDD22D3FBCFE02BE916D227 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00717F97B372A0C8177761ECE1EBFCC9 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1321FA5BE51F20152EFEEAD2DF86264D /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		025C909225F5D1505857AD676045BD79 /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DD6269B5D433646990D053C1BE8ED86B /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		026C2332BD198E437138742C3E31C910 /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E80E99900FD85AE8497348CCCF7BB6 /* VIMObjectMapper+Generic.swift */; };
 		037869DBEF8372DD2FAFD9CCF7C74999 /* VIMChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1642F81FE2B6075D3F53F64D9661DA3B /* VIMChannel.m */; };
@@ -15,7 +15,7 @@
 		04F8B992ED7442F7EA7CB4CC494DB52A /* VIMLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB998775BC0746B9C955DD4E84712D94 /* VIMLive.swift */; };
 		0700E71CDDDFF624D4782CC0893584E4 /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 354F708ECA61A2D09230BC2D11127563 /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		077CB6DBB6DF2281635B37C929601103 /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A5F5B0FDBA5BEA33C54B361C623DD /* Request+Configs.swift */; };
-		07A838805D75951F0C07DFE532F807F7 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = DF08848C4D20199424B4C46E998F601B /* UIWebView+AFNetworking.m */; };
+		07A838805D75951F0C07DFE532F807F7 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */; };
 		081BA41A4AAE9AA3FB3DE2904A7A52F1 /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 04EAB97A115CD978A14846C884D749B6 /* VIMVideoPreference.m */; };
 		0A236489AE652EE1C529FF21274E28D7 /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53886DF0B3D70B00BDCAF83C3FC21D /* Request+Comment.swift */; };
 		0A49B0BA50953C3DF34C78106AD81941 /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600BEB389D031E92F894D6226B7C8F4D /* AuthenticationController.swift */; };
@@ -27,94 +27,94 @@
 		0C4185B8071F4C00A122786C42267F61 /* VIMLiveStreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE559EBA7D568094DE418CDFC294970C /* VIMLiveStreams.swift */; };
 		0C9FB09AE50C35EF19BDD5722096FFC7 /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2B93EB7C004451ACA90394671BB95 /* VIMObjectMapper.m */; };
 		0D828D13ACFDAAD7F3AC7C92DEF864A6 /* VIMSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D235AD1856F5C589BEAF9E4FC005E6 /* VIMSpace.swift */; };
-		0E0D46D8300E70F26C25F7CB5534C1B3 /* VimeoNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 718DC36F32779DC90E0C41A36AC2F0AC /* VimeoNetworking-iOS-dummy.m */; };
+		0E0D46D8300E70F26C25F7CB5534C1B3 /* VimeoNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7D83DA48B23C73C97878387A2F94D1 /* VimeoNetworking-iOS-dummy.m */; };
 		0EC5A9F302BA3E80F41E63C7D8907D8D /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6541BD7AB0F17432290D19DDE180D316 /* AppConfiguration.swift */; };
-		0FCF89C4780D1DBB05339AA8B46295F6 /* OHHTTPStubsMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 401026E25B68A923C0B6E168B189900A /* OHHTTPStubsMethodSwizzling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		104E6876B90B4D50379E4A9A99779FE8 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F49260E55B65FF1AA0FAC6AD5F62D98F /* UIProgressView+AFNetworking.m */; };
-		105BC7B62FD47A2281D6F6F3F100B5F0 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F49260E55B65FF1AA0FAC6AD5F62D98F /* UIProgressView+AFNetworking.m */; };
+		0FCF89C4780D1DBB05339AA8B46295F6 /* OHHTTPStubsMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8EECBE5AC34543AC0DA54CBA417F94 /* OHHTTPStubsMethodSwizzling.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		104E6876B90B4D50379E4A9A99779FE8 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A155E222221ECA310A527C1C4F3E79 /* UIProgressView+AFNetworking.m */; };
+		105BC7B62FD47A2281D6F6F3F100B5F0 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A155E222221ECA310A527C1C4F3E79 /* UIProgressView+AFNetworking.m */; };
 		11037B4A805A1451D215D0BA2FCACB0C /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC2226C458356246DAE3E43149D2140E /* AFNetworking.framework */; };
 		11B03B5B112E9435CB9EB040940E148A /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF706384DAA54F410FC2C4F527F391E /* VimeoClient.swift */; };
 		1244665E2409E99DF2D203B778E230BE /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EB478DA1571590140A9EF037D46D485 /* VIMCategory.m */; };
 		1313C8BE9932DD9B81A557115BC78B0A /* Pods-VimeoNetworkingExample-iOSTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C59CBF3BB7FBFE6BCBBB5EB05D3DA20 /* Pods-VimeoNetworkingExample-iOSTests-dummy.m */; };
-		133648C2ACAD932C65DE12AB83012961 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D4182ADE116CA08CB2B4E1EF539811A /* AFHTTPSessionManager.m */; };
+		133648C2ACAD932C65DE12AB83012961 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 55414FC27D39F6FE310EA0A1A9B01652 /* AFHTTPSessionManager.m */; };
 		13EB733326FFD5927AF32B0979BA53E3 /* VIMProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D0B77ECA667371F4D11CC2179EC413 /* VIMProgrammedContent.swift */; };
 		148012661AC11B5144446BEE86D4F5B1 /* VIMLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB998775BC0746B9C955DD4E84712D94 /* VIMLive.swift */; };
 		14815EC7CE6B844374C16752D60A58EE /* VIMTrigger.m in Sources */ = {isa = PBXBuildFile; fileRef = 36DC0ADF4080F7F62F229D9FBA414D6D /* VIMTrigger.m */; };
 		14B27042A053CD9B9463DE11D0658DDA /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB2033C30CA130FEA01B2241D3F3F655 /* CFNetwork.framework */; };
-		14C33620EE8EEC6CD3D4A40B791C209B /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2E42478CA76BB6EBAE6C77E59532E6 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		14C33620EE8EEC6CD3D4A40B791C209B /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DDFF4DA52A4F6F21983F6455B1BBA00 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1616DFA5E2AA11C134A180E99DA63096 /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D435BD7921CBCDC87A847759D72B51C /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		168D57BF26F274669EC349BCAD9B1023 /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32B0D9718FC14738188E3E79CCB61B3 /* PlayProgress.swift */; };
 		17BC8423F994A90FCDBD14A342CAF9B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */; };
 		18B40624CB29C66B5A186F8725ABFD8C /* VIMQuantityQuota.h in Headers */ = {isa = PBXBuildFile; fileRef = 354F708ECA61A2D09230BC2D11127563 /* VIMQuantityQuota.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18DDC5F4943C6894CC86557AC60ED8EF /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = A3DC5B0ABE9FD3C219EA281D609118B9 /* AFAutoPurgingImageCache.m */; };
+		18DDC5F4943C6894CC86557AC60ED8EF /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0253070E47023CF89CC23147E1435854 /* AFAutoPurgingImageCache.m */; };
 		197D6CFBD901E69356EDADA0829D7EA0 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DCD58F3FDB49CAB9C841EB0973B4F55 /* VIMVideoHLSFile.m */; };
 		19F9FA3FF53DED24C2CBD6CEA1B76755 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = C0281338E2ABACEC9C2E0D98AD9C7B28 /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A1D508EC3B0DFB6DADB8BAC8417D7F4 /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 50619DBA8E123C123B0CD2B8BDC7AA31 /* digicert-sha2.cer */; };
 		1ABB581BBA926B821517D836529CEA25 /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = 5811EFB16042D6FBD1583EB7157A4944 /* VIMAppeal.m */; };
 		1B579E9BC68B99E36A202AEE10E03248 /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A51AD98B7FB72BAB2F01D5CF75D348B /* ErrorCode.swift */; };
 		1D005C862A4510619E580EC061A23D7E /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 976F2632149220B6FD4D1ABCD9BE8347 /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1D3018AA33347B489EA4F092DEEA6FB5 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 32DA090D06B850ABB7CAB4B10F7C7E98 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D3018AA33347B489EA4F092DEEA6FB5 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E6358FA7C9EE5C5A002DE3D91FB1FDD /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1DE32C9C6AE522504354595AC3C682BA /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 444DEF80D39EE6ECF5B9FCB6C11C968F /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E00553AA92F761CE3CA20B842A30E4B /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 460FF79A87A4367281362F5C424747A0 /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1ED734C00923049829BE412286D9913A /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D24AC2247C760AB8D074EE0A61081 /* Request+Notifications.swift */; };
 		1F73435DDD3C9D797DCB2333C3D94D0D /* VIMObjectMapper+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E80E99900FD85AE8497348CCCF7BB6 /* VIMObjectMapper+Generic.swift */; };
-		2046B95CA0A09111313C0869219A7452 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7647B1BF5A086B627A30A9F6CF30168F /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2046B95CA0A09111313C0869219A7452 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EDD28BF9E17BFD5BD58B97EB672984 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		206BCCF8AFA02A5530E60157BF3306AA /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20B19E530CD5ACE5473BD5A4FFC583 /* Request+Soundtrack.swift */; };
 		207EB18F3063BFC98D5FA730A1120B33 /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = F6653787554A5DD3C4AD7E741D79C43E /* VIMVideoDASHFile.m */; };
-		2108FCAB8DAA25568D722C1CF805FA64 /* AFNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 83EA0676CF21BA54E28A0CD5DD8AC21A /* AFNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2108FCAB8DAA25568D722C1CF805FA64 /* AFNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 574DDA2F1DA0EDF2376E53BA1430851E /* AFNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21CB3C23B7B5C1FAA73FF18649DC10E9 /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = C59902AF61FD02ED3DE6DB2B2D1D2433 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21CFCEBA5F5815A52BDA52192720E35C /* VIMSoundtrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 94CE0DDC3DD0A355A198035ED50FA887 /* VIMSoundtrack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		22A325F7DE55941DDF29C35D1A14CCB2 /* VIMObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2B93EB7C004451ACA90394671BB95 /* VIMObjectMapper.m */; };
 		238A49C9939B3C7BDC95ADB417C27A2C /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFECD0DF05B25F9844E61A9880BA410 /* Response.swift */; };
-		23C7A2297208FA7F24E7151E95F75DA4 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FB909CA01DA859FF3FC525EA127F2107 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23C7A2297208FA7F24E7151E95F75DA4 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F21BECB66C74C9E7191AD486147C466 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24917C1B6EB8AFEA397168CEB1F6E4CD /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238CD7D8BB5E478B550EFF23CE699770 /* VimeoSessionManager+Constructors.swift */; };
 		252ADD4C174ADF8C51FBD53710BEDD22 /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 83780327FED2094C7FB0DCAE299FD7A5 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		25F1567F2A3CAB513C87C95591748B06 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA1355D1605FF0ACAA75DF5D4190DD /* Subscription.swift */; };
-		262E9BB53B76EE70D2E2D0FE39E3ABF2 /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 84EF1EEF4D368BD5CFC8174DD3FA603C /* AFImageDownloader.m */; };
+		262E9BB53B76EE70D2E2D0FE39E3ABF2 /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C5180CE8C0AEED2C554ED751A28E51 /* AFImageDownloader.m */; };
 		26E82B38596CB57D29F8485F0A0456A0 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727A496A9F9CEE3A461236AC96190395 /* VIMBadge.swift */; };
-		26FBF75D69C41B9DD9D451F96A8AB6B4 /* OHHTTPStubsMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B74F4016605464912CC5A20B05C72E /* OHHTTPStubsMethodSwizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		283FB32387F8FE605285817BA06B972F /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B15C0878CB0C1A442EDB4FFC6FCA78D2 /* AFURLSessionManager.m */; };
+		26FBF75D69C41B9DD9D451F96A8AB6B4 /* OHHTTPStubsMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E96CFB2C90199A00BC2B3195410C55D /* OHHTTPStubsMethodSwizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		283FB32387F8FE605285817BA06B972F /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B8180C0BD5E8EC37F90490D3CA269BAA /* AFURLSessionManager.m */; };
 		28716EB93A16D3BFD922E2578D7A5BAB /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = 94A9ED292066F23D3980211252C761BC /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2896E2EC2D9CAF6F297586ED1C5BA99A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */; };
 		289B49F116FA037440B5198440BCEF18 /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B387BBAE47D74F220CA7AF7E64EB73 /* VIMNotification.m */; };
 		28EC8B3BA6FEBA4612AE88E10A17E681 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 124D5039A1F4CEF665FDA222B57DD677 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AD0526440746F9F05B8A715F11ECF51 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7647B1BF5A086B627A30A9F6CF30168F /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2AD0526440746F9F05B8A715F11ECF51 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EDD28BF9E17BFD5BD58B97EB672984 /* AFURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C36845817885EE1499525078EC90376 /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CE0B2CEDCA02B0336A26CAF233335E7 /* VIMQuantityQuota.m */; };
-		2C84F790405CE5C2BFD0B26FF71A3DC3 /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = BD0F06927E6DCCD70513AD4F7017E0C1 /* OHHTTPStubsResponse+JSON.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2CAE1D3E1F5EEF6BF2F1087AECFBAAC4 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EC90DBE7933C4957EC1940C58E4CBA3 /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C84F790405CE5C2BFD0B26FF71A3DC3 /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = 84DC4945F0CE70C8829DE6AABD8B24F8 /* OHHTTPStubsResponse+JSON.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		2CAE1D3E1F5EEF6BF2F1087AECFBAAC4 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = DDA1346A32994737D350AC6EC4C7E3BC /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2CDE65AF8A7601CA81224848A17206F3 /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = EA6AFEADD257070DA241A6DE3FE996B8 /* VIMUser.m */; };
 		2CFF57B45A1D719357AE9EB924AFC9A4 /* VIMLiveChatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938153199D95AF78E89094DD5AA19CAC /* VIMLiveChatUser.swift */; };
 		2D03ECA7A65F01493F0F36CA2BA96529 /* PlayProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32B0D9718FC14738188E3E79CCB61B3 /* PlayProgress.swift */; };
 		2D5A6A84F8F6BAAD272A96D018ABD07E /* VIMTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = 83CE90A6CA5CB9F9ABF903126E8EB641 /* VIMTrigger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2E0AA3C22FA193E2DA12114D5ECAE18A /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 116399426B26CFD5FD6337B68AEA451C /* AFNetworkReachabilityManager.m */; };
-		2E8A197EDD2F7124658FD8AA4433D670 /* OHHTTPStubs+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFF6518DB1C31D746A751613D1751 /* OHHTTPStubs+NSURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		2E0AA3C22FA193E2DA12114D5ECAE18A /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A714259BF8355E2CF37EE17258A289CC /* AFNetworkReachabilityManager.m */; };
+		2E8A197EDD2F7124658FD8AA4433D670 /* OHHTTPStubs+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FE3BBE46E4C7CAB980BE0B85C34AEDB3 /* OHHTTPStubs+NSURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		2EEF0A8C36D5E9C2B41F13B6FC652193 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = A8D8F7A437D9A6776896A730C017F954 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2F334FC50F86B51BEA2412182CAEDFC6 /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E9A244E10D11F27FC8B2C120CA03267 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FCA04058A7FFB8440B102031C3D079F /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D24AC2247C760AB8D074EE0A61081 /* Request+Notifications.swift */; };
-		31690F8DCE17FD728FCEF023AF10C65D /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = BD0F06927E6DCCD70513AD4F7017E0C1 /* OHHTTPStubsResponse+JSON.m */; };
-		325FAB22F382F0F517B476472FFDB847 /* OHHTTPStubsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A080F18E8B7646F65EA74331AE60746 /* OHHTTPStubsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31690F8DCE17FD728FCEF023AF10C65D /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = 84DC4945F0CE70C8829DE6AABD8B24F8 /* OHHTTPStubsResponse+JSON.m */; };
+		325FAB22F382F0F517B476472FFDB847 /* OHHTTPStubsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		326650E36E5670E3CFC4BCA179099CB9 /* VIMConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = C0281338E2ABACEC9C2E0D98AD9C7B28 /* VIMConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3375C0D32DCF0B6992B3D44458B3C8D4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEE1FA6FEF6A458A376A1B4C1E8A5B /* AFURLResponseSerialization.m */; };
-		3392907797F114E953C679ABA921BC78 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 618327D4DFADDA200A5129D04FC3B50D /* AFSecurityPolicy.m */; };
-		340457C0F1D082F668CFF7E1DF3D61C1 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ADE08DB317825E6252DADAF183C8594 /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3375C0D32DCF0B6992B3D44458B3C8D4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 414091E794E2076CE03DFEBD89D38746 /* AFURLResponseSerialization.m */; };
+		3392907797F114E953C679ABA921BC78 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */; };
+		340457C0F1D082F668CFF7E1DF3D61C1 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 7830DB57DE3EA2CFD49FD16DCB51353D /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		342113DC8B5E5B1D295ADEEB259FD51F /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 945D61D8C14B3521948E03816738A4DE /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3427999648A02BD49C5D71488529409F /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C7C1F9A887AA46CC02742939DD319A9 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		345343367D9511CBCA90AFC41B9B4ABA /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 618327D4DFADDA200A5129D04FC3B50D /* AFSecurityPolicy.m */; };
+		3427999648A02BD49C5D71488529409F /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 006AC8BB3C72CA483D8DF7E93BA7D212 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		345343367D9511CBCA90AFC41B9B4ABA /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */; };
 		34D1BED815A298B496AA5F44D496CE60 /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D73E83D537CFA1A3A1E46D3C90AF59B /* VIMModelObject.m */; };
-		3517B770BE855D36D4DD051FB084B034 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BAFF4B2230B954A9192546154C238EE3 /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3651018F1F0E0F1EDB2169BB44719266 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E739EEE834C7C0BAB582D70BEEF9E73 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3517B770BE855D36D4DD051FB084B034 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 614359312042614CD737C5244FDE4995 /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3651018F1F0E0F1EDB2169BB44719266 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = DB9683AAFA44CD07EF76EEF539C98082 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		369876394A5D6B2E24E2D7788B0083A6 /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5E48372F2DEA56E3286072A1F50BF5 /* VIMVideoPlayFile.m */; };
 		3774EC97E1AE2720029A975B724C3BD7 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483BC4B898F27AC1CB61DC2B40DB5796 /* ResponseCache.swift */; };
-		392E961C28CF6D04564A806D1EE602CE /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEE1FA6FEF6A458A376A1B4C1E8A5B /* AFURLResponseSerialization.m */; };
+		392E961C28CF6D04564A806D1EE602CE /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 414091E794E2076CE03DFEBD89D38746 /* AFURLResponseSerialization.m */; };
 		3B3F2158E6712F00D55B9C13E7E27253 /* NetworkingNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCF9F8F6D70CB3C9ECB2C287D0EEF22 /* NetworkingNotification.swift */; };
 		3B4EF739D828BE54717998E6A8E43A56 /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39AA3A2AAE57F8EA725E4C60A64027C /* NSURLSessionConfiguration+Extensions.swift */; };
 		3D25CB42C6E4ED7F99905649216CCEF8 /* VIMLiveStreams.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE559EBA7D568094DE418CDFC294970C /* VIMLiveStreams.swift */; };
 		3DDB062A7D454DD3F4F3B2659DE0573A /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D546CE6D725C63D5D4CBAECBC0A982B /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3E193AD16FFC6FAF727DC56EC48C97F8 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 116399426B26CFD5FD6337B68AEA451C /* AFNetworkReachabilityManager.m */; };
+		3E193AD16FFC6FAF727DC56EC48C97F8 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A714259BF8355E2CF37EE17258A289CC /* AFNetworkReachabilityManager.m */; };
 		3E3D1C58080CAA85D8524988A321A078 /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A138196DB723F44A6CC162F1069C21 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E51FB67A529DDB6BB268B05C674123E /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 7666E344E7B2EB0D57E54461444DA988 /* VIMVODConnection.m */; };
 		3EEF631471A679EEC22F69560CD27691 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E24B7AF42B9CCA92E9A921DE209B454 /* Result.swift */; };
-		3F741EA0C204DC7EE8A068BA1B8EFD03 /* OHHTTPStubsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = F6288BEC4348892675C2475A77E86422 /* OHHTTPStubsResponse.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		3F741EA0C204DC7EE8A068BA1B8EFD03 /* OHHTTPStubsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A07D1FF3DFDE6B422F2EAADD824CF8 /* OHHTTPStubsResponse.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		3F780B6A34A6CA9C636836D034CC462C /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FA315091126838D7B0C813407ED0128 /* VIMUserBadge.m */; };
 		40689A1A2B48ABF8CA5529CB74DEE54E /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C69EEA3F1070199D263832FB5405713 /* VimeoReachability.swift */; };
 		41572E6FB49ADDC861A38197967556FC /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EA9468CA9ECE872AB05990C9E5DD0B /* Dictionary+Extension.swift */; };
@@ -122,29 +122,29 @@
 		41AB4A49DEA24C033039CF7C55C82507 /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = DFBC061669ECF9828BC495A7ED8224CA /* VIMRecommendation.m */; };
 		4303F1B51B78E7B7DF31982EBC85296A /* VIMThumbnailUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A138196DB723F44A6CC162F1069C21 /* VIMThumbnailUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		430A451DD18B8E685B7BF6B0CBFB43F8 /* VIMPolicyDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 460FF79A87A4367281362F5C424747A0 /* VIMPolicyDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4361504926FEFF45F6D4AA34C6556E43 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F11C447B4A5C1DD7EC8A74F705C45D7 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4361504926FEFF45F6D4AA34C6556E43 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0A53DBADB8E47787E5EB397CA667D2 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44046F2EF4C6DE8A0F77BF138DE1BC4A /* VIMUploadQuota.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F926AFA66D2BA02ABEA8E0CC0EA1E8E /* VIMUploadQuota.swift */; };
-		440D9DD318C5956C33A45AC9845581C0 /* NSURLRequest+HTTPBodyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D70075751D4887B8E75038A18FE14AB /* NSURLRequest+HTTPBodyTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		440D9DD318C5956C33A45AC9845581C0 /* NSURLRequest+HTTPBodyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		45A31EE29B1B5CDCD4C7CF7A0EF9F89C /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 33009827B09F12EA3D4A381041262FB4 /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		45BB1FECF92BE31D17301FFF26D608AE /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39AA3A2AAE57F8EA725E4C60A64027C /* NSURLSessionConfiguration+Extensions.swift */; };
 		465B71CB390360C89A48858737386666 /* Request+Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EC9500893E82413EA06DCB6B88BEB1 /* Request+Authentication.swift */; };
-		46DE41A766A44C64ACD4D6ACF403856A /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BAFF4B2230B954A9192546154C238EE3 /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46DE41A766A44C64ACD4D6ACF403856A /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 614359312042614CD737C5244FDE4995 /* AFNetworkReachabilityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47089D8845969D08F3BBFBA81FFD50BF /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1FB70C75EBB3AEC7A47923C95AF14D /* VIMGroup.m */; };
 		4767C8A38E4B90F03D543B6E6733FA02 /* VIMVideo+VOD.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EB2142BFAAB1124741786C0AF6CCB63 /* VIMVideo+VOD.m */; };
 		47E0D621AF59BB37393DD7BC37C8597F /* PinCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FD0D59B0CCCC535215F828E7331612 /* PinCodeInfo.swift */; };
 		47EB47248B0CBC76E3607FBE8CABF0BF /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DF148892C3ABD3CC940B502193A8E79 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		480161656669FA5A7EE934ADA23D7760 /* Request+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A5F5B0FDBA5BEA33C54B361C623DD /* Request+Configs.swift */; };
-		4C2CC621FE64C8F2B2CBEC0AEAC6CBC2 /* OHPathHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B18965434B4C68D2A4F947A029A1906 /* OHPathHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C2CC621FE64C8F2B2CBEC0AEAC6CBC2 /* OHPathHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0606579DBD66FA4905BDE4F2FE00F6 /* OHPathHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C6CB3DA04CBA21A4FA985285A2CA935 /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 40F24E8193C2BE38D8277F67EE1955B1 /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4CF98C69E62F59634FF245A84F4DAF07 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 85551D9083D5C20B2665444C48558A44 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CF98C69E62F59634FF245A84F4DAF07 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B13AC05770B2268AAE5B8B3430B674DE /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CFBB764B3D6DB94DCC7D012FBE342F8 /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3937FDFCF80B4C9A8350ED82D2ECE55B /* VIMVideoProgressiveFile.m */; };
-		4E77488ECAE3D3CCF8F2AA55FE66C922 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB1CC3483006C633E669183CE549B946 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E77488ECAE3D3CCF8F2AA55FE66C922 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F5C0B219A4075B82721CEAA92BA6055 /* VIMGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1FB70C75EBB3AEC7A47923C95AF14D /* VIMGroup.m */; };
 		502EF423F4B784B5C23646643A724F84 /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA37E80CBDF85EFB07653B898BCDDD9 /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		508993925A49B58D175AF2EAE36C6DF0 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 08A008ACC9E799DF4602B4DB46382C7B /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		50B46C2116807F35035EB4FE5B846949 /* Request+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF22B27C2300EE058B13556A0504F06 /* Request+User.swift */; };
 		547F781DBC725CAFBF0AB125E27148D4 /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A749B81E908B35FC844C9442E46C4D9 /* Request+Category.swift */; };
-		54A2E4C7475C5FB2D165EB7A9ECABB89 /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = A3DC5B0ABE9FD3C219EA281D609118B9 /* AFAutoPurgingImageCache.m */; };
+		54A2E4C7475C5FB2D165EB7A9ECABB89 /* AFAutoPurgingImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0253070E47023CF89CC23147E1435854 /* AFAutoPurgingImageCache.m */; };
 		55FFD8FFAA8EE9D673512B72981329F3 /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FCD70CA87921F98B314C93A892DC80D /* VIMPolicyDocument.m */; };
 		567971987BDC873EA4DD219ECDC2EE29 /* VimeoSessionManager+Constructors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238CD7D8BB5E478B550EFF23CE699770 /* VimeoSessionManager+Constructors.swift */; };
 		56821353552A909E8C64E0A5DA994402 /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B9C08F447F23CA0F58D4CB554BE51268 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -154,9 +154,9 @@
 		598A0231A8CB18C2D8B7F66CAEBD8F91 /* VIMUploadTicket.h in Headers */ = {isa = PBXBuildFile; fileRef = 945D61D8C14B3521948E03816738A4DE /* VIMUploadTicket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		59D27E479B32C72CDD48D5452F52A72B /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7F1A19EDAB6B91821C0B66DA6606EE /* AccountStore.swift */; };
 		59F3BC22D706970EB5DA273C0CC9A1D3 /* VIMPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DF148892C3ABD3CC940B502193A8E79 /* VIMPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A8B148E874234B38E7D54B4BC805DB4 /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C4CD64935D011C2ED6898B50D4CDDE /* OHPathHelpers.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		5A8B148E874234B38E7D54B4BC805DB4 /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A234D8396D42365A10FBF78662D78E6 /* OHPathHelpers.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		5A9399F4BC99E431F528139F8CC5AB4A /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A5F79E513960BA3518C3AF708D5511 /* SubscriptionCollection.swift */; };
-		5A9D278FB43EEB42291EB41FA16335E6 /* OHHTTPStubsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A080F18E8B7646F65EA74331AE60746 /* OHHTTPStubsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A9D278FB43EEB42291EB41FA16335E6 /* OHHTTPStubsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5AA71189CD89FF9FCB2B2B7E6A08D5B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */; };
 		5C92F460F498DB8B9F6E2049D666372C /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EA9468CA9ECE872AB05990C9E5DD0B /* Dictionary+Extension.swift */; };
 		5CA599233FA378F4132D26ACCDF53285 /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = ED29A8CCF216DD068CC72E828B1AFBE1 /* VIMConnection.m */; };
@@ -169,7 +169,7 @@
 		629848D527EEA3532C0FDDE6E0D11033 /* VIMVideoProgressiveFile.h in Headers */ = {isa = PBXBuildFile; fileRef = B9C08F447F23CA0F58D4CB554BE51268 /* VIMVideoProgressiveFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63517F655058856D536C3B65ED44D276 /* Request+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA634AF354D27194C73D4F11D0226CCA /* Request+Cache.swift */; };
 		6456158A248550C560802C5762D17FB6 /* VIMVideoPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 04EAB97A115CD978A14846C884D749B6 /* VIMVideoPreference.m */; };
-		646094043F88EC0F6CBF6ABCF6F6B108 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 06868FE8F75FA7CDAD397EA9E63FE0AF /* UIRefreshControl+AFNetworking.m */; };
+		646094043F88EC0F6CBF6ABCF6F6B108 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = DFA8937B48AF5FF0492C6D81134A4920 /* UIRefreshControl+AFNetworking.m */; };
 		64F2C1A29E097487E289035781CAD389 /* VIMMappable.h in Headers */ = {isa = PBXBuildFile; fileRef = 33009827B09F12EA3D4A381041262FB4 /* VIMMappable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6511BB5AE617C6651576BBC2B1192F4D /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE465D1211573B009F93A08AE2A1B352 /* NSError+Extensions.swift */; };
 		65240DCEE590EEBE4993621684FB4048 /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCA6ACC575AB709FB4B506C2B3954A2 /* Objc_ExceptionCatcher.m */; };
@@ -179,27 +179,27 @@
 		695CD57E720F2AAF0B34A25953538167 /* VIMPictureCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DACD44283F7816CE5EAC8719476D07C /* VIMPictureCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A46C008649D779ACA7F4E14093A64AB /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F76285C6537E689ED1252C8227229E /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AFED95B1B4948072F76EF5DD93D0535 /* VIMUser.m in Sources */ = {isa = PBXBuildFile; fileRef = EA6AFEADD257070DA241A6DE3FE996B8 /* VIMUser.m */; };
-		6B85FCDF20F6D88B46A33C0CAE76B7DE /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 06868FE8F75FA7CDAD397EA9E63FE0AF /* UIRefreshControl+AFNetworking.m */; };
+		6B85FCDF20F6D88B46A33C0CAE76B7DE /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = DFA8937B48AF5FF0492C6D81134A4920 /* UIRefreshControl+AFNetworking.m */; };
 		6BCAA839C1CCB14F9C51D12D3F0CE3DA /* VIMAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = 11BB2ADFF04A8A2B2C35C4DBBDFD0D83 /* VIMAccount.m */; };
 		6BE11A1762E3D061979CB106623DB4C3 /* VIMVideoPlayRepresentation.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D396D24AAC8580B596A7AA51066CC /* VIMVideoPlayRepresentation.m */; };
 		6BEF7610C9D0DA718CD0CDB4D0CE2B85 /* VIMVideoFairPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 16866E9EDA1707C451567790CE00699D /* VIMVideoFairPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6CF4676A55D177939AA3BEE126BDD727 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0864552A7599E2DCE46506D035A84470 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CF4676A55D177939AA3BEE126BDD727 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B2635634392B942A9DD483C6329941C5 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CFEFD7B10A7AA28DC9208CBDEB91E66 /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 337C679C0033E1196D3296D15FD8C2E5 /* VIMVideo.m */; };
-		6D1E801F11377FA300FC7A9D7B4DD353 /* OHHTTPStubs-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 98AE2185572A3BA1F7F05262F566494E /* OHHTTPStubs-tvOS-dummy.m */; };
-		6EE3FA8D4C0A48B2C289CABA55546E37 /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C7C1F9A887AA46CC02742939DD319A9 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6FB0DD2508175E19C53B688664F1D955 /* VimeoNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A3DE97881D47078D62A3D882545BA367 /* VimeoNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		709192415331306947F497DBE3572673 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C6E25A656F0267F49C59411CAE5093 /* UIButton+AFNetworking.m */; };
-		7106B5A492229DAC29B9FE3C9A58BC42 /* OHHTTPStubsResponse+JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AEF2D89A9C7EF2CA680FC1286BB6E38 /* OHHTTPStubsResponse+JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D1E801F11377FA300FC7A9D7B4DD353 /* OHHTTPStubs-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9C92185B5AE98FDFAEAC5BD3B9777 /* OHHTTPStubs-tvOS-dummy.m */; };
+		6EE3FA8D4C0A48B2C289CABA55546E37 /* UIImage+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 006AC8BB3C72CA483D8DF7E93BA7D212 /* UIImage+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FB0DD2508175E19C53B688664F1D955 /* VimeoNetworking-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C461DC0072C2B5EEB7310C9E07C9625 /* VimeoNetworking-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		709192415331306947F497DBE3572673 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 10A360AA316FBBFB69D5C5F0233196D3 /* UIButton+AFNetworking.m */; };
+		7106B5A492229DAC29B9FE3C9A58BC42 /* OHHTTPStubsResponse+JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FF6CD300017F92D8B4F1CD9AD735769 /* OHHTTPStubsResponse+JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		73C6B03764C5E36897363206BB62AE86 /* SubscriptionCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A5F79E513960BA3518C3AF708D5511 /* SubscriptionCollection.swift */; };
 		7408D110BFF90177DCEC74DADFF4C597 /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EA1EB96CF5A2362308F18F78CCFA959 /* VIMPictureCollection.m */; };
-		7425C8F7D7E404156DCE727E03A7739F /* VimeoNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 30766B769E54A458277210073DF50046 /* VimeoNetworking-tvOS-dummy.m */; };
+		7425C8F7D7E404156DCE727E03A7739F /* VimeoNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ECA226C11972598EE0BDCEE5D35E1F4B /* VimeoNetworking-tvOS-dummy.m */; };
 		748486B8276D8100BD0579F5C849E5DB /* VIMVideoDASHFile.m in Sources */ = {isa = PBXBuildFile; fileRef = F6653787554A5DD3C4AD7E741D79C43E /* VIMVideoDASHFile.m */; };
-		7540B3341205665B12B164E1B40C3695 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A871485C394D029F58600E577F7CE2E /* UIImageView+AFNetworking.m */; };
-		7687E666EF6B73BA53089B06A0BC9139 /* OHHTTPStubsResponse+JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AEF2D89A9C7EF2CA680FC1286BB6E38 /* OHHTTPStubsResponse+JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7540B3341205665B12B164E1B40C3695 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = C45174DCB15F51AD57A41DE785396FDD /* UIImageView+AFNetworking.m */; };
+		7687E666EF6B73BA53089B06A0BC9139 /* OHHTTPStubsResponse+JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FF6CD300017F92D8B4F1CD9AD735769 /* OHHTTPStubsResponse+JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		76DE646BA1E30AE5A5E7CFB6C5EB3933 /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F0CE15D12F813D8BD00DB5B662D60632 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77457B736AB9BDA9E60464DD0A5A4753 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E3BFE051F80C7D8716234F0D95F7D2D /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		775C8C32395479BF9922D7920C29C2EF /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 32DA090D06B850ABB7CAB4B10F7C7E98 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		77725B8711C0789B09F81B15C5809581 /* OHHTTPStubsMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B74F4016605464912CC5A20B05C72E /* OHHTTPStubsMethodSwizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		77457B736AB9BDA9E60464DD0A5A4753 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A60D7C472E5A947ED6BA247241E741B /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		775C8C32395479BF9922D7920C29C2EF /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E6358FA7C9EE5C5A002DE3D91FB1FDD /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77725B8711C0789B09F81B15C5809581 /* OHHTTPStubsMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E96CFB2C90199A00BC2B3195410C55D /* OHHTTPStubsMethodSwizzling.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		785BD8225D731711EBC40DD1FE90DAB9 /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 2165ECF9F8CAC231DFC2DC3AFCA51B12 /* VIMVODItem.m */; };
 		78A032B578D8241F2C9A403A621C5DA4 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFC4E5A9B0B069411B6406D44DBAF0 /* Mappable.swift */; };
 		78A446EB35DEB83448D1BBAE63A32BF4 /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 990E98F03B2973DD7DEF3E1526A3CFA6 /* VIMTag.m */; };
@@ -212,30 +212,30 @@
 		7E03A3D0116AE55CB81E54231E55867A /* VIMComment.h in Headers */ = {isa = PBXBuildFile; fileRef = 29A3554DB86AC0CA6FBA14DC12AE715F /* VIMComment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E72F24AEC83E2F97F73113AA7AB43D4 /* VIMSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D235AD1856F5C589BEAF9E4FC005E6 /* VIMSpace.swift */; };
 		7E758C058D9823328C03BF6455458D29 /* VIMModelObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D73E83D537CFA1A3A1E46D3C90AF59B /* VIMModelObject.m */; };
-		7EE791E0D6A810A352504B9EDA5CB9E2 /* OHHTTPStubs+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBFF6518DB1C31D746A751613D1751 /* OHHTTPStubs+NSURLSessionConfiguration.m */; };
+		7EE791E0D6A810A352504B9EDA5CB9E2 /* OHHTTPStubs+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FE3BBE46E4C7CAB980BE0B85C34AEDB3 /* OHHTTPStubs+NSURLSessionConfiguration.m */; };
 		807916C87D8B2AE2B2D4EABE046DC09B /* VIMSoundtrack.m in Sources */ = {isa = PBXBuildFile; fileRef = C551EB3E4A8AEC5C0079CE120B78D898 /* VIMSoundtrack.m */; };
 		8187C66AB968428B5C9917C5A2AF564D /* VimeoReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C69EEA3F1070199D263832FB5405713 /* VimeoReachability.swift */; };
 		82796958402910CFE85E11411A35EEB5 /* VimeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF706384DAA54F410FC2C4F527F391E /* VimeoClient.swift */; };
 		827FD8600FBC3FB71C1F53C43AFA58A8 /* VIMUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C16AD2D62643913F2016CDB1A8F4D8 /* VIMUpload.swift */; };
 		82995B410E33693F2F37E00F648CCD96 /* VIMLiveChatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938153199D95AF78E89094DD5AA19CAC /* VIMLiveChatUser.swift */; };
-		82BE25BAEE20AACE1767F096D021346F /* OHHTTPStubsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = F6288BEC4348892675C2475A77E86422 /* OHHTTPStubsResponse.m */; };
+		82BE25BAEE20AACE1767F096D021346F /* OHHTTPStubsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A07D1FF3DFDE6B422F2EAADD824CF8 /* OHHTTPStubsResponse.m */; };
 		82C918E9D4E035D5ED72BDD3D2007A91 /* VIMConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = ED29A8CCF216DD068CC72E828B1AFBE1 /* VIMConnection.m */; };
 		83093FD2FFD8FC894EAA21BFA0B5DBD6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDDC891AFB03CD09B35BC1C377F37166 /* Security.framework */; };
-		8314BC15542060383EFCA2DAF5DD3432 /* OHHTTPStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = 0505109CFF4C687AF46E9503DD8210E8 /* OHHTTPStubs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8314BC15542060383EFCA2DAF5DD3432 /* OHHTTPStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		836AE263C6E52C16CB0D248EC13F3BB9 /* ResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483BC4B898F27AC1CB61DC2B40DB5796 /* ResponseCache.swift */; };
 		845BF6D02E2106365392312137488551 /* VIMBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727A496A9F9CEE3A461236AC96190395 /* VIMBadge.swift */; };
-		85E63A687EF81297647181B84C69D644 /* AFNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD261ED3E915F394BECB82B06442F87 /* AFNetworking-iOS-dummy.m */; };
+		85E63A687EF81297647181B84C69D644 /* AFNetworking-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A083E8E2DD7AD5A8CA77BB288DD34377 /* AFNetworking-iOS-dummy.m */; };
 		85EEFF5EAB282F48B6516B3BA934CBC8 /* VIMQuantityQuota.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CE0B2CEDCA02B0336A26CAF233335E7 /* VIMQuantityQuota.m */; };
-		872A2D33CE11426771ADBA0FF2EEB35C /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = CB1CC3483006C633E669183CE549B946 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		872A2D33CE11426771ADBA0FF2EEB35C /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		875A9361734B97CB9857B41A5B444BA0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */; };
-		87E1272DF69030AE5C1E6FA5FA328928 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B15C0878CB0C1A442EDB4FFC6FCA78D2 /* AFURLSessionManager.m */; };
+		87E1272DF69030AE5C1E6FA5FA328928 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B8180C0BD5E8EC37F90490D3CA269BAA /* AFURLSessionManager.m */; };
 		8888835FF6423B2FB48A381C7E357344 /* VIMVideoPlayFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 444DEF80D39EE6ECF5B9FCB6C11C968F /* VIMVideoPlayFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A5AB7D173D8F80675CC2C6E105DFB63 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B428B7434D16B8CDC3FF036471D70B6D /* CoreGraphics.framework */; };
-		8A7D95264F78DEF81451D29DC1C91FDE /* VimeoNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C94529D8B8703E42BD48DF09888E412C /* VimeoNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AFBE34AF57A71975C3FA8B3BA525FBE /* AFNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DD8043066A89F0C3B0B121295F2F58D /* AFNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8CC2C51E63A0F4EFF95B8C0D1FFCF1BF /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 84EF1EEF4D368BD5CFC8174DD3FA603C /* AFImageDownloader.m */; };
+		8A7D95264F78DEF81451D29DC1C91FDE /* VimeoNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 010722D39F81298FE76249F6D7951171 /* VimeoNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AFBE34AF57A71975C3FA8B3BA525FBE /* AFNetworking-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E911C478DE04F75AE4FE191CE6A5D8A /* AFNetworking-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8CC2C51E63A0F4EFF95B8C0D1FFCF1BF /* AFImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C5180CE8C0AEED2C554ED751A28E51 /* AFImageDownloader.m */; };
 		8CDA10B23C1BE87D634AA82032990C31 /* Request+Soundtrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20B19E530CD5ACE5473BD5A4FFC583 /* Request+Soundtrack.swift */; };
-		8D1C112E94044C595A43CE0F5BF32CE6 /* OHHTTPStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D4628139C29E288D16EF0D23CAA8927 /* OHHTTPStubs.m */; };
+		8D1C112E94044C595A43CE0F5BF32CE6 /* OHHTTPStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = A3AAA79C011A0D7096BEECF36E6BFFB1 /* OHHTTPStubs.m */; };
 		8D886BCC4C77D30C2C924162A5914D76 /* VIMPreference.m in Sources */ = {isa = PBXBuildFile; fileRef = 997AC5DE1FA278A656B468D5145CC2B9 /* VIMPreference.m */; };
 		8D8BA802D3F1DE7027C79644BBC19281 /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B5FC27936FE2F46206F8DB1024CD7AA /* VIMComment.m */; };
 		8DFD02999FF7FE9F6E749F01E210DD3C /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451EF7382B1605D927E544B9ECB048E /* Request+ProgrammedContent.swift */; };
@@ -251,7 +251,7 @@
 		9307180442F56C415378783E53917F0E /* VIMPictureCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EA1EB96CF5A2362308F18F78CCFA959 /* VIMPictureCollection.m */; };
 		9309591C651E737D950A163B16C9DD4E /* VIMPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = 94A9ED292066F23D3980211252C761BC /* VIMPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		931187A920F31E3E856600B7A7C12474 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEFC4E5A9B0B069411B6406D44DBAF0 /* Mappable.swift */; };
-		93B26B108CD9143683A34435CAFB62CD /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C6E25A656F0267F49C59411CAE5093 /* UIButton+AFNetworking.m */; };
+		93B26B108CD9143683A34435CAFB62CD /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 10A360AA316FBBFB69D5C5F0233196D3 /* UIButton+AFNetworking.m */; };
 		93F271D3F91ED2E4F39F0534AA3D57CF /* AuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600BEB389D031E92F894D6226B7C8F4D /* AuthenticationController.swift */; };
 		949FECD7EF151719F5CB3F8D295337F2 /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 141613E27500987EFA7D6D289799CE01 /* VIMActivity.m */; };
 		9547B6B4AB9D7A0669DD3AC4D8F63439 /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7DA2171FEA4851FA6271DE2917193E /* Spatial.swift */; };
@@ -260,35 +260,35 @@
 		96AB8F09B16F213B7C22C918470957C1 /* Request+Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C6D2F2667820406CE020694ECB0C4 /* Request+Channel.swift */; };
 		96F1A9E763A201658C28B94738ABD651 /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 73C64A8B6899BAADAA92531BD1D144F4 /* VIMInteraction.m */; };
 		975CF0F4F44F6EA9D4A482C0993DB73E /* ExceptionCatcher+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BE014B17E9B4FB08A7E2D9166BAB58 /* ExceptionCatcher+Swift.swift */; };
-		97CFDFF4A1CDA0F674516EA644C00CBC /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C4CD64935D011C2ED6898B50D4CDDE /* OHPathHelpers.m */; };
+		97CFDFF4A1CDA0F674516EA644C00CBC /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A234D8396D42365A10FBF78662D78E6 /* OHPathHelpers.m */; };
 		9BE372283CCDEF9C7B3B60B9A692AF5C /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBB59C93B058A49CE7EAC43E00F4C30 /* String+Parameters.swift */; };
 		9BF16B9A2FDFE903F68C89347704C15C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */; };
-		9CDCEBE9386F450950739E26A9834C08 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F11C447B4A5C1DD7EC8A74F705C45D7 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9CDCEBE9386F450950739E26A9834C08 /* AFAutoPurgingImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E0A53DBADB8E47787E5EB397CA667D2 /* AFAutoPurgingImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9D0C760BC22AA2328DCAFA74C7ADFD26 /* VIMVideoDRMFiles.m in Sources */ = {isa = PBXBuildFile; fileRef = EE187DD624BADD97CB86FB1B83124BE1 /* VIMVideoDRMFiles.m */; };
-		9D305E2EC3640C235E7D18D3C81C9480 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 039818FD26CA118ABEEA7C6D11F409CA /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D305E2EC3640C235E7D18D3C81C9480 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 34DF3D6618104D202D7E400FAC38D4C5 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9D8D93833DCF245A5030901EA05F3AE4 /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E18455BDAE1871EFC75462CB510A0E /* VIMVideoUtils.m */; };
-		9E3853549EA2E01D48F49C9FBBA50B68 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E3BFE051F80C7D8716234F0D95F7D2D /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9E6F9175F92BD79B778F9E0196B36F7A /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = BA815CE673111F13239C7DDCB582831D /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E3853549EA2E01D48F49C9FBBA50B68 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A60D7C472E5A947ED6BA247241E741B /* AFURLResponseSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9E6F9175F92BD79B778F9E0196B36F7A /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 03CBB8C8659174E12110BF9F15D0EEB4 /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9ED75BCBB053A1D8F14830FDE70132CC /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E24B7AF42B9CCA92E9A921DE209B454 /* Result.swift */; };
 		9FFD17894E51FDA747C68FB1974F3055 /* VIMLiveQuota.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EAB039A6FB6B200763CD2A22B3144A /* VIMLiveQuota.swift */; };
 		A01FC871422BA0B224012771B7EC3AC2 /* VIMCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EB478DA1571590140A9EF037D46D485 /* VIMCategory.m */; };
 		A0391C9CE3634B1A22780FC9C3867279 /* VIMRecommendation.m in Sources */ = {isa = PBXBuildFile; fileRef = DFBC061669ECF9828BC495A7ED8224CA /* VIMRecommendation.m */; };
 		A2336E1CF5503C7F95A1DF2C7EA8363D /* VIMPeriodic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE16B4A66409809D716B9830897F3A /* VIMPeriodic.swift */; };
-		A2C0A5DF12ECFE0DFC9BA404AA736F52 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FB909CA01DA859FF3FC525EA127F2107 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A2C0A5DF12ECFE0DFC9BA404AA736F52 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F21BECB66C74C9E7191AD486147C466 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2F3A0BB3447B0AD6AF5E8F028981F88 /* VIMSeason.h in Headers */ = {isa = PBXBuildFile; fileRef = A8D8F7A437D9A6776896A730C017F954 /* VIMSeason.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2F4DD4A4EDD4767441CAD3D2D6F6996 /* VIMPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = D7ED495F96351C8E44EF7AD04B27DA8F /* VIMPicture.m */; };
 		A3148F25C3403A49C9A23424AEA241EC /* VIMLiveHeartbeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26A51850DAB1AA601D155390CAF8147 /* VIMLiveHeartbeat.swift */; };
-		A38045A5825E3B7DE0DC4578D5B06746 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = DF08848C4D20199424B4C46E998F601B /* UIWebView+AFNetworking.m */; };
+		A38045A5825E3B7DE0DC4578D5B06746 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */; };
 		A3EAFFE38AE1A284F454BAEF8DD9BAEC /* VIMCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D435BD7921CBCDC87A847759D72B51C /* VIMCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A49DC905560E90186091AD737BB51A5E /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 039818FD26CA118ABEEA7C6D11F409CA /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A49DC905560E90186091AD737BB51A5E /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 34DF3D6618104D202D7E400FAC38D4C5 /* UIWebView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A59B298F077F526D2556D61C0B3E4282 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */; };
-		A6289C10FAD8DF4F1D49B6A28ACA958B /* OHHTTPStubsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B6255F90E78087D9005AF8679E252 /* OHHTTPStubsSwift.swift */; };
+		A6289C10FAD8DF4F1D49B6A28ACA958B /* OHHTTPStubsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D14ACCEE1C6E9C7BB7A1B7F5B64BF03 /* OHHTTPStubsSwift.swift */; };
 		A6632799AF50C6DDDA81A52C6C3849E3 /* VIMNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B387BBAE47D74F220CA7AF7E64EB73 /* VIMNotification.m */; };
 		A6B265AEF21133E5F49EB03B90537918 /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002C0C474DB5DB7C7CD2A0289140C192 /* Request+Picture.swift */; };
 		A6D987AE0E0AE8889D7AC3EF98F8D98B /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7F1A19EDAB6B91821C0B66DA6606EE /* AccountStore.swift */; };
 		A734F3863720F4033632448A17EAD3EA /* VIMRecommendation.h in Headers */ = {isa = PBXBuildFile; fileRef = B1E09519749331A478D454CFD1FD4C60 /* VIMRecommendation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A757908C37C5B4F7106A72A1F96A0E56 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CDF8736416D1FB26621B5E594601AE9 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7630DB01B82694021E8AACDA4A7C03E /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 117992A3E9C7F7CE964285F808F41C03 /* AFURLRequestSerialization.m */; };
+		A7630DB01B82694021E8AACDA4A7C03E /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 509F7396F2DCDBEF6C4833C26D738EFF /* AFURLRequestSerialization.m */; };
 		A7A60A0171602CEF151228A4A9EE9A4F /* VIMInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 73C64A8B6899BAADAA92531BD1D144F4 /* VIMInteraction.m */; };
 		A96917A1E96AC1EBA15B1E5C552231C3 /* VIMUserBadge.h in Headers */ = {isa = PBXBuildFile; fileRef = C59902AF61FD02ED3DE6DB2B2D1D2433 /* VIMUserBadge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A973148000C93A723944EC48F301B43C /* VIMPrivacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 40F24E8193C2BE38D8277F67EE1955B1 /* VIMPrivacy.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -299,13 +299,13 @@
 		AB6DEDCE2464DC4858175537BF04C193 /* VIMVODItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 2165ECF9F8CAC231DFC2DC3AFCA51B12 /* VIMVODItem.m */; };
 		AC1D5BDC9B246F2802561658834073AD /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 06A5F2867A813A5FD4CCADD5F0AD4968 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC3C26D63AEDAD40CE7D7E97E6E7CF79 /* Pods-VimeoNetworkingExample-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D68BC1F974E81C4E33197B3E237F4984 /* Pods-VimeoNetworkingExample-tvOS-dummy.m */; };
-		ACBBD3E5609FF742DB70AAC1F1DB12B7 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E739EEE834C7C0BAB582D70BEEF9E73 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACBBD3E5609FF742DB70AAC1F1DB12B7 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = DB9683AAFA44CD07EF76EEF539C98082 /* UIRefreshControl+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD1471987E0B21959D1293B0FDC45775 /* VIMActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F76285C6537E689ED1252C8227229E /* VIMActivity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE29EC53B7CD3E0B5C2C9FDF3A76EEF2 /* Request+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A749B81E908B35FC844C9442E46C4D9 /* Request+Category.swift */; };
 		AE4021E7808DFD9072563392EAF6A1AA /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9447F13F56AB208D60EFF94C526B308 /* VimeoResponseSerializer.swift */; };
 		AE40F650A587550C83182210D05A626B /* VIMSizeQuota.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F86439A5809C754BEFFEA1F1F356328 /* VIMSizeQuota.swift */; };
 		AEAE305FCB3412E59DF6DA0AADCF12CF /* VIMPeriodic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE16B4A66409809D716B9830897F3A /* VIMPeriodic.swift */; };
-		AEF80C5F4B3AF4FBCEBF94F48AFA54D1 /* OHHTTPStubs-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5CB7459156AE663C1050F4E9BCA162 /* OHHTTPStubs-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEF80C5F4B3AF4FBCEBF94F48AFA54D1 /* OHHTTPStubs-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D2F9F3D542328AF7EE1EF09EE8CE15A6 /* OHHTTPStubs-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF552685189AE5DBCC3CBB93C3236978 /* VIMAccount.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA37E80CBDF85EFB07653B898BCDDD9 /* VIMAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AFA5CEA3D9128D94D75641A83C31DE42 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3B224AF3818E361C18369B8290B377 /* KeychainStore.swift */; };
 		AFADA476CC57A2D6C5F5496C6531F29F /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 7666E344E7B2EB0D57E54461444DA988 /* VIMVODConnection.m */; };
@@ -313,21 +313,21 @@
 		B006630225BFB62EB5A4582F54329189 /* VIMVideo+VOD.h in Headers */ = {isa = PBXBuildFile; fileRef = 4096DFF2978CB5C45BB1EA65E9D5DB07 /* VIMVideo+VOD.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B257B93DC4634FD92782804FD1B313FD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */; };
 		B30C4B5847309A20DA01AB708C81817D /* VIMSizeQuota.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F86439A5809C754BEFFEA1F1F356328 /* VIMSizeQuota.swift */; };
-		B3AF6D82691DF3E0E77E846C66276411 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 574F83336B483EBFA1E8E9D50E348C42 /* UIActivityIndicatorView+AFNetworking.m */; };
+		B3AF6D82691DF3E0E77E846C66276411 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E37639A24B2B30BB8029B0BEE3E0BF19 /* UIActivityIndicatorView+AFNetworking.m */; };
 		B44FB838E408086D2247C03C52F938F4 /* VIMVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 337C679C0033E1196D3296D15FD8C2E5 /* VIMVideo.m */; };
 		B544C0B24A7531CF0DF9CF2E40F5DAC3 /* VIMCredit.m in Sources */ = {isa = PBXBuildFile; fileRef = CC6E72041692DAA0F452829A7E82C12F /* VIMCredit.m */; };
-		B556DEE110375D71E467F607AAC97660 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A871485C394D029F58600E577F7CE2E /* UIImageView+AFNetworking.m */; };
-		B5E89290E80DE4E1C33F7C9051B0DFE3 /* NSURLRequest+HTTPBodyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D70075751D4887B8E75038A18FE14AB /* NSURLRequest+HTTPBodyTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B556DEE110375D71E467F607AAC97660 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = C45174DCB15F51AD57A41DE785396FDD /* UIImageView+AFNetworking.m */; };
+		B5E89290E80DE4E1C33F7C9051B0DFE3 /* NSURLRequest+HTTPBodyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5EE2F1498B08D825782CB8728CF8968 /* String+Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBB59C93B058A49CE7EAC43E00F4C30 /* String+Parameters.swift */; };
-		B6C4B0EFA0D490F70AE9AA04F916A49A /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B28FFAF92DDD22D3FBCFE02BE916D227 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6C4B0EFA0D490F70AE9AA04F916A49A /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1321FA5BE51F20152EFEEAD2DF86264D /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B733F2F9230292B1AE9A281D3804921A /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE465D1211573B009F93A08AE2A1B352 /* NSError+Extensions.swift */; };
-		B8000901B98D1B45B1951CDBB11C2318 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 117992A3E9C7F7CE964285F808F41C03 /* AFURLRequestSerialization.m */; };
-		B8936099CFCA8FC0DA3A1FE3FA9D24F6 /* OHHTTPStubs-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CFF3EA798F2BD3BFF03F34375CC44323 /* OHHTTPStubs-iOS-dummy.m */; };
+		B8000901B98D1B45B1951CDBB11C2318 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 509F7396F2DCDBEF6C4833C26D738EFF /* AFURLRequestSerialization.m */; };
+		B8936099CFCA8FC0DA3A1FE3FA9D24F6 /* OHHTTPStubs-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4325EAD8A9CF3A766582A6F02701D03A /* OHHTTPStubs-iOS-dummy.m */; };
 		B8D9A6D7199F1BB0C89B31D696981E3C /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868C8630C6B0AE2AE2EADAE4EAEC7E48 /* Request+Trigger.swift */; };
 		B9C21396BAA9CF03EBFDD4E6F79FD2C1 /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F1548C213F2310570E40003D43A340 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BA1C398CF9F838EC0274C82BB036A6B5 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6541BD7AB0F17432290D19DDE180D316 /* AppConfiguration.swift */; };
-		BA26048C8417E6393B94DFE607CF41E9 /* OHHTTPStubs-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 33137EC96B0EAC2DD37666B3A74E761F /* OHHTTPStubs-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA389B8F02B788944394EC2C1D6C05F3 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0864552A7599E2DCE46506D035A84470 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA26048C8417E6393B94DFE607CF41E9 /* OHHTTPStubs-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCCDB5BA217AC73E3269E357E6C6A6B /* OHHTTPStubs-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BA389B8F02B788944394EC2C1D6C05F3 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B2635634392B942A9DD483C6329941C5 /* AFHTTPSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BBB55CE9F03CB303580F3FD3D944FCC0 /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E4EA39F22E4B50E8D4B0422B6B1AE318 /* VIMNotificationsConnection.m */; };
 		BC1E95B362F02CF3574AC43A343108C3 /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A69C53310CD4FFBB8313D7029D9DAD4 /* VIMSeason.m */; };
 		BCD8B10AAC6C1BFA32A1A4C1A24D41EF /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CE086533E408A3943908000D7B977B9 /* VIMVideoFile.m */; };
@@ -345,7 +345,7 @@
 		C555783B5FBE0BB748C91A0BA6B50CE6 /* VIMVideoProgressiveFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 3937FDFCF80B4C9A8350ED82D2ECE55B /* VIMVideoProgressiveFile.m */; };
 		C59ECDF3A33A5B340BA858EF93362C9F /* Spatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7DA2171FEA4851FA6271DE2917193E /* Spatial.swift */; };
 		C61AB44944FDDF5CE278E2AF4B3C8890 /* VIMReviewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BBD5F669C44687722B23CB4DB112B8 /* VIMReviewPage.swift */; };
-		C8283EB1E24A80E6ACF5DA3983BD20D7 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BC217249B6956500008D3DBEE89477DD /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8283EB1E24A80E6ACF5DA3983BD20D7 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 72B473B2EAEBBE1A38EAA0CBE7A89628 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8350AAD4B592F59689F94079A2CE612 /* VIMVideoPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F5E48372F2DEA56E3286072A1F50BF5 /* VIMVideoPlayFile.m */; };
 		C844DDE593AF591AFD7D2FD2B0761EBA /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DB008CBF81FC369D8F8DD0DD8EAA00 /* VimeoSessionManager.swift */; };
 		C84F08FF5E54FD99EA979E52866D095A /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFECD0DF05B25F9844E61A9880BA410 /* Response.swift */; };
@@ -355,13 +355,13 @@
 		C9C55674F82F2F2CA0B0A65B65A1A088 /* Pods-VimeoNetworkingExample-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 04375F2FEC78FF1003F8137E128307EB /* Pods-VimeoNetworkingExample-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA78BA16C3920D30D7F9220DC0FDA682 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */; };
 		CA974F62684483084862F1B3FDC99D58 /* VIMUploadTicket.m in Sources */ = {isa = PBXBuildFile; fileRef = 945AF89D0281706D1BDA2CBC11C72167 /* VIMUploadTicket.m */; };
-		CAAD70359B8866C63B8E38603B581587 /* OHHTTPStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D4628139C29E288D16EF0D23CAA8927 /* OHHTTPStubs.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CAAD70359B8866C63B8E38603B581587 /* OHHTTPStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = A3AAA79C011A0D7096BEECF36E6BFFB1 /* OHHTTPStubs.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		CC6A47EE0C77DDEFE178E6F8CB26219F /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608E7687538126F51A87AA6E85DFE7E2 /* Request+PolicyDocument.swift */; };
 		CCA2B3DEC930B3CB72B715B55C3C602E /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA1355D1605FF0ACAA75DF5D4190DD /* Subscription.swift */; };
 		CD05E3C91C846584DA28BC56A7911392 /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002C0C474DB5DB7C7CD2A0289140C192 /* Request+Picture.swift */; };
 		CDEC3A8C189EBB8B54132385D65A38CF /* Request+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA53886DF0B3D70B00BDCAF83C3FC21D /* Request+Comment.swift */; };
 		CDEC91A6E7319FB562CAE8A8B84CB7D0 /* Objc_ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 976F2632149220B6FD4D1ABCD9BE8347 /* Objc_ExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CE4A9D602E1EB71F49CA39BCD0EBC293 /* OHPathHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B18965434B4C68D2A4F947A029A1906 /* OHPathHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE4A9D602E1EB71F49CA39BCD0EBC293 /* OHPathHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0606579DBD66FA4905BDE4F2FE00F6 /* OHPathHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE79BDF0884F4559218155EFF354128B /* VIMComment.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B5FC27936FE2F46206F8DB1024CD7AA /* VIMComment.m */; };
 		CE84011A05DFE31EE244390EF788B419 /* VIMChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 83780327FED2094C7FB0DCAE299FD7A5 /* VIMChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CF024B9740FB58B69DEDCE00974064DA /* Request+ProgrammedContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451EF7382B1605D927E544B9ECB048E /* Request+ProgrammedContent.swift */; };
@@ -375,9 +375,9 @@
 		D608925F4B5380350867D6616340CAEC /* VIMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 990E98F03B2973DD7DEF3E1526A3CFA6 /* VIMTag.m */; };
 		D613624C32D92D672416A28CD5BB82CC /* VimeoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = A965B5573DFDBD9889B367517089AAD8 /* VimeoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D66595AF0806BBD184B35D4784FD633F /* AFNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC2226C458356246DAE3E43149D2140E /* AFNetworking.framework */; };
-		D6A5989AF85BF0F0346FE8BAAF94B8E2 /* AFNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 23BB0FCFA1888840EF3ABB74F51AEF4D /* AFNetworking-tvOS-dummy.m */; };
+		D6A5989AF85BF0F0346FE8BAAF94B8E2 /* AFNetworking-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8988067C241ED04A45672E5B279E399D /* AFNetworking-tvOS-dummy.m */; };
 		D6D1764D14E4C34CB91CDF61940607C6 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = EF77BF0DA5CC947E75F348EB5B70CA9B /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D6D32B19824842A2D8AD39CD22BFA2DF /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BC217249B6956500008D3DBEE89477DD /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6D32B19824842A2D8AD39CD22BFA2DF /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 72B473B2EAEBBE1A38EAA0CBE7A89628 /* UIKit+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6E4AEF6A0DA3E63262A4D7501483E6C /* NetworkingNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCF9F8F6D70CB3C9ECB2C287D0EEF22 /* NetworkingNotification.swift */; };
 		D73C8526F6FED7D5BFEB8721E4EB3860 /* VIMPrivacy.m in Sources */ = {isa = PBXBuildFile; fileRef = 42C9D7B8A3E9061C49530BFA14925746 /* VIMPrivacy.m */; };
 		D7698F599DD180540F6F2DED9375AEB7 /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CE086533E408A3943908000D7B977B9 /* VIMVideoFile.m */; };
@@ -390,49 +390,49 @@
 		DB07655700BA95DC2861C1D7A4C5430A /* VIMReviewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BBD5F669C44687722B23CB4DB112B8 /* VIMReviewPage.swift */; };
 		DBAA54ABFEE279869686F99661EFCFFF /* VIMUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C16AD2D62643913F2016CDB1A8F4D8 /* VIMUpload.swift */; };
 		DC82DCC7C7B88BA8581AD48797E608E0 /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F874D7C4735D709A00F0BB63AD6D845 /* Request+Toggle.swift */; };
-		DC9084AC3A8E734456A646DD4E6579D4 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D4182ADE116CA08CB2B4E1EF539811A /* AFHTTPSessionManager.m */; };
+		DC9084AC3A8E734456A646DD4E6579D4 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 55414FC27D39F6FE310EA0A1A9B01652 /* AFHTTPSessionManager.m */; };
 		DCA39A3AF62D160349C0D51A91E2B573 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3B224AF3818E361C18369B8290B377 /* KeychainStore.swift */; };
 		DDBD835F0B736750191C38DFEC97A085 /* VIMModelObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F0CE15D12F813D8BD00DB5B662D60632 /* VIMModelObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DE28C5BC9A0380B7C152220A44094873 /* NSURLRequest+HTTPBodyTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = A32BEE544DC0369D90A60420B63D2024 /* NSURLRequest+HTTPBodyTesting.m */; };
+		DE28C5BC9A0380B7C152220A44094873 /* NSURLRequest+HTTPBodyTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AEBBDE827402241273190CAA3FA49F /* NSURLRequest+HTTPBodyTesting.m */; };
 		DED82035F653AC572E2DF4ED1E2D5B1D /* VIMCredit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F064F3A97CF922699FA7A7DF0C63DA6 /* VIMCredit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DF98C9314A4BEB0FE5D3439C8ABDDD7F /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 50619DBA8E123C123B0CD2B8BDC7AA31 /* digicert-sha2.cer */; };
 		DFCC6E2AFD1F0C83B026A3985F068D7F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */; };
 		E0CC88A09FEECC47BB203C9966091D78 /* VIMInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 06A5F2867A813A5FD4CCADD5F0AD4968 /* VIMInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E0F21073F4AE2DDEFA01FDB9B3E577E5 /* Request+PolicyDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608E7687538126F51A87AA6E85DFE7E2 /* Request+PolicyDocument.swift */; };
-		E134799D9CCFEBDA1665156F3525C3D4 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ADE08DB317825E6252DADAF183C8594 /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E15505BDBDB14C308FE87E7596015A4B /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = BA815CE673111F13239C7DDCB582831D /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E134799D9CCFEBDA1665156F3525C3D4 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 7830DB57DE3EA2CFD49FD16DCB51353D /* UIButton+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E15505BDBDB14C308FE87E7596015A4B /* AFImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 03CBB8C8659174E12110BF9F15D0EEB4 /* AFImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2A0E2D5DE665177FB45AE27D17F128B /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F8DB92C20BE6B4DD26B0B909395C8 /* Scope.swift */; };
 		E312358C381E70ECCB0CB5F272D5D070 /* Request+Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868C8630C6B0AE2AE2EADAE4EAEC7E48 /* Request+Trigger.swift */; };
 		E3AE35CED367F20EDC382667E40FEE9E /* VIMSeason.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A69C53310CD4FFBB8313D7029D9DAD4 /* VIMSeason.m */; };
 		E49A0E814B74E0C758F25CEE911321E1 /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A51AD98B7FB72BAB2F01D5CF75D348B /* ErrorCode.swift */; };
 		E5D024B955DE93EBF512F2FE3063F64F /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D546CE6D725C63D5D4CBAECBC0A982B /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E66EC1E6F61060BBE56B2F27E0FDD06C /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2E42478CA76BB6EBAE6C77E59532E6 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E66EC1E6F61060BBE56B2F27E0FDD06C /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DDFF4DA52A4F6F21983F6455B1BBA00 /* UIProgressView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E7B0EE248A1CCC09A8C7EB44DFDB1A17 /* VIMVODItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E749F0F363F966E77909FF11A825D9F /* VIMVODItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E868C08D43B264C4B26CC4E16C58CD8E /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B82DC43D30129ECD267D5608CC476F /* Request+Video.swift */; };
 		EA6C8BE588C229D2BBBD2CDD3A5E1F17 /* VIMLiveHeartbeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26A51850DAB1AA601D155390CAF8147 /* VIMLiveHeartbeat.swift */; };
-		EA80EEAAA328F1ECED1587B3D635C941 /* Compatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 9886BB547554A74ED6E1805FE7CF9BE5 /* Compatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA80EEAAA328F1ECED1587B3D635C941 /* Compatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 581BD34554C024C68A52F36F6CA3D78F /* Compatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA90B8EAEA3347A190DC85734246E335 /* VIMAppeal.m in Sources */ = {isa = PBXBuildFile; fileRef = 5811EFB16042D6FBD1583EB7157A4944 /* VIMAppeal.m */; };
 		EA9F363576879F5A85F57F775E9FCB15 /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43F8DB92C20BE6B4DD26B0B909395C8 /* Scope.swift */; };
-		EB6ACED989A2BE453D1D254B34E7D0DF /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 85551D9083D5C20B2665444C48558A44 /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB6ACED989A2BE453D1D254B34E7D0DF /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = B13AC05770B2268AAE5B8B3430B674DE /* UIActivityIndicatorView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EBCAC78F24EBDE350D5DC63C452354B0 /* VIMVideoUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E9A244E10D11F27FC8B2C120CA03267 /* VIMVideoUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECA25636CA551896177B9E9489A09399 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EC90DBE7933C4957EC1940C58E4CBA3 /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECA25636CA551896177B9E9489A09399 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = DDA1346A32994737D350AC6EC4C7E3BC /* AFURLRequestSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED7DC14BEA8BC44683846E1E5B6462E9 /* Request+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B82DC43D30129ECD267D5608CC476F /* Request+Video.swift */; };
 		EEA2C3ADDD2CBE21B385EEBFA2A508CF /* VIMPolicyDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FCD70CA87921F98B314C93A892DC80D /* VIMPolicyDocument.m */; };
 		EF5804158D3CE6B1CE04102F60B39E33 /* VIMVideoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 48E18455BDAE1871EFC75462CB510A0E /* VIMVideoUtils.m */; };
-		EF71A0066AA04CF35163C9C001F6E9C5 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 45F5E04D7AE257107C861EA50DB483B6 /* AFNetworkActivityIndicatorManager.m */; };
+		EF71A0066AA04CF35163C9C001F6E9C5 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E3A20E3A1B39A6E94A94C136AECC39 /* AFNetworkActivityIndicatorManager.m */; };
 		EFD3D1F950610E8F779301A39E55D6E5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A29EAA5175F47E8C1B4F750DEB587 /* Constants.swift */; };
 		EFDAE6EDF1FB5D72C25D735231AB1172 /* Objc_ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DCA6ACC575AB709FB4B506C2B3954A2 /* Objc_ExceptionCatcher.m */; };
-		EFF77DF9B056320A0AB07C001EE9AEE2 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 574F83336B483EBFA1E8E9D50E348C42 /* UIActivityIndicatorView+AFNetworking.m */; };
+		EFF77DF9B056320A0AB07C001EE9AEE2 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E37639A24B2B30BB8029B0BEE3E0BF19 /* UIActivityIndicatorView+AFNetworking.m */; };
 		F30EABC19BD0587B0FCB5A685893EBEE /* VIMVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = AB038766672B3B1E30156DC24EE6C3A2 /* VIMVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3C092FD7B850638B7956D9175E9FA7F /* NSURLRequest+HTTPBodyTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = A32BEE544DC0369D90A60420B63D2024 /* NSURLRequest+HTTPBodyTesting.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		F3C092FD7B850638B7956D9175E9FA7F /* NSURLRequest+HTTPBodyTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AEBBDE827402241273190CAA3FA49F /* NSURLRequest+HTTPBodyTesting.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		F4899162C02C2084DDCAB4746BC28364 /* VIMVideoDASHFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CDF8736416D1FB26621B5E594601AE9 /* VIMVideoDASHFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4A8B5924392AA3DC07C61205A746802 /* VIMVODConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 08A008ACC9E799DF4602B4DB46382C7B /* VIMVODConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F516D75122BCFA23C77790EEE32BD433 /* VIMObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 762FD6E7A08C68E73D6CB0A88F6A9621 /* VIMObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F53D0FFBC586750543F03C44390F8F2A /* Compatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 9886BB547554A74ED6E1805FE7CF9BE5 /* Compatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F66DDED380965CD4C3DFFEFB00139AB1 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 45F5E04D7AE257107C861EA50DB483B6 /* AFNetworkActivityIndicatorManager.m */; };
+		F53D0FFBC586750543F03C44390F8F2A /* Compatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 581BD34554C024C68A52F36F6CA3D78F /* Compatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F66DDED380965CD4C3DFFEFB00139AB1 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E3A20E3A1B39A6E94A94C136AECC39 /* AFNetworkActivityIndicatorManager.m */; };
 		F678F3B2E64CA0AA29DE1B2D570DE482 /* VIMNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F1548C213F2310570E40003D43A340 /* VIMNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6B045977AAAE4D800FB38B9DAFD3B3F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170A29EAA5175F47E8C1B4F750DEB587 /* Constants.swift */; };
-		F6D6C627883C0EC2778D2485BED37D38 /* OHHTTPStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = 0505109CFF4C687AF46E9503DD8210E8 /* OHHTTPStubs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F6D6C627883C0EC2778D2485BED37D38 /* OHHTTPStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6E36288523446F38E87644A40652921 /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FA315091126838D7B0C813407ED0128 /* VIMUserBadge.m */; };
 		F7065EDEDBFD13C4B1E549B96F30C4A5 /* VIMNotificationsConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B862B8B225A7D1EC0C858CB7D5551D6 /* VIMNotificationsConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F74FAA4AF3FD57F124D7140F8C888C23 /* VIMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 141613E27500987EFA7D6D289799CE01 /* VIMActivity.m */; };
@@ -442,8 +442,8 @@
 		FC957973481DEF2083F3E923FDCDF7C1 /* VIMVideoFairPlayFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 22BAD39682C35CBD1BF906DF7C010AAA /* VIMVideoFairPlayFile.m */; };
 		FD38F293D24362EB51E371A38B32EC68 /* VIMUser.h in Headers */ = {isa = PBXBuildFile; fileRef = EF77BF0DA5CC947E75F348EB5B70CA9B /* VIMUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE6E74D8A2C0A67DB9FB0E6EB99F6FB6 /* VIMVideoPreference.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BFBF2E34B5F976309E5545F4DFE1D6B /* VIMVideoPreference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE8705D993A03E8BD5191395032DB8D1 /* OHHTTPStubsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B6255F90E78087D9005AF8679E252 /* OHHTTPStubsSwift.swift */; };
-		FE8BB01BDBC5EDC20C594225F8E4AE36 /* OHHTTPStubsMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 401026E25B68A923C0B6E168B189900A /* OHHTTPStubsMethodSwizzling.m */; };
+		FE8705D993A03E8BD5191395032DB8D1 /* OHHTTPStubsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D14ACCEE1C6E9C7BB7A1B7F5B64BF03 /* OHHTTPStubsSwift.swift */; };
+		FE8BB01BDBC5EDC20C594225F8E4AE36 /* OHHTTPStubsMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8EECBE5AC34543AC0DA54CBA417F94 /* OHHTTPStubsMethodSwizzling.m */; };
 		FFBA1B5B15C9CECC7C2D7C806D06CF83 /* VIMGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E80D9AE18F1F351FAE3A50A26BB8CBE3 /* VIMGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
@@ -523,94 +523,92 @@
 /* Begin PBXFileReference section */
 		000EA47632C06FCD6198CEF39763F7D5 /* Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		002C0C474DB5DB7C7CD2A0289140C192 /* Request+Picture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Picture.swift"; path = "VimeoNetworking/Sources/Request+Picture.swift"; sourceTree = "<group>"; };
-		00C4CD64935D011C2ED6898B50D4CDDE /* OHPathHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHPathHelpers.m; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.m; sourceTree = "<group>"; };
-		021D16BBA71C462F3C78EB912BE6A4E7 /* VimeoNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VimeoNetworking-tvOS.xcconfig"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
-		02E0295CFDD790D464A7BFCB9EF7DC1E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		039818FD26CA118ABEEA7C6D11F409CA /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		006AC8BB3C72CA483D8DF7E93BA7D212 /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
+		010722D39F81298FE76249F6D7951171 /* VimeoNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-umbrella.h"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
+		0253070E47023CF89CC23147E1435854 /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
+		03AEBBDE827402241273190CAA3FA49F /* NSURLRequest+HTTPBodyTesting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+HTTPBodyTesting.m"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.m"; sourceTree = "<group>"; };
+		03CBB8C8659174E12110BF9F15D0EEB4 /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
 		04375F2FEC78FF1003F8137E128307EB /* Pods-VimeoNetworkingExample-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-iOS-umbrella.h"; sourceTree = "<group>"; };
 		04B82DC43D30129ECD267D5608CC476F /* Request+Video.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Video.swift"; path = "VimeoNetworking/Sources/Request+Video.swift"; sourceTree = "<group>"; };
 		04EAB97A115CD978A14846C884D749B6 /* VIMVideoPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPreference.m; sourceTree = "<group>"; };
-		0505109CFF4C687AF46E9503DD8210E8 /* OHHTTPStubs.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubs.h; path = OHHTTPStubs/Sources/OHHTTPStubs.h; sourceTree = "<group>"; };
 		0552430816D30D6F1F0E809D75B756B9 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		06868FE8F75FA7CDAD397EA9E63FE0AF /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
+		05E3A20E3A1B39A6E94A94C136AECC39 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
 		06A5F2867A813A5FD4CCADD5F0AD4968 /* VIMInteraction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMInteraction.h; sourceTree = "<group>"; };
 		0755211153097C193228697B495C6B49 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0864552A7599E2DCE46506D035A84470 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
 		08A008ACC9E799DF4602B4DB46382C7B /* VIMVODConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODConnection.h; sourceTree = "<group>"; };
+		08A155E222221ECA310A527C1C4F3E79 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
 		09A5F79E513960BA3518C3AF708D5511 /* SubscriptionCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionCollection.swift; sourceTree = "<group>"; };
+		0A8BACDE7FE48A49C444D800DE02E9AF /* AFNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "AFNetworking-tvOS.modulemap"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
 		0B862B8B225A7D1EC0C858CB7D5551D6 /* VIMNotificationsConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotificationsConnection.h; sourceTree = "<group>"; };
 		0BFBF2E34B5F976309E5545F4DFE1D6B /* VIMVideoPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPreference.h; sourceTree = "<group>"; };
 		0CFECD0DF05B25F9844E61A9880BA410 /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Response.swift; path = VimeoNetworking/Sources/Response.swift; sourceTree = "<group>"; };
+		0D14ACCEE1C6E9C7BB7A1B7F5B64BF03 /* OHHTTPStubsSwift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OHHTTPStubsSwift.swift; path = OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift; sourceTree = "<group>"; };
 		0D435BD7921CBCDC87A847759D72B51C /* VIMCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCategory.h; sourceTree = "<group>"; };
-		0DD8043066A89F0C3B0B121295F2F58D /* AFNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-umbrella.h"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
-		0E739EEE834C7C0BAB582D70BEEF9E73 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
+		0DE7D373DA97F4FDF2F3E7E86955CCEA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../VimeoNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
+		0E6358FA7C9EE5C5A002DE3D91FB1FDD /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		0EB2142BFAAB1124741786C0AF6CCB63 /* VIMVideo+VOD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VIMVideo+VOD.m"; sourceTree = "<group>"; };
 		0F064F3A97CF922699FA7A7DF0C63DA6 /* VIMCredit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMCredit.h; sourceTree = "<group>"; };
+		10A360AA316FBBFB69D5C5F0233196D3 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
 		113D24AC2247C760AB8D074EE0A61081 /* Request+Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Notifications.swift"; path = "VimeoNetworking/Sources/Request+Notifications.swift"; sourceTree = "<group>"; };
-		116399426B26CFD5FD6337B68AEA451C /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		117992A3E9C7F7CE964285F808F41C03 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
 		11BB2ADFF04A8A2B2C35C4DBBDFD0D83 /* VIMAccount.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAccount.m; sourceTree = "<group>"; };
 		124D5039A1F4CEF665FDA222B57DD677 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		12B387BBAE47D74F220CA7AF7E64EB73 /* VIMNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotification.m; sourceTree = "<group>"; };
+		12C5180CE8C0AEED2C554ED751A28E51 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
+		1321FA5BE51F20152EFEEAD2DF86264D /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
+		138E683BC81CCB1695E602328599209D /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		141613E27500987EFA7D6D289799CE01 /* VIMActivity.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMActivity.m; sourceTree = "<group>"; };
 		1642F81FE2B6075D3F53F64D9661DA3B /* VIMChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMChannel.m; sourceTree = "<group>"; };
 		16805C9DFD7B6F444D2425C715B5F737 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		16866E9EDA1707C451567790CE00699D /* VIMVideoFairPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFairPlayFile.h; sourceTree = "<group>"; };
 		170A29EAA5175F47E8C1B4F750DEB587 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = VimeoNetworking/Sources/Constants.swift; sourceTree = "<group>"; };
-		177F1682F0D833C9004F50E9A752FDAB /* AFNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "AFNetworking-iOS.modulemap"; sourceTree = "<group>"; };
-		17E350CB4AB82E6208A077258E26F453 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../OHHTTPStubs-tvOS/Info.plist"; sourceTree = "<group>"; };
-		1A8A0C98C1E33DDA9336160E18236982 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1ADE08DB317825E6252DADAF183C8594 /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
-		1D4182ADE116CA08CB2B4E1EF539811A /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		17D8C95CBB8DC14FD7ABA9005B777B27 /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
+		1BF45048A3F5CA691B268D14EEB20A8B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1D4D396D24AAC8580B596A7AA51066CC /* VIMVideoPlayRepresentation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayRepresentation.m; sourceTree = "<group>"; };
 		1DACD44283F7816CE5EAC8719476D07C /* VIMPictureCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPictureCollection.h; sourceTree = "<group>"; };
-		1DB20FBCCFF0D4A8A2B4A33DCD65C6CE /* AFNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		1DCA6ACC575AB709FB4B506C2B3954A2 /* Objc_ExceptionCatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Objc_ExceptionCatcher.m; path = VimeoNetworking/Sources/Objc_ExceptionCatcher.m; sourceTree = "<group>"; };
+		1E53BAC736CE51BE9F3B64E399A4BB30 /* AFNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "AFNetworking-iOS.modulemap"; sourceTree = "<group>"; };
 		1EAABD436AE17C338E12E1FEDCFD6B94 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
+		1EB60D5E72F18CE610B91D2F142A1F39 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F5D8A2BF59417627F165C0C14BD75C4 /* Pods-VimeoNetworkingExample-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOS-frameworks.sh"; sourceTree = "<group>"; };
 		1F5E48372F2DEA56E3286072A1F50BF5 /* VIMVideoPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoPlayFile.m; sourceTree = "<group>"; };
 		2165ECF9F8CAC231DFC2DC3AFCA51B12 /* VIMVODItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODItem.m; sourceTree = "<group>"; };
+		225DB0FDDE8488D307E09492A2A09960 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../OHHTTPStubs-tvOS/Info.plist"; sourceTree = "<group>"; };
 		22BAD39682C35CBD1BF906DF7C010AAA /* VIMVideoFairPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFairPlayFile.m; sourceTree = "<group>"; };
 		238CD7D8BB5E478B550EFF23CE699770 /* VimeoSessionManager+Constructors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "VimeoSessionManager+Constructors.swift"; path = "VimeoNetworking/Sources/VimeoSessionManager+Constructors.swift"; sourceTree = "<group>"; };
-		23BB0FCFA1888840EF3ABB74F51AEF4D /* AFNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AFNetworking-tvOS-dummy.m"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
 		25BBD5F669C44687722B23CB4DB112B8 /* VIMReviewPage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMReviewPage.swift; sourceTree = "<group>"; };
 		27BE014B17E9B4FB08A7E2D9166BAB58 /* ExceptionCatcher+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ExceptionCatcher+Swift.swift"; path = "VimeoNetworking/Sources/ExceptionCatcher+Swift.swift"; sourceTree = "<group>"; };
 		28BA986678FBF992A9B92E301EA30A93 /* Pods-VimeoNetworkingExample-tvOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-tvOSTests-dummy.m"; sourceTree = "<group>"; };
-		29003D45D48EB43DB3DB7E3B3BF3BA44 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../VimeoNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
 		29A3554DB86AC0CA6FBA14DC12AE715F /* VIMComment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMComment.h; sourceTree = "<group>"; };
-		2A080F18E8B7646F65EA74331AE60746 /* OHHTTPStubsResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsResponse.h; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.h; sourceTree = "<group>"; };
+		2A0606579DBD66FA4905BDE4F2FE00F6 /* OHPathHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHPathHelpers.h; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.h; sourceTree = "<group>"; };
 		2A7DA2171FEA4851FA6271DE2917193E /* Spatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Spatial.swift; sourceTree = "<group>"; };
-		2A871485C394D029F58600E577F7CE2E /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		2CD87A78D6DE7C189BFDDE05A55CAFDB /* OHHTTPStubs-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "OHHTTPStubs-tvOS.xcconfig"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.xcconfig"; sourceTree = "<group>"; };
-		2D5CB7459156AE663C1050F4E9BCA162 /* OHHTTPStubs-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-umbrella.h"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-umbrella.h"; sourceTree = "<group>"; };
+		2C461DC0072C2B5EEB7310C9E07C9625 /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
 		2EAA1355D1605FF0ACAA75DF5D4190DD /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		2F874D7C4735D709A00F0BB63AD6D845 /* Request+Toggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Toggle.swift"; path = "VimeoNetworking/Sources/Request+Toggle.swift"; sourceTree = "<group>"; };
-		2FF104EB0D18595B2CF3EE3C4AD6CC7D /* AFNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "AFNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
-		30766B769E54A458277210073DF50046 /* VimeoNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VimeoNetworking-tvOS-dummy.m"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
 		31F0D9E3232AD6F046191F9B602A78D5 /* VIMVideoDRMFiles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDRMFiles.h; sourceTree = "<group>"; };
-		32DA090D06B850ABB7CAB4B10F7C7E98 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		33009827B09F12EA3D4A381041262FB4 /* VIMMappable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMMappable.h; sourceTree = "<group>"; };
-		33137EC96B0EAC2DD37666B3A74E761F /* OHHTTPStubs-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-iOS-umbrella.h"; sourceTree = "<group>"; };
 		337C679C0033E1196D3296D15FD8C2E5 /* VIMVideo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideo.m; sourceTree = "<group>"; };
+		34DF3D6618104D202D7E400FAC38D4C5 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
 		354F708ECA61A2D09230BC2D11127563 /* VIMQuantityQuota.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMQuantityQuota.h; sourceTree = "<group>"; };
 		35D235AD1856F5C589BEAF9E4FC005E6 /* VIMSpace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMSpace.swift; sourceTree = "<group>"; };
 		35EC9500893E82413EA06DCB6B88BEB1 /* Request+Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Authentication.swift"; path = "VimeoNetworking/Sources/Request+Authentication.swift"; sourceTree = "<group>"; };
 		36DC0ADF4080F7F62F229D9FBA414D6D /* VIMTrigger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTrigger.m; sourceTree = "<group>"; };
+		37E47978D75B6D1669D965A6F7831F1F /* OHHTTPStubs-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OHHTTPStubs-iOS.xcconfig"; sourceTree = "<group>"; };
 		3937FDFCF80B4C9A8350ED82D2ECE55B /* VIMVideoProgressiveFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoProgressiveFile.m; sourceTree = "<group>"; };
+		3B5AD8616028CFB680DB31E587DBC111 /* OHHTTPStubs-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "OHHTTPStubs-iOS.modulemap"; sourceTree = "<group>"; };
 		3B5FC27936FE2F46206F8DB1024CD7AA /* VIMComment.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMComment.m; sourceTree = "<group>"; };
-		3BF71B69A726D518AD38C04896097A70 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DB9F95F175362974D9C05ED9E54009C /* Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3E911C478DE04F75AE4FE191CE6A5D8A /* AFNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-umbrella.h"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		3EC2B93EB7C004451ACA90394671BB95 /* VIMObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMObjectMapper.m; sourceTree = "<group>"; };
 		3F926AFA66D2BA02ABEA8E0CC0EA1E8E /* VIMUploadQuota.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMUploadQuota.swift; sourceTree = "<group>"; };
 		3FA315091126838D7B0C813407ED0128 /* VIMUserBadge.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUserBadge.m; sourceTree = "<group>"; };
-		401026E25B68A923C0B6E168B189900A /* OHHTTPStubsMethodSwizzling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsMethodSwizzling.m; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.m; sourceTree = "<group>"; };
 		402E1AD49AB01E49B347380A10C3C098 /* Pods-VimeoNetworkingExample-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		4096DFF2978CB5C45BB1EA65E9D5DB07 /* VIMVideo+VOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+VOD.h"; sourceTree = "<group>"; };
 		40F24E8193C2BE38D8277F67EE1955B1 /* VIMPrivacy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPrivacy.h; sourceTree = "<group>"; };
+		414091E794E2076CE03DFEBD89D38746 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
 		42C9D7B8A3E9061C49530BFA14925746 /* VIMPrivacy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPrivacy.m; sourceTree = "<group>"; };
+		4325EAD8A9CF3A766582A6F02701D03A /* OHHTTPStubs-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OHHTTPStubs-iOS-dummy.m"; sourceTree = "<group>"; };
 		444DEF80D39EE6ECF5B9FCB6C11C968F /* VIMVideoPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayFile.h; sourceTree = "<group>"; };
 		454BAD09CFD6687B92C0849B1D0274C5 /* Pods-VimeoNetworkingExample-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOS-resources.sh"; sourceTree = "<group>"; };
-		45F5E04D7AE257107C861EA50DB483B6 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
 		460FF79A87A4367281362F5C424747A0 /* VIMPolicyDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPolicyDocument.h; sourceTree = "<group>"; };
 		483BC4B898F27AC1CB61DC2B40DB5796 /* ResponseCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResponseCache.swift; path = VimeoNetworking/Sources/ResponseCache.swift; sourceTree = "<group>"; };
 		48768BFA1C3AEDF044FF6D46EB55FD3F /* Pods-VimeoNetworkingExample-iOSTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-iOSTests-acknowledgements.markdown"; sourceTree = "<group>"; };
@@ -619,186 +617,189 @@
 		4B7F1A19EDAB6B91821C0B66DA6606EE /* AccountStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccountStore.swift; path = VimeoNetworking/Sources/AccountStore.swift; sourceTree = "<group>"; };
 		4D34101D5D3A71BDCFA4376B435094B0 /* Pods-VimeoNetworkingExample-iOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-frameworks.sh"; sourceTree = "<group>"; };
 		4D73E83D537CFA1A3A1E46D3C90AF59B /* VIMModelObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMModelObject.m; sourceTree = "<group>"; };
-		4E6CF31F799FC3DBF6DB3AA7141C9AD8 /* VimeoNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
+		4DCCDB5BA217AC73E3269E357E6C6A6B /* OHHTTPStubs-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-iOS-umbrella.h"; sourceTree = "<group>"; };
+		4DDFF4DA52A4F6F21983F6455B1BBA00 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
 		4EA1EB96CF5A2362308F18F78CCFA959 /* VIMPictureCollection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPictureCollection.m; sourceTree = "<group>"; };
-		4F0B6255F90E78087D9005AF8679E252 /* OHHTTPStubsSwift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OHHTTPStubsSwift.swift; path = OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift; sourceTree = "<group>"; };
 		4F86439A5809C754BEFFEA1F1F356328 /* VIMSizeQuota.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMSizeQuota.swift; sourceTree = "<group>"; };
 		4F8C6D2F2667820406CE020694ECB0C4 /* Request+Channel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Channel.swift"; path = "VimeoNetworking/Sources/Request+Channel.swift"; sourceTree = "<group>"; };
-		4FEBFF6518DB1C31D746A751613D1751 /* OHHTTPStubs+NSURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubs+NSURLSessionConfiguration.m"; path = "OHHTTPStubs/Sources/NSURLSession/OHHTTPStubs+NSURLSessionConfiguration.m"; sourceTree = "<group>"; };
 		50619DBA8E123C123B0CD2B8BDC7AA31 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; name = "digicert-sha2.cer"; path = "VimeoNetworking/Resources/digicert-sha2.cer"; sourceTree = "<group>"; };
+		509F7396F2DCDBEF6C4833C26D738EFF /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		5104E41841C42E1DBCD1D8C5DCFC6B3D /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		544FDAA985D72F4FCCC6032A2DA17200 /* Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		55414FC27D39F6FE310EA0A1A9B01652 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
 		55EAB039A6FB6B200763CD2A22B3144A /* VIMLiveQuota.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveQuota.swift; sourceTree = "<group>"; };
-		574F83336B483EBFA1E8E9D50E348C42 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		574DDA2F1DA0EDF2376E53BA1430851E /* AFNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
 		5811EFB16042D6FBD1583EB7157A4944 /* VIMAppeal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAppeal.m; sourceTree = "<group>"; };
+		581BD34554C024C68A52F36F6CA3D78F /* Compatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Compatibility.h; path = OHHTTPStubs/Sources/Compatibility.h; sourceTree = "<group>"; };
 		58C63053F787C6960CE8A5D73E8E4DFB /* Pods-VimeoNetworkingExample-iOSTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-iOSTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		5A067FDC6CDFFF60B43E8487A5451CD1 /* Pods-VimeoNetworkingExample-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		5A234D8396D42365A10FBF78662D78E6 /* OHPathHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHPathHelpers.m; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.m; sourceTree = "<group>"; };
 		5B3361E3E2E28F928C79FDBA4F0BB1C0 /* Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		5C3B224AF3818E361C18369B8290B377 /* KeychainStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeychainStore.swift; path = VimeoNetworking/Sources/KeychainStore.swift; sourceTree = "<group>"; };
+		5CE9C92185B5AE98FDFAEAC5BD3B9777 /* OHHTTPStubs-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubs-tvOS-dummy.m"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-dummy.m"; sourceTree = "<group>"; };
 		5CF706384DAA54F410FC2C4F527F391E /* VimeoClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoClient.swift; path = VimeoNetworking/Sources/VimeoClient.swift; sourceTree = "<group>"; };
-		5D70075751D4887B8E75038A18FE14AB /* NSURLRequest+HTTPBodyTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+HTTPBodyTesting.h"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.h"; sourceTree = "<group>"; };
 		5DCD58F3FDB49CAB9C841EB0973B4F55 /* VIMVideoHLSFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoHLSFile.m; sourceTree = "<group>"; };
-		5E3BFE051F80C7D8716234F0D95F7D2D /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		5E96CFB2C90199A00BC2B3195410C55D /* OHHTTPStubsMethodSwizzling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsMethodSwizzling.h; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.h; sourceTree = "<group>"; };
 		600BEB389D031E92F894D6226B7C8F4D /* AuthenticationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthenticationController.swift; path = VimeoNetworking/Sources/AuthenticationController.swift; sourceTree = "<group>"; };
 		608E7687538126F51A87AA6E85DFE7E2 /* Request+PolicyDocument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+PolicyDocument.swift"; path = "VimeoNetworking/Sources/Request+PolicyDocument.swift"; sourceTree = "<group>"; };
-		61651A42F365DF165AF11718975F5522 /* VimeoNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VimeoNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
-		618327D4DFADDA200A5129D04FC3B50D /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
-		64103BB120CA8600A536D1946C6C1F50 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		614359312042614CD737C5244FDE4995 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
 		64A597545D5BC043A6907C054056C2C1 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		651706A6FF3F7A445E4EE2A7FA155F1A /* VIMVideoHLSFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoHLSFile.h; sourceTree = "<group>"; };
 		6541BD7AB0F17432290D19DDE180D316 /* AppConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppConfiguration.swift; path = VimeoNetworking/Sources/AppConfiguration.swift; sourceTree = "<group>"; };
-		68C6E25A656F0267F49C59411CAE5093 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
 		6A17A2224722F22EBFDF4A59E64BE3E6 /* Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		6A2E42478CA76BB6EBAE6C77E59532E6 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
 		6A51AD98B7FB72BAB2F01D5CF75D348B /* ErrorCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorCode.swift; path = VimeoNetworking/Sources/ErrorCode.swift; sourceTree = "<group>"; };
 		6A749B81E908B35FC844C9442E46C4D9 /* Request+Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Category.swift"; path = "VimeoNetworking/Sources/Request+Category.swift"; sourceTree = "<group>"; };
+		6AC9CDC0D57678EA71466D6CBBF16A60 /* AFNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-prefix.pch"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
 		6C2FA4D3A8916ACEA1102D5BE833880E /* Pods-VimeoNetworkingExample-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		6CE086533E408A3943908000D7B977B9 /* VIMVideoFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFile.m; sourceTree = "<group>"; };
 		6D546CE6D725C63D5D4CBAECBC0A982B /* VIMTag.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTag.h; sourceTree = "<group>"; };
 		6E749F0F363F966E77909FF11A825D9F /* VIMVODItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODItem.h; sourceTree = "<group>"; };
-		6EC90DBE7933C4957EC1940C58E4CBA3 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		6FDEE1FA6FEF6A458A376A1B4C1E8A5B /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
 		708050156ED66C1D9239A7DD48F7F12E /* Pods-VimeoNetworkingExample-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-iOS.modulemap"; sourceTree = "<group>"; };
-		718DC36F32779DC90E0C41A36AC2F0AC /* VimeoNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VimeoNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
 		72222C2D536EF74A481361820A067878 /* Pods-VimeoNetworkingExample-tvOSTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOSTests-resources.sh"; sourceTree = "<group>"; };
 		727A496A9F9CEE3A461236AC96190395 /* VIMBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMBadge.swift; sourceTree = "<group>"; };
+		72B473B2EAEBBE1A38EAA0CBE7A89628 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
 		73C64A8B6899BAADAA92531BD1D144F4 /* VIMInteraction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMInteraction.m; sourceTree = "<group>"; };
 		73D3DF6500C2DEDAB59007A63E2F2BF8 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		741579C52861339FF7467FFB88914372 /* Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown"; sourceTree = "<group>"; };
+		75DE43EA457B381EA1DA2F68405211AF /* VimeoNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-prefix.pch"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
 		762FD6E7A08C68E73D6CB0A88F6A9621 /* VIMObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMObjectMapper.h; sourceTree = "<group>"; };
-		7647B1BF5A086B627A30A9F6CF30168F /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
 		7649B1363D1B885170B4B9AB473BD84E /* Pods-VimeoNetworkingExample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		7666E344E7B2EB0D57E54461444DA988 /* VIMVODConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODConnection.m; sourceTree = "<group>"; };
 		76FA211D148128741F132E2B6A9225E6 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = VimeoNetworking/Sources/Request.swift; sourceTree = "<group>"; };
 		775A3EFCD50AB172D161D7C4CAAE9C3E /* Pods-VimeoNetworkingExample-iOSTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOSTests-frameworks.sh"; sourceTree = "<group>"; };
+		7830DB57DE3EA2CFD49FD16DCB51353D /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		799C344BC3BC8D05D3ABFB0E2D3A080C /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AC69B3F4EFA7C209AC2EDD06594DB24 /* Pods-VimeoNetworkingExample-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-tvOS.modulemap"; sourceTree = "<group>"; };
-		7B18965434B4C68D2A4F947A029A1906 /* OHPathHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHPathHelpers.h; path = OHHTTPStubs/Sources/OHPathHelpers/OHPathHelpers.h; sourceTree = "<group>"; };
 		7C59CBF3BB7FBFE6BCBBB5EB05D3DA20 /* Pods-VimeoNetworkingExample-iOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOSTests-dummy.m"; sourceTree = "<group>"; };
-		7CD6207175AC324B0E2212FC1A80E95E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CE0B2CEDCA02B0336A26CAF233335E7 /* VIMQuantityQuota.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMQuantityQuota.m; sourceTree = "<group>"; };
 		7DF148892C3ABD3CC940B502193A8E79 /* VIMPreference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPreference.h; sourceTree = "<group>"; };
+		7E0A53DBADB8E47787E5EB397CA667D2 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
+		7E21A976BFCFD23583CB61A834D05AB7 /* AFNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		7E9A244E10D11F27FC8B2C120CA03267 /* VIMVideoUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoUtils.h; sourceTree = "<group>"; };
-		7F53E4A5DED96DBF2CF631E214393F6F /* AFNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-prefix.pch"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
-		835E66ADD1A77D5BC604DB9A7D728132 /* VimeoNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "VimeoNetworking-iOS.modulemap"; sourceTree = "<group>"; };
+		8144126DEBAE34BEBAD942C2D49231A7 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		81C2D553F2E2803279FF04C57DFAADD1 /* VimeoNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VimeoNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
 		83780327FED2094C7FB0DCAE299FD7A5 /* VIMChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMChannel.h; sourceTree = "<group>"; };
 		83CE90A6CA5CB9F9ABF903126E8EB641 /* VIMTrigger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTrigger.h; sourceTree = "<group>"; };
-		83EA0676CF21BA54E28A0CD5DD8AC21A /* AFNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
 		83FD0D59B0CCCC535215F828E7331612 /* PinCodeInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PinCodeInfo.swift; sourceTree = "<group>"; };
-		84EF1EEF4D368BD5CFC8174DD3FA603C /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
-		85551D9083D5C20B2665444C48558A44 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		84DC4945F0CE70C8829DE6AABD8B24F8 /* OHHTTPStubsResponse+JSON.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubsResponse+JSON.m"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.m"; sourceTree = "<group>"; };
 		8585DE8883414855CDB578EBF2B4A237 /* Pods-VimeoNetworkingExample-iOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-resources.sh"; sourceTree = "<group>"; };
-		8597CE12BCA651E967C9490727A4FF09 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
+		862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		868C8630C6B0AE2AE2EADAE4EAEC7E48 /* Request+Trigger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Trigger.swift"; path = "VimeoNetworking/Sources/Request+Trigger.swift"; sourceTree = "<group>"; };
-		8BD261ED3E915F394BECB82B06442F87 /* AFNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
+		86D51C279B459F930381E6BDC96B3A2D /* AFNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "AFNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
+		877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsResponse.h; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.h; sourceTree = "<group>"; };
+		8988067C241ED04A45672E5B279E399D /* AFNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AFNetworking-tvOS-dummy.m"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
+		89F8C8EAAB07999FD4BD8979EF0C4614 /* OHHTTPStubs-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-iOS-prefix.pch"; sourceTree = "<group>"; };
+		8A60D7C472E5A947ED6BA247241E741B /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
 		8CDF8736416D1FB26621B5E594601AE9 /* VIMVideoDASHFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDASHFile.h; sourceTree = "<group>"; };
 		8D01E8B8BCB3440E70361E99123CBD33 /* VIMVideoFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFile.h; sourceTree = "<group>"; };
 		8EB478DA1571590140A9EF037D46D485 /* VIMCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCategory.m; sourceTree = "<group>"; };
-		91D3383470DD6000C1F330294F23062A /* VimeoNetworking-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-prefix.pch"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-prefix.pch"; sourceTree = "<group>"; };
-		931E2AE87DC3D775A010879EC39795DF /* OHHTTPStubs-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-iOS-prefix.pch"; sourceTree = "<group>"; };
+		9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+HTTPBodyTesting.h"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.h"; sourceTree = "<group>"; };
 		937A04B01D07FF37F808ADD2628BCC3D /* Pods-VimeoNetworkingExample-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOS-dummy.m"; sourceTree = "<group>"; };
 		938153199D95AF78E89094DD5AA19CAC /* VIMLiveChatUser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveChatUser.swift; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		945AF89D0281706D1BDA2CBC11C72167 /* VIMUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUploadTicket.m; sourceTree = "<group>"; };
 		945D61D8C14B3521948E03816738A4DE /* VIMUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadTicket.h; sourceTree = "<group>"; };
-		94754AE0C279F06453F0AA2C230F1AA3 /* OHHTTPStubs-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-prefix.pch"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-prefix.pch"; sourceTree = "<group>"; };
+		945E94EE93AA9FC917A41894927F6864 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94A9ED292066F23D3980211252C761BC /* VIMPicture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPicture.h; sourceTree = "<group>"; };
 		94CE0DDC3DD0A355A198035ED50FA887 /* VIMSoundtrack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSoundtrack.h; sourceTree = "<group>"; };
+		965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
 		96D0B77ECA667371F4D11CC2179EC413 /* VIMProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMProgrammedContent.swift; sourceTree = "<group>"; };
 		976F2632149220B6FD4D1ABCD9BE8347 /* Objc_ExceptionCatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Objc_ExceptionCatcher.h; path = VimeoNetworking/Sources/Objc_ExceptionCatcher.h; sourceTree = "<group>"; };
-		9886BB547554A74ED6E1805FE7CF9BE5 /* Compatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Compatibility.h; path = OHHTTPStubs/Sources/Compatibility.h; sourceTree = "<group>"; };
 		989BE0813D71894A683809A5FAA975FC /* Pods-VimeoNetworkingExample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		98AE2185572A3BA1F7F05262F566494E /* OHHTTPStubs-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubs-tvOS-dummy.m"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-dummy.m"; sourceTree = "<group>"; };
 		990E98F03B2973DD7DEF3E1526A3CFA6 /* VIMTag.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMTag.m; sourceTree = "<group>"; };
 		997AC5DE1FA278A656B468D5145CC2B9 /* VIMPreference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPreference.m; sourceTree = "<group>"; };
 		999DC7C279D201A50C4B211B2187D90D /* Pods-VimeoNetworkingExample-iOSTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-iOSTests-umbrella.h"; sourceTree = "<group>"; };
 		9A69C53310CD4FFBB8313D7029D9DAD4 /* VIMSeason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSeason.m; sourceTree = "<group>"; };
-		9AEF2D89A9C7EF2CA680FC1286BB6E38 /* OHHTTPStubsResponse+JSON.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubsResponse+JSON.h"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.h"; sourceTree = "<group>"; };
 		9C69EEA3F1070199D263832FB5405713 /* VimeoReachability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoReachability.swift; path = VimeoNetworking/Sources/VimeoReachability.swift; sourceTree = "<group>"; };
-		9C6EBB0206A054C2534730D13ABB5BAB /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
-		9C7C1F9A887AA46CC02742939DD319A9 /* UIImage+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+AFNetworking.h"; path = "UIKit+AFNetworking/UIImage+AFNetworking.h"; sourceTree = "<group>"; };
-		9D4628139C29E288D16EF0D23CAA8927 /* OHHTTPStubs.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubs.m; path = OHHTTPStubs/Sources/OHHTTPStubs.m; sourceTree = "<group>"; };
-		9D5B6DD5D81552A5CF21DB4FDA737534 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E24B7AF42B9CCA92E9A921DE209B454 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = VimeoNetworking/Sources/Result.swift; sourceTree = "<group>"; };
-		9F11C447B4A5C1DD7EC8A74F705C45D7 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
+		9F21BECB66C74C9E7191AD486147C466 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
 		9FCD70CA87921F98B314C93A892DC80D /* VIMPolicyDocument.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPolicyDocument.m; sourceTree = "<group>"; };
+		9FF6CD300017F92D8B4F1CD9AD735769 /* OHHTTPStubsResponse+JSON.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubsResponse+JSON.h"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.h"; sourceTree = "<group>"; };
+		A083E8E2DD7AD5A8CA77BB288DD34377 /* AFNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
 		A260EABF3F2CB69ECC0B7175256CDDDB /* Pods-VimeoNetworkingExample-iOSTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOSTests-resources.sh"; sourceTree = "<group>"; };
 		A2E80E99900FD85AE8497348CCCF7BB6 /* VIMObjectMapper+Generic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "VIMObjectMapper+Generic.swift"; path = "VimeoNetworking/Sources/VIMObjectMapper+Generic.swift"; sourceTree = "<group>"; };
-		A32BEE544DC0369D90A60420B63D2024 /* NSURLRequest+HTTPBodyTesting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+HTTPBodyTesting.m"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.m"; sourceTree = "<group>"; };
 		A3856B705413AABF027F61E774071E92 /* VIMVideoPlayRepresentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayRepresentation.h; sourceTree = "<group>"; };
-		A3DC5B0ABE9FD3C219EA281D609118B9 /* AFAutoPurgingImageCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFAutoPurgingImageCache.m; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.m"; sourceTree = "<group>"; };
-		A3DE97881D47078D62A3D882545BA367 /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
+		A3AAA79C011A0D7096BEECF36E6BFFB1 /* OHHTTPStubs.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubs.m; path = OHHTTPStubs/Sources/OHHTTPStubs.m; sourceTree = "<group>"; };
 		A43F8DB92C20BE6B4DD26B0B909395C8 /* Scope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scope.swift; path = VimeoNetworking/Sources/Scope.swift; sourceTree = "<group>"; };
 		A4DB008CBF81FC369D8F8DD0DD8EAA00 /* VimeoSessionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoSessionManager.swift; path = VimeoNetworking/Sources/VimeoSessionManager.swift; sourceTree = "<group>"; };
 		A4F0AB7C8F91FEA58A7B1A291D6971AF /* VimeoNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = VimeoNetworking.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A5A138196DB723F44A6CC162F1069C21 /* VIMThumbnailUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMThumbnailUploadTicket.h; sourceTree = "<group>"; };
+		A5EDD28BF9E17BFD5BD58B97EB672984 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
 		A672A92B3A5BD622F465A73CA87CCA4C /* Pods-VimeoNetworkingExample-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		A69A5F5B0FDBA5BEA33C54B361C623DD /* Request+Configs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Configs.swift"; path = "VimeoNetworking/Sources/Request+Configs.swift"; sourceTree = "<group>"; };
+		A714259BF8355E2CF37EE17258A289CC /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
 		A71B9A8EBDDD8A1265CAC511A018B5F4 /* VimeoRequestSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoRequestSerializer.swift; path = VimeoNetworking/Sources/VimeoRequestSerializer.swift; sourceTree = "<group>"; };
 		A8D8F7A437D9A6776896A730C017F954 /* VIMSeason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSeason.h; sourceTree = "<group>"; };
 		A965B5573DFDBD9889B367517089AAD8 /* VimeoNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VimeoNetworking.h; path = VimeoNetworking/Sources/VimeoNetworking.h; sourceTree = "<group>"; };
-		A9D379804D5FAA5107DC6D38790AAACC /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9F1548C213F2310570E40003D43A340 /* VIMNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotification.h; sourceTree = "<group>"; };
+		AA534480CFCA0CFAFE06E5FB3FD85719 /* VimeoNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		AB038766672B3B1E30156DC24EE6C3A2 /* VIMVideo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideo.h; sourceTree = "<group>"; };
-		AB86201FD0623F5A2BD47444489AEF52 /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB221E3090D0D4AB624A7F122A4E9AF8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubs.h; path = OHHTTPStubs/Sources/OHHTTPStubs.h; sourceTree = "<group>"; };
 		AE465D1211573B009F93A08AE2A1B352 /* NSError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSError+Extensions.swift"; path = "VimeoNetworking/Sources/NSError+Extensions.swift"; sourceTree = "<group>"; };
+		AE88F26D6FCFDCBB6C5849506BA11320 /* OHHTTPStubs-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "OHHTTPStubs-tvOS.modulemap"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.modulemap"; sourceTree = "<group>"; };
+		B001E69D258345AA7A26440F9473E822 /* OHHTTPStubs-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-prefix.pch"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-prefix.pch"; sourceTree = "<group>"; };
 		B0092F91DB4E89BECC74FDCB31842A8B /* Pods-VimeoNetworkingExample-iOSTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-iOSTests.modulemap"; sourceTree = "<group>"; };
-		B15C0878CB0C1A442EDB4FFC6FCA78D2 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
+		B13AC05770B2268AAE5B8B3430B674DE /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
 		B1E09519749331A478D454CFD1FD4C60 /* VIMRecommendation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMRecommendation.h; sourceTree = "<group>"; };
-		B28FFAF92DDD22D3FBCFE02BE916D227 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
+		B2635634392B942A9DD483C6329941C5 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
 		B39AA3A2AAE57F8EA725E4C60A64027C /* NSURLSessionConfiguration+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSessionConfiguration+Extensions.swift"; path = "VimeoNetworking/Sources/NSURLSessionConfiguration+Extensions.swift"; sourceTree = "<group>"; };
 		B428B7434D16B8CDC3FF036471D70B6D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		B8180C0BD5E8EC37F90490D3CA269BAA /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
 		B84F1ADBCA270A8520D5A490C32294DA /* Pods-VimeoNetworkingExample-tvOSTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOSTests-frameworks.sh"; sourceTree = "<group>"; };
 		B9C08F447F23CA0F58D4CB554BE51268 /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
 		BA04045C17425D7C640AE7E83006A948 /* Pods-VimeoNetworkingExample-iOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-iOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		BA815CE673111F13239C7DDCB582831D /* AFImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFImageDownloader.h; path = "UIKit+AFNetworking/AFImageDownloader.h"; sourceTree = "<group>"; };
-		BAFF4B2230B954A9192546154C238EE3 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
-		BC217249B6956500008D3DBEE89477DD /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
 		BC2226C458356246DAE3E43149D2140E /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BD0F06927E6DCCD70513AD4F7017E0C1 /* OHHTTPStubsResponse+JSON.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubsResponse+JSON.m"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.m"; sourceTree = "<group>"; };
+		BC3A227C66643D0661280E4118924975 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C0281338E2ABACEC9C2E0D98AD9C7B28 /* VIMConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMConnection.h; sourceTree = "<group>"; };
+		C0E92D2F6DB9D2B266B9BAB669A98D16 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AFNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
 		C114507B123A90E70675F1ECDDB83ADC /* VIMLiveTime.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveTime.swift; sourceTree = "<group>"; };
-		C2B74F4016605464912CC5A20B05C72E /* OHHTTPStubsMethodSwizzling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsMethodSwizzling.h; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.h; sourceTree = "<group>"; };
+		C45174DCB15F51AD57A41DE785396FDD /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		C53A223AEB3FFB33DC4CD965C33A30D1 /* VIMLiveChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveChat.swift; sourceTree = "<group>"; };
 		C551EB3E4A8AEC5C0079CE120B78D898 /* VIMSoundtrack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSoundtrack.m; sourceTree = "<group>"; };
 		C55B792A56DC07D6D1734C166C4F59B7 /* Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-tvOSTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		C59902AF61FD02ED3DE6DB2B2D1D2433 /* VIMUserBadge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUserBadge.h; sourceTree = "<group>"; };
-		C640171416F4884A7E9E809A968F008D /* AFNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "AFNetworking-tvOS.xcconfig"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
 		C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		C94529D8B8703E42BD48DF09888E412C /* VimeoNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VimeoNetworking-tvOS-umbrella.h"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
-		C9D7170F5DFB378DF9AEEA0091EAF8D3 /* OHHTTPStubs-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OHHTTPStubs-iOS.xcconfig"; sourceTree = "<group>"; };
 		CA53886DF0B3D70B00BDCAF83C3FC21D /* Request+Comment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Comment.swift"; path = "VimeoNetworking/Sources/Request+Comment.swift"; sourceTree = "<group>"; };
-		CB1CC3483006C633E669183CE549B946 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
-		CB42D4CDF851CAE05D81CC4AC9E5EB42 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB7D83DA48B23C73C97878387A2F94D1 /* VimeoNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VimeoNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
 		CBF67C27F1C7628A0A2CBAE563B6971F /* VIMThumbnailUploadTicket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMThumbnailUploadTicket.m; sourceTree = "<group>"; };
 		CC6E72041692DAA0F452829A7E82C12F /* VIMCredit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCredit.m; sourceTree = "<group>"; };
 		CDEFC4E5A9B0B069411B6406D44DBAF0 /* Mappable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mappable.swift; path = VimeoNetworking/Sources/Mappable.swift; sourceTree = "<group>"; };
-		CFF3EA798F2BD3BFF03F34375CC44323 /* OHHTTPStubs-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OHHTTPStubs-iOS-dummy.m"; sourceTree = "<group>"; };
+		D0E49DAEFDD4B970BB48849EA6AA92BB /* VimeoNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "VimeoNetworking-iOS.modulemap"; sourceTree = "<group>"; };
 		D0EE16B4A66409809D716B9830897F3A /* VIMPeriodic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMPeriodic.swift; sourceTree = "<group>"; };
+		D2F9F3D542328AF7EE1EF09EE8CE15A6 /* OHHTTPStubs-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-umbrella.h"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-umbrella.h"; sourceTree = "<group>"; };
+		D3EF1317C9374F6B7C44808F7CBA15AA /* VimeoNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VimeoNetworking-tvOS.xcconfig"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
 		D4469116C20C0DD973D6DE4B43F6C7B5 /* Pods-VimeoNetworkingExample-tvOSTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-tvOSTests.modulemap"; sourceTree = "<group>"; };
+		D5C507A361CCF752CAEA4F683158426F /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5FCD41BBCF70210BD5EEA0A41CEE2C7 /* AFNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "AFNetworking-tvOS.xcconfig"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
 		D68BC1F974E81C4E33197B3E237F4984 /* Pods-VimeoNetworkingExample-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-tvOS-dummy.m"; sourceTree = "<group>"; };
 		D6F76285C6537E689ED1252C8227229E /* VIMActivity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMActivity.h; sourceTree = "<group>"; };
+		D7A07D1FF3DFDE6B422F2EAADD824CF8 /* OHHTTPStubsResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsResponse.m; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.m; sourceTree = "<group>"; };
 		D7ED495F96351C8E44EF7AD04B27DA8F /* VIMPicture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPicture.m; sourceTree = "<group>"; };
-		D8BA41C9D10408061D7575DE9C7D538B /* OHHTTPStubs-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "OHHTTPStubs-iOS.modulemap"; sourceTree = "<group>"; };
 		D9447F13F56AB208D60EFF94C526B308 /* VimeoResponseSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoResponseSerializer.swift; path = VimeoNetworking/Sources/VimeoResponseSerializer.swift; sourceTree = "<group>"; };
-		D97FD648E821928DC09B4E4F0AE83B1A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DB9683AAFA44CD07EF76EEF539C98082 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
 		DB998775BC0746B9C955DD4E84712D94 /* VIMLive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLive.swift; sourceTree = "<group>"; };
 		DC1FB70C75EBB3AEC7A47923C95AF14D /* VIMGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMGroup.m; sourceTree = "<group>"; };
 		DC2F0DDDEBC9FB1680C624614785D88A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		DD6269B5D433646990D053C1BE8ED86B /* Pods-VimeoNetworkingExample-tvOSTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-tvOSTests-umbrella.h"; sourceTree = "<group>"; };
-		DF08848C4D20199424B4C46E998F601B /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		DDA1346A32994737D350AC6EC4C7E3BC /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		DFA8937B48AF5FF0492C6D81134A4920 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
 		DFBC061669ECF9828BC495A7ED8224CA /* VIMRecommendation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMRecommendation.m; sourceTree = "<group>"; };
 		E26A51850DAB1AA601D155390CAF8147 /* VIMLiveHeartbeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveHeartbeat.swift; sourceTree = "<group>"; };
+		E37639A24B2B30BB8029B0BEE3E0BF19 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
 		E4C16AD2D62643913F2016CDB1A8F4D8 /* VIMUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMUpload.swift; sourceTree = "<group>"; };
 		E4EA39F22E4B50E8D4B0422B6B1AE318 /* VIMNotificationsConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMNotificationsConnection.m; sourceTree = "<group>"; };
-		E5B988DA2B544758CCD18CD02E00812E /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5E87C0AC6A9E12C06F30533C33A4885 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		E74114B938D09E9B95B2A232D842310D /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E80D9AE18F1F351FAE3A50A26BB8CBE3 /* VIMGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMGroup.h; sourceTree = "<group>"; };
+		EA62E9E3D17573D9885A0866C372E2B1 /* OHHTTPStubs-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "OHHTTPStubs-tvOS.xcconfig"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.xcconfig"; sourceTree = "<group>"; };
 		EA6AFEADD257070DA241A6DE3FE996B8 /* VIMUser.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMUser.m; sourceTree = "<group>"; };
 		EACFED5608733705B9DAC66AA24C7099 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EB2033C30CA130FEA01B2241D3F3F655 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
 		EBBB59C93B058A49CE7EAC43E00F4C30 /* String+Parameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Parameters.swift"; path = "VimeoNetworking/Sources/String+Parameters.swift"; sourceTree = "<group>"; };
-		EBE30968EFE50165122521388F58339D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AFNetworking-tvOS/Info.plist"; sourceTree = "<group>"; };
+		ECA226C11972598EE0BDCEE5D35E1F4B /* VimeoNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VimeoNetworking-tvOS-dummy.m"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
 		ED29A8CCF216DD068CC72E828B1AFBE1 /* VIMConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMConnection.m; sourceTree = "<group>"; };
-		ED7BF8C339E993E18B24CFE87058A3E5 /* AFNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "AFNetworking-tvOS.modulemap"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
 		EE187DD624BADD97CB86FB1B83124BE1 /* VIMVideoDRMFiles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDRMFiles.m; sourceTree = "<group>"; };
 		EE559EBA7D568094DE418CDFC294970C /* VIMLiveStreams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveStreams.swift; sourceTree = "<group>"; };
 		EF77BF0DA5CC947E75F348EB5B70CA9B /* VIMUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUser.h; sourceTree = "<group>"; };
@@ -806,21 +807,20 @@
 		F0CE15D12F813D8BD00DB5B662D60632 /* VIMModelObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMModelObject.h; sourceTree = "<group>"; };
 		F283ABDC10103645EBA859B401258CB5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F32B0D9718FC14738188E3E79CCB61B3 /* PlayProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlayProgress.swift; sourceTree = "<group>"; };
-		F3B27B0AB145FB7FFBA28D9E3A1F9B8D /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F451EF7382B1605D927E544B9ECB048E /* Request+ProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+ProgrammedContent.swift"; path = "VimeoNetworking/Sources/Request+ProgrammedContent.swift"; sourceTree = "<group>"; };
-		F49260E55B65FF1AA0FAC6AD5F62D98F /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		F6288BEC4348892675C2475A77E86422 /* OHHTTPStubsResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsResponse.m; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.m; sourceTree = "<group>"; };
 		F6653787554A5DD3C4AD7E741D79C43E /* VIMVideoDASHFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDASHFile.m; sourceTree = "<group>"; };
 		F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		F6EA9468CA9ECE872AB05990C9E5DD0B /* Dictionary+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extension.swift"; path = "VimeoNetworking/Sources/Dictionary+Extension.swift"; sourceTree = "<group>"; };
 		F9A61B3A1B1F36E1336BC9A695FC14E2 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		F9EC6CD01086A1A77AF274418AA446F1 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA634AF354D27194C73D4F11D0226CCA /* Request+Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Cache.swift"; path = "VimeoNetworking/Sources/Request+Cache.swift"; sourceTree = "<group>"; };
-		FB909CA01DA859FF3FC525EA127F2107 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
 		FBCF9F8F6D70CB3C9ECB2C287D0EEF22 /* NetworkingNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkingNotification.swift; path = VimeoNetworking/Sources/NetworkingNotification.swift; sourceTree = "<group>"; };
 		FBF22B27C2300EE058B13556A0504F06 /* Request+User.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+User.swift"; path = "VimeoNetworking/Sources/Request+User.swift"; sourceTree = "<group>"; };
 		FC5B73D734D830ADBD2B57DD946DF93F /* VIMAppeal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMAppeal.h; sourceTree = "<group>"; };
+		FCCC1DC113B8BE0D5CB23BC822459F5F /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD8EECBE5AC34543AC0DA54CBA417F94 /* OHHTTPStubsMethodSwizzling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsMethodSwizzling.m; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.m; sourceTree = "<group>"; };
 		FDDC891AFB03CD09B35BC1C377F37166 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		FEE35DEA8A4CA96F130F7F7354C487C0 /* OHHTTPStubs-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "OHHTTPStubs-tvOS.modulemap"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.modulemap"; sourceTree = "<group>"; };
+		FE3BBE46E4C7CAB980BE0B85C34AEDB3 /* OHHTTPStubs+NSURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubs+NSURLSessionConfiguration.m"; path = "OHHTTPStubs/Sources/NSURLSession/OHHTTPStubs+NSURLSessionConfiguration.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -917,42 +917,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		10D7CE3A9318DDDB3A3DC0210BB390A6 /* Serialization */ = {
+		11FA9A3CF190E3CBDDCF1711537B8FA5 /* Serialization */ = {
 			isa = PBXGroup;
 			children = (
-				6EC90DBE7933C4957EC1940C58E4CBA3 /* AFURLRequestSerialization.h */,
-				117992A3E9C7F7CE964285F808F41C03 /* AFURLRequestSerialization.m */,
-				5E3BFE051F80C7D8716234F0D95F7D2D /* AFURLResponseSerialization.h */,
-				6FDEE1FA6FEF6A458A376A1B4C1E8A5B /* AFURLResponseSerialization.m */,
+				DDA1346A32994737D350AC6EC4C7E3BC /* AFURLRequestSerialization.h */,
+				509F7396F2DCDBEF6C4833C26D738EFF /* AFURLRequestSerialization.m */,
+				8A60D7C472E5A947ED6BA247241E741B /* AFURLResponseSerialization.h */,
+				414091E794E2076CE03DFEBD89D38746 /* AFURLResponseSerialization.m */,
 			);
 			name = Serialization;
 			sourceTree = "<group>";
 		};
-		16399AF20E808873496DC15196FA24DE /* UIKit */ = {
+		122EB36EA3296265C05C763CD70CB4AA /* Reachability */ = {
 			isa = PBXGroup;
 			children = (
-				9F11C447B4A5C1DD7EC8A74F705C45D7 /* AFAutoPurgingImageCache.h */,
-				A3DC5B0ABE9FD3C219EA281D609118B9 /* AFAutoPurgingImageCache.m */,
-				BA815CE673111F13239C7DDCB582831D /* AFImageDownloader.h */,
-				84EF1EEF4D368BD5CFC8174DD3FA603C /* AFImageDownloader.m */,
-				FB909CA01DA859FF3FC525EA127F2107 /* AFNetworkActivityIndicatorManager.h */,
-				45F5E04D7AE257107C861EA50DB483B6 /* AFNetworkActivityIndicatorManager.m */,
-				85551D9083D5C20B2665444C48558A44 /* UIActivityIndicatorView+AFNetworking.h */,
-				574F83336B483EBFA1E8E9D50E348C42 /* UIActivityIndicatorView+AFNetworking.m */,
-				1ADE08DB317825E6252DADAF183C8594 /* UIButton+AFNetworking.h */,
-				68C6E25A656F0267F49C59411CAE5093 /* UIButton+AFNetworking.m */,
-				9C7C1F9A887AA46CC02742939DD319A9 /* UIImage+AFNetworking.h */,
-				32DA090D06B850ABB7CAB4B10F7C7E98 /* UIImageView+AFNetworking.h */,
-				2A871485C394D029F58600E577F7CE2E /* UIImageView+AFNetworking.m */,
-				BC217249B6956500008D3DBEE89477DD /* UIKit+AFNetworking.h */,
-				6A2E42478CA76BB6EBAE6C77E59532E6 /* UIProgressView+AFNetworking.h */,
-				F49260E55B65FF1AA0FAC6AD5F62D98F /* UIProgressView+AFNetworking.m */,
-				0E739EEE834C7C0BAB582D70BEEF9E73 /* UIRefreshControl+AFNetworking.h */,
-				06868FE8F75FA7CDAD397EA9E63FE0AF /* UIRefreshControl+AFNetworking.m */,
-				039818FD26CA118ABEEA7C6D11F409CA /* UIWebView+AFNetworking.h */,
-				DF08848C4D20199424B4C46E998F601B /* UIWebView+AFNetworking.m */,
+				614359312042614CD737C5244FDE4995 /* AFNetworkReachabilityManager.h */,
+				A714259BF8355E2CF37EE17258A289CC /* AFNetworkReachabilityManager.m */,
 			);
-			name = UIKit;
+			name = Reachability;
 			sourceTree = "<group>";
 		};
 		187F4EB452C3D57F45FB86A2724A94B8 /* iOS */ = {
@@ -968,21 +950,36 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		1B88650AAAF8F76F451EE752B0E88CB9 /* Products */ = {
+		1FA730EFD95BF567C0A2259A69357DEA /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				64103BB120CA8600A536D1946C6C1F50 /* AFNetworking.framework */,
-				3BF71B69A726D518AD38C04896097A70 /* AFNetworking.framework */,
-				7CD6207175AC324B0E2212FC1A80E95E /* OHHTTPStubs.framework */,
-				A9D379804D5FAA5107DC6D38790AAACC /* OHHTTPStubs.framework */,
-				AB86201FD0623F5A2BD47444489AEF52 /* Pods_VimeoNetworkingExample_iOS.framework */,
-				F3B27B0AB145FB7FFBA28D9E3A1F9B8D /* Pods_VimeoNetworkingExample_iOSTests.framework */,
-				E5B988DA2B544758CCD18CD02E00812E /* Pods_VimeoNetworkingExample_tvOS.framework */,
-				CB42D4CDF851CAE05D81CC4AC9E5EB42 /* Pods_VimeoNetworkingExample_tvOSTests.framework */,
-				1A8A0C98C1E33DDA9336160E18236982 /* VimeoNetworking.framework */,
-				8597CE12BCA651E967C9490727A4FF09 /* VimeoNetworking.framework */,
+				FCCC1DC113B8BE0D5CB23BC822459F5F /* AFNetworking.framework */,
+				8144126DEBAE34BEBAD942C2D49231A7 /* AFNetworking.framework */,
+				945E94EE93AA9FC917A41894927F6864 /* OHHTTPStubs.framework */,
+				138E683BC81CCB1695E602328599209D /* OHHTTPStubs.framework */,
+				799C344BC3BC8D05D3ABFB0E2D3A080C /* Pods_VimeoNetworkingExample_iOS.framework */,
+				D5C507A361CCF752CAEA4F683158426F /* Pods_VimeoNetworkingExample_iOSTests.framework */,
+				5104E41841C42E1DBCD1D8C5DCFC6B3D /* Pods_VimeoNetworkingExample_tvOS.framework */,
+				1EB60D5E72F18CE610B91D2F142A1F39 /* Pods_VimeoNetworkingExample_tvOSTests.framework */,
+				F9EC6CD01086A1A77AF274418AA446F1 /* VimeoNetworking.framework */,
+				E74114B938D09E9B95B2A232D842310D /* VimeoNetworking.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		20907D0BAC6C7E55D51279BF6DB41557 /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				1321FA5BE51F20152EFEEAD2DF86264D /* AFNetworking.h */,
+				BEE7CF7E32D19CECF33DB2F1ABF01F95 /* NSURLSession */,
+				122EB36EA3296265C05C763CD70CB4AA /* Reachability */,
+				ABB1304DE43C079CBAB7CBAF003A9D69 /* Security */,
+				11FA9A3CF190E3CBDDCF1711537B8FA5 /* Serialization */,
+				457CB66F660F7AFBBB12B847822E9544 /* Support Files */,
+				732DD4F4E13A76179E5482BAEC27431A /* UIKit */,
+			);
+			name = AFNetworking;
+			path = AFNetworking;
 			sourceTree = "<group>";
 		};
 		229CB67E4F089F610353DE562BF2905C /* VimeoNetworking */ = {
@@ -1034,39 +1031,10 @@
 				B4E207D6B8F73FA3DF7FBC7DFAEDD61A /* Models */,
 				2C644267E01CE0523EDB937A67FE9645 /* Pod */,
 				D208DBD0446139BBCC56DBF1C771D465 /* Resources */,
-				DDE2E8131A2F6EC42E9C31C5F8CCEF85 /* Support Files */,
+				7555C944F09CDB917A7B1EB69839A73C /* Support Files */,
 			);
 			name = VimeoNetworking;
 			path = ..;
-			sourceTree = "<group>";
-		};
-		28642A256998D7BDCC0F58612ED8A5D0 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				631ED60349256723CEE6AA3FE17F42E5 /* AFNetworking */,
-				861D19B2FA7DD2B2437C68E42F37AF01 /* OHHTTPStubs */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		286AB301D0384802E77DFCC9E5D51728 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				17E350CB4AB82E6208A077258E26F453 /* Info.plist */,
-				D97FD648E821928DC09B4E4F0AE83B1A /* Info.plist */,
-				D8BA41C9D10408061D7575DE9C7D538B /* OHHTTPStubs-iOS.modulemap */,
-				C9D7170F5DFB378DF9AEEA0091EAF8D3 /* OHHTTPStubs-iOS.xcconfig */,
-				CFF3EA798F2BD3BFF03F34375CC44323 /* OHHTTPStubs-iOS-dummy.m */,
-				931E2AE87DC3D775A010879EC39795DF /* OHHTTPStubs-iOS-prefix.pch */,
-				33137EC96B0EAC2DD37666B3A74E761F /* OHHTTPStubs-iOS-umbrella.h */,
-				FEE35DEA8A4CA96F130F7F7354C487C0 /* OHHTTPStubs-tvOS.modulemap */,
-				2CD87A78D6DE7C189BFDDE05A55CAFDB /* OHHTTPStubs-tvOS.xcconfig */,
-				98AE2185572A3BA1F7F05262F566494E /* OHHTTPStubs-tvOS-dummy.m */,
-				94754AE0C279F06453F0AA2C230F1AA3 /* OHHTTPStubs-tvOS-prefix.pch */,
-				2D5CB7459156AE663C1050F4E9BCA162 /* OHHTTPStubs-tvOS-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/OHHTTPStubs-iOS";
 			sourceTree = "<group>";
 		};
 		2C644267E01CE0523EDB937A67FE9645 /* Pod */ = {
@@ -1077,6 +1045,25 @@
 				A4F0AB7C8F91FEA58A7B1A291D6971AF /* VimeoNetworking.podspec */,
 			);
 			name = Pod;
+			sourceTree = "<group>";
+		};
+		2CEFB4B4B3B8C10B2CF0BFA6D06AA7CD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				20907D0BAC6C7E55D51279BF6DB41557 /* AFNetworking */,
+				73165FDAE9F96C2B304D2BD5FD0CC348 /* OHHTTPStubs */,
+				3B7EEEDB284F38195BF53975FB328469 /* SwiftLint */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		3140497731C9327368A8599A3BC16898 /* OHPathHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				2A0606579DBD66FA4905BDE4F2FE00F6 /* OHPathHelpers.h */,
+				5A234D8396D42365A10FBF78662D78E6 /* OHPathHelpers.m */,
+			);
+			name = OHPathHelpers;
 			sourceTree = "<group>";
 		};
 		34E2D799A96824C7D435E11DC64F7563 /* Pods-VimeoNetworkingExample-tvOSTests */ = {
@@ -1097,37 +1084,113 @@
 			path = "Target Support Files/Pods-VimeoNetworkingExample-tvOSTests";
 			sourceTree = "<group>";
 		};
-		5BF4473391EF60121168737B5CAD94E0 /* Reachability */ = {
+		3B7EEEDB284F38195BF53975FB328469 /* SwiftLint */ = {
 			isa = PBXGroup;
 			children = (
-				BAFF4B2230B954A9192546154C238EE3 /* AFNetworkReachabilityManager.h */,
-				116399426B26CFD5FD6337B68AEA451C /* AFNetworkReachabilityManager.m */,
 			);
-			name = Reachability;
+			name = SwiftLint;
+			path = SwiftLint;
 			sourceTree = "<group>";
 		};
-		5F8BF643601C315280DC1ED36E01B3BB /* JSON */ = {
+		40092B72B740650FB942135BF493FAB7 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
-				9AEF2D89A9C7EF2CA680FC1286BB6E38 /* OHHTTPStubsResponse+JSON.h */,
-				BD0F06927E6DCCD70513AD4F7017E0C1 /* OHHTTPStubsResponse+JSON.m */,
+				0D14ACCEE1C6E9C7BB7A1B7F5B64BF03 /* OHHTTPStubsSwift.swift */,
 			);
-			name = JSON;
+			name = Swift;
 			sourceTree = "<group>";
 		};
-		631ED60349256723CEE6AA3FE17F42E5 /* AFNetworking */ = {
+		4258E450DDC6FEFB16B8E05B38C07FE5 /* NSURLSession */ = {
 			isa = PBXGroup;
 			children = (
-				B28FFAF92DDD22D3FBCFE02BE916D227 /* AFNetworking.h */,
-				90DF41999824E211C25DEB379481BA32 /* NSURLSession */,
-				5BF4473391EF60121168737B5CAD94E0 /* Reachability */,
-				8DBA5DD1C50933D69470961EDB5650C0 /* Security */,
-				10D7CE3A9318DDDB3A3DC0210BB390A6 /* Serialization */,
-				8BA25BD32EAD9E6AFB4341AE207D66E6 /* Support Files */,
-				16399AF20E808873496DC15196FA24DE /* UIKit */,
+				9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */,
+				03AEBBDE827402241273190CAA3FA49F /* NSURLRequest+HTTPBodyTesting.m */,
+				FE3BBE46E4C7CAB980BE0B85C34AEDB3 /* OHHTTPStubs+NSURLSessionConfiguration.m */,
+				5E96CFB2C90199A00BC2B3195410C55D /* OHHTTPStubsMethodSwizzling.h */,
+				FD8EECBE5AC34543AC0DA54CBA417F94 /* OHHTTPStubsMethodSwizzling.m */,
 			);
-			name = AFNetworking;
-			path = AFNetworking;
+			name = NSURLSession;
+			sourceTree = "<group>";
+		};
+		457CB66F660F7AFBBB12B847822E9544 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1E53BAC736CE51BE9F3B64E399A4BB30 /* AFNetworking-iOS.modulemap */,
+				86D51C279B459F930381E6BDC96B3A2D /* AFNetworking-iOS.xcconfig */,
+				A083E8E2DD7AD5A8CA77BB288DD34377 /* AFNetworking-iOS-dummy.m */,
+				7E21A976BFCFD23583CB61A834D05AB7 /* AFNetworking-iOS-prefix.pch */,
+				574DDA2F1DA0EDF2376E53BA1430851E /* AFNetworking-iOS-umbrella.h */,
+				0A8BACDE7FE48A49C444D800DE02E9AF /* AFNetworking-tvOS.modulemap */,
+				D5FCD41BBCF70210BD5EEA0A41CEE2C7 /* AFNetworking-tvOS.xcconfig */,
+				8988067C241ED04A45672E5B279E399D /* AFNetworking-tvOS-dummy.m */,
+				6AC9CDC0D57678EA71466D6CBBF16A60 /* AFNetworking-tvOS-prefix.pch */,
+				3E911C478DE04F75AE4FE191CE6A5D8A /* AFNetworking-tvOS-umbrella.h */,
+				AB221E3090D0D4AB624A7F122A4E9AF8 /* Info.plist */,
+				C0E92D2F6DB9D2B266B9BAB669A98D16 /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/AFNetworking-iOS";
+			sourceTree = "<group>";
+		};
+		73165FDAE9F96C2B304D2BD5FD0CC348 /* OHHTTPStubs */ = {
+			isa = PBXGroup;
+			children = (
+				9333470E18C17A1784E98FA5456F29FB /* Core */,
+				7DE9AA17EBAB343CEB2C970D022E0BF3 /* JSON */,
+				4258E450DDC6FEFB16B8E05B38C07FE5 /* NSURLSession */,
+				3140497731C9327368A8599A3BC16898 /* OHPathHelpers */,
+				D43A524074B4CE8EEB302A500F4C4BC3 /* Support Files */,
+				40092B72B740650FB942135BF493FAB7 /* Swift */,
+			);
+			name = OHHTTPStubs;
+			path = OHHTTPStubs;
+			sourceTree = "<group>";
+		};
+		732DD4F4E13A76179E5482BAEC27431A /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				7E0A53DBADB8E47787E5EB397CA667D2 /* AFAutoPurgingImageCache.h */,
+				0253070E47023CF89CC23147E1435854 /* AFAutoPurgingImageCache.m */,
+				03CBB8C8659174E12110BF9F15D0EEB4 /* AFImageDownloader.h */,
+				12C5180CE8C0AEED2C554ED751A28E51 /* AFImageDownloader.m */,
+				9F21BECB66C74C9E7191AD486147C466 /* AFNetworkActivityIndicatorManager.h */,
+				05E3A20E3A1B39A6E94A94C136AECC39 /* AFNetworkActivityIndicatorManager.m */,
+				B13AC05770B2268AAE5B8B3430B674DE /* UIActivityIndicatorView+AFNetworking.h */,
+				E37639A24B2B30BB8029B0BEE3E0BF19 /* UIActivityIndicatorView+AFNetworking.m */,
+				7830DB57DE3EA2CFD49FD16DCB51353D /* UIButton+AFNetworking.h */,
+				10A360AA316FBBFB69D5C5F0233196D3 /* UIButton+AFNetworking.m */,
+				006AC8BB3C72CA483D8DF7E93BA7D212 /* UIImage+AFNetworking.h */,
+				0E6358FA7C9EE5C5A002DE3D91FB1FDD /* UIImageView+AFNetworking.h */,
+				C45174DCB15F51AD57A41DE785396FDD /* UIImageView+AFNetworking.m */,
+				72B473B2EAEBBE1A38EAA0CBE7A89628 /* UIKit+AFNetworking.h */,
+				4DDFF4DA52A4F6F21983F6455B1BBA00 /* UIProgressView+AFNetworking.h */,
+				08A155E222221ECA310A527C1C4F3E79 /* UIProgressView+AFNetworking.m */,
+				DB9683AAFA44CD07EF76EEF539C98082 /* UIRefreshControl+AFNetworking.h */,
+				DFA8937B48AF5FF0492C6D81134A4920 /* UIRefreshControl+AFNetworking.m */,
+				34DF3D6618104D202D7E400FAC38D4C5 /* UIWebView+AFNetworking.h */,
+				862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */,
+			);
+			name = UIKit;
+			sourceTree = "<group>";
+		};
+		7555C944F09CDB917A7B1EB69839A73C /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				BC3A227C66643D0661280E4118924975 /* Info.plist */,
+				0DE7D373DA97F4FDF2F3E7E86955CCEA /* Info.plist */,
+				D0E49DAEFDD4B970BB48849EA6AA92BB /* VimeoNetworking-iOS.modulemap */,
+				81C2D553F2E2803279FF04C57DFAADD1 /* VimeoNetworking-iOS.xcconfig */,
+				CB7D83DA48B23C73C97878387A2F94D1 /* VimeoNetworking-iOS-dummy.m */,
+				AA534480CFCA0CFAFE06E5FB3FD85719 /* VimeoNetworking-iOS-prefix.pch */,
+				2C461DC0072C2B5EEB7310C9E07C9625 /* VimeoNetworking-iOS-umbrella.h */,
+				17D8C95CBB8DC14FD7ABA9005B777B27 /* VimeoNetworking-tvOS.modulemap */,
+				D3EF1317C9374F6B7C44808F7CBA15AA /* VimeoNetworking-tvOS.xcconfig */,
+				ECA226C11972598EE0BDCEE5D35E1F4B /* VimeoNetworking-tvOS-dummy.m */,
+				75DE43EA457B381EA1DA2F68405211AF /* VimeoNetworking-tvOS-prefix.pch */,
+				010722D39F81298FE76249F6D7951171 /* VimeoNetworking-tvOS-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Pods/Target Support Files/VimeoNetworking-iOS";
 			sourceTree = "<group>";
 		};
 		76D3F309D094199550ABEA2829344C2F /* Targets Support Files */ = {
@@ -1147,76 +1210,31 @@
 				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
 				C1A2911484DC04920B5279262586993F /* Development Pods */,
 				E9D556AAF0AFD0B62B6597A5D043E0FE /* Frameworks */,
-				28642A256998D7BDCC0F58612ED8A5D0 /* Pods */,
-				1B88650AAAF8F76F451EE752B0E88CB9 /* Products */,
+				2CEFB4B4B3B8C10B2CF0BFA6D06AA7CD /* Pods */,
+				1FA730EFD95BF567C0A2259A69357DEA /* Products */,
 				76D3F309D094199550ABEA2829344C2F /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		7DF1397DD5A0E28FD86E7F1C5EDDD11D /* NSURLSession */ = {
+		7DE9AA17EBAB343CEB2C970D022E0BF3 /* JSON */ = {
 			isa = PBXGroup;
 			children = (
-				5D70075751D4887B8E75038A18FE14AB /* NSURLRequest+HTTPBodyTesting.h */,
-				A32BEE544DC0369D90A60420B63D2024 /* NSURLRequest+HTTPBodyTesting.m */,
-				4FEBFF6518DB1C31D746A751613D1751 /* OHHTTPStubs+NSURLSessionConfiguration.m */,
-				C2B74F4016605464912CC5A20B05C72E /* OHHTTPStubsMethodSwizzling.h */,
-				401026E25B68A923C0B6E168B189900A /* OHHTTPStubsMethodSwizzling.m */,
+				9FF6CD300017F92D8B4F1CD9AD735769 /* OHHTTPStubsResponse+JSON.h */,
+				84DC4945F0CE70C8829DE6AABD8B24F8 /* OHHTTPStubsResponse+JSON.m */,
 			);
-			name = NSURLSession;
+			name = JSON;
 			sourceTree = "<group>";
 		};
-		861D19B2FA7DD2B2437C68E42F37AF01 /* OHHTTPStubs */ = {
+		9333470E18C17A1784E98FA5456F29FB /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				BF63CA1F79793FF8477D211572F2423B /* Core */,
-				5F8BF643601C315280DC1ED36E01B3BB /* JSON */,
-				7DF1397DD5A0E28FD86E7F1C5EDDD11D /* NSURLSession */,
-				E55C8E0D21C3AADAEEC7B31D3F11301E /* OHPathHelpers */,
-				286AB301D0384802E77DFCC9E5D51728 /* Support Files */,
-				AF376D12182A4E0DF457973B21963C62 /* Swift */,
+				581BD34554C024C68A52F36F6CA3D78F /* Compatibility.h */,
+				AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */,
+				A3AAA79C011A0D7096BEECF36E6BFFB1 /* OHHTTPStubs.m */,
+				877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */,
+				D7A07D1FF3DFDE6B422F2EAADD824CF8 /* OHHTTPStubsResponse.m */,
 			);
-			name = OHHTTPStubs;
-			path = OHHTTPStubs;
-			sourceTree = "<group>";
-		};
-		8BA25BD32EAD9E6AFB4341AE207D66E6 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				177F1682F0D833C9004F50E9A752FDAB /* AFNetworking-iOS.modulemap */,
-				2FF104EB0D18595B2CF3EE3C4AD6CC7D /* AFNetworking-iOS.xcconfig */,
-				8BD261ED3E915F394BECB82B06442F87 /* AFNetworking-iOS-dummy.m */,
-				1DB20FBCCFF0D4A8A2B4A33DCD65C6CE /* AFNetworking-iOS-prefix.pch */,
-				83EA0676CF21BA54E28A0CD5DD8AC21A /* AFNetworking-iOS-umbrella.h */,
-				ED7BF8C339E993E18B24CFE87058A3E5 /* AFNetworking-tvOS.modulemap */,
-				C640171416F4884A7E9E809A968F008D /* AFNetworking-tvOS.xcconfig */,
-				23BB0FCFA1888840EF3ABB74F51AEF4D /* AFNetworking-tvOS-dummy.m */,
-				7F53E4A5DED96DBF2CF631E214393F6F /* AFNetworking-tvOS-prefix.pch */,
-				0DD8043066A89F0C3B0B121295F2F58D /* AFNetworking-tvOS-umbrella.h */,
-				EBE30968EFE50165122521388F58339D /* Info.plist */,
-				9D5B6DD5D81552A5CF21DB4FDA737534 /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AFNetworking-iOS";
-			sourceTree = "<group>";
-		};
-		8DBA5DD1C50933D69470961EDB5650C0 /* Security */ = {
-			isa = PBXGroup;
-			children = (
-				CB1CC3483006C633E669183CE549B946 /* AFSecurityPolicy.h */,
-				618327D4DFADDA200A5129D04FC3B50D /* AFSecurityPolicy.m */,
-			);
-			name = Security;
-			sourceTree = "<group>";
-		};
-		90DF41999824E211C25DEB379481BA32 /* NSURLSession */ = {
-			isa = PBXGroup;
-			children = (
-				0864552A7599E2DCE46506D035A84470 /* AFHTTPSessionManager.h */,
-				1D4182ADE116CA08CB2B4E1EF539811A /* AFHTTPSessionManager.m */,
-				7647B1BF5A086B627A30A9F6CF30168F /* AFURLSessionManager.h */,
-				B15C0878CB0C1A442EDB4FFC6FCA78D2 /* AFURLSessionManager.m */,
-			);
-			name = NSURLSession;
+			name = Core;
 			sourceTree = "<group>";
 		};
 		93DA2BCC25FB3A46FCC392153F3D0604 /* Pods-VimeoNetworkingExample-iOSTests */ = {
@@ -1248,12 +1266,13 @@
 			name = tvOS;
 			sourceTree = "<group>";
 		};
-		AF376D12182A4E0DF457973B21963C62 /* Swift */ = {
+		ABB1304DE43C079CBAB7CBAF003A9D69 /* Security */ = {
 			isa = PBXGroup;
 			children = (
-				4F0B6255F90E78087D9005AF8679E252 /* OHHTTPStubsSwift.swift */,
+				85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */,
+				965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */,
 			);
-			name = Swift;
+			name = Security;
 			sourceTree = "<group>";
 		};
 		B4E207D6B8F73FA3DF7FBC7DFAEDD61A /* Models */ = {
@@ -1371,16 +1390,15 @@
 			path = VimeoNetworking/Sources/Models;
 			sourceTree = "<group>";
 		};
-		BF63CA1F79793FF8477D211572F2423B /* Core */ = {
+		BEE7CF7E32D19CECF33DB2F1ABF01F95 /* NSURLSession */ = {
 			isa = PBXGroup;
 			children = (
-				9886BB547554A74ED6E1805FE7CF9BE5 /* Compatibility.h */,
-				0505109CFF4C687AF46E9503DD8210E8 /* OHHTTPStubs.h */,
-				9D4628139C29E288D16EF0D23CAA8927 /* OHHTTPStubs.m */,
-				2A080F18E8B7646F65EA74331AE60746 /* OHHTTPStubsResponse.h */,
-				F6288BEC4348892675C2475A77E86422 /* OHHTTPStubsResponse.m */,
+				B2635634392B942A9DD483C6329941C5 /* AFHTTPSessionManager.h */,
+				55414FC27D39F6FE310EA0A1A9B01652 /* AFHTTPSessionManager.m */,
+				A5EDD28BF9E17BFD5BD58B97EB672984 /* AFURLSessionManager.h */,
+				B8180C0BD5E8EC37F90490D3CA269BAA /* AFURLSessionManager.m */,
 			);
-			name = Core;
+			name = NSURLSession;
 			sourceTree = "<group>";
 		};
 		C1A2911484DC04920B5279262586993F /* Development Pods */ = {
@@ -1417,6 +1435,26 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
+		D43A524074B4CE8EEB302A500F4C4BC3 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1BF45048A3F5CA691B268D14EEB20A8B /* Info.plist */,
+				225DB0FDDE8488D307E09492A2A09960 /* Info.plist */,
+				3B5AD8616028CFB680DB31E587DBC111 /* OHHTTPStubs-iOS.modulemap */,
+				37E47978D75B6D1669D965A6F7831F1F /* OHHTTPStubs-iOS.xcconfig */,
+				4325EAD8A9CF3A766582A6F02701D03A /* OHHTTPStubs-iOS-dummy.m */,
+				89F8C8EAAB07999FD4BD8979EF0C4614 /* OHHTTPStubs-iOS-prefix.pch */,
+				4DCCDB5BA217AC73E3269E357E6C6A6B /* OHHTTPStubs-iOS-umbrella.h */,
+				AE88F26D6FCFDCBB6C5849506BA11320 /* OHHTTPStubs-tvOS.modulemap */,
+				EA62E9E3D17573D9885A0866C372E2B1 /* OHHTTPStubs-tvOS.xcconfig */,
+				5CE9C92185B5AE98FDFAEAC5BD3B9777 /* OHHTTPStubs-tvOS-dummy.m */,
+				B001E69D258345AA7A26440F9473E822 /* OHHTTPStubs-tvOS-prefix.pch */,
+				D2F9F3D542328AF7EE1EF09EE8CE15A6 /* OHHTTPStubs-tvOS-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/OHHTTPStubs-iOS";
+			sourceTree = "<group>";
+		};
 		DC298CE2C88237806F7899826530A7C6 /* Pods-VimeoNetworkingExample-tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1433,35 +1471,6 @@
 			);
 			name = "Pods-VimeoNetworkingExample-tvOS";
 			path = "Target Support Files/Pods-VimeoNetworkingExample-tvOS";
-			sourceTree = "<group>";
-		};
-		DDE2E8131A2F6EC42E9C31C5F8CCEF85 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				29003D45D48EB43DB3DB7E3B3BF3BA44 /* Info.plist */,
-				02E0295CFDD790D464A7BFCB9EF7DC1E /* Info.plist */,
-				835E66ADD1A77D5BC604DB9A7D728132 /* VimeoNetworking-iOS.modulemap */,
-				61651A42F365DF165AF11718975F5522 /* VimeoNetworking-iOS.xcconfig */,
-				718DC36F32779DC90E0C41A36AC2F0AC /* VimeoNetworking-iOS-dummy.m */,
-				4E6CF31F799FC3DBF6DB3AA7141C9AD8 /* VimeoNetworking-iOS-prefix.pch */,
-				A3DE97881D47078D62A3D882545BA367 /* VimeoNetworking-iOS-umbrella.h */,
-				9C6EBB0206A054C2534730D13ABB5BAB /* VimeoNetworking-tvOS.modulemap */,
-				021D16BBA71C462F3C78EB912BE6A4E7 /* VimeoNetworking-tvOS.xcconfig */,
-				30766B769E54A458277210073DF50046 /* VimeoNetworking-tvOS-dummy.m */,
-				91D3383470DD6000C1F330294F23062A /* VimeoNetworking-tvOS-prefix.pch */,
-				C94529D8B8703E42BD48DF09888E412C /* VimeoNetworking-tvOS-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Pods/Target Support Files/VimeoNetworking-iOS";
-			sourceTree = "<group>";
-		};
-		E55C8E0D21C3AADAEEC7B31D3F11301E /* OHPathHelpers */ = {
-			isa = PBXGroup;
-			children = (
-				7B18965434B4C68D2A4F947A029A1906 /* OHPathHelpers.h */,
-				00C4CD64935D011C2ED6898B50D4CDDE /* OHPathHelpers.m */,
-			);
-			name = OHPathHelpers;
 			sourceTree = "<group>";
 		};
 		E9D556AAF0AFD0B62B6597A5D043E0FE /* Frameworks */ = {
@@ -1716,7 +1725,7 @@
 			);
 			name = "AFNetworking-tvOS";
 			productName = "AFNetworking-tvOS";
-			productReference = 3BF71B69A726D518AD38C04896097A70 /* AFNetworking.framework */;
+			productReference = FCCC1DC113B8BE0D5CB23BC822459F5F /* AFNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		57553697013421D7CBF09FEB177CFC9F /* Pods-VimeoNetworkingExample-tvOSTests */ = {
@@ -1735,7 +1744,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-tvOSTests";
 			productName = "Pods-VimeoNetworkingExample-tvOSTests";
-			productReference = CB42D4CDF851CAE05D81CC4AC9E5EB42 /* Pods_VimeoNetworkingExample_tvOSTests.framework */;
+			productReference = 1EB60D5E72F18CE610B91D2F142A1F39 /* Pods_VimeoNetworkingExample_tvOSTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		65A499A9A590910089751AF838CEFAEF /* VimeoNetworking-tvOS */ = {
@@ -1754,7 +1763,7 @@
 			);
 			name = "VimeoNetworking-tvOS";
 			productName = "VimeoNetworking-tvOS";
-			productReference = 8597CE12BCA651E967C9490727A4FF09 /* VimeoNetworking.framework */;
+			productReference = F9EC6CD01086A1A77AF274418AA446F1 /* VimeoNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		6CEB2AA9DFB2A84E6BC4F19A4266FC37 /* AFNetworking-iOS */ = {
@@ -1771,7 +1780,7 @@
 			);
 			name = "AFNetworking-iOS";
 			productName = "AFNetworking-iOS";
-			productReference = 64103BB120CA8600A536D1946C6C1F50 /* AFNetworking.framework */;
+			productReference = 8144126DEBAE34BEBAD942C2D49231A7 /* AFNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		82B874EF050E4D5EA9F54FD64D640971 /* Pods-VimeoNetworkingExample-iOS */ = {
@@ -1790,7 +1799,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-iOS";
 			productName = "Pods-VimeoNetworkingExample-iOS";
-			productReference = AB86201FD0623F5A2BD47444489AEF52 /* Pods_VimeoNetworkingExample_iOS.framework */;
+			productReference = 799C344BC3BC8D05D3ABFB0E2D3A080C /* Pods_VimeoNetworkingExample_iOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		A250FB3F25BCBDF82EDED6A8E7CA25C9 /* OHHTTPStubs-tvOS */ = {
@@ -1807,7 +1816,7 @@
 			);
 			name = "OHHTTPStubs-tvOS";
 			productName = "OHHTTPStubs-tvOS";
-			productReference = 7CD6207175AC324B0E2212FC1A80E95E /* OHHTTPStubs.framework */;
+			productReference = 138E683BC81CCB1695E602328599209D /* OHHTTPStubs.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		A33B0E4A31DD20D2C1A59F59507A100D /* VimeoNetworking-iOS */ = {
@@ -1826,7 +1835,7 @@
 			);
 			name = "VimeoNetworking-iOS";
 			productName = "VimeoNetworking-iOS";
-			productReference = 1A8A0C98C1E33DDA9336160E18236982 /* VimeoNetworking.framework */;
+			productReference = E74114B938D09E9B95B2A232D842310D /* VimeoNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		B758A6BE8F7ACC80E050CFEECAA161C1 /* Pods-VimeoNetworkingExample-iOSTests */ = {
@@ -1845,7 +1854,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-iOSTests";
 			productName = "Pods-VimeoNetworkingExample-iOSTests";
-			productReference = F3B27B0AB145FB7FFBA28D9E3A1F9B8D /* Pods_VimeoNetworkingExample_iOSTests.framework */;
+			productReference = D5C507A361CCF752CAEA4F683158426F /* Pods_VimeoNetworkingExample_iOSTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		EBA6406B2744DDA1E479453E90A537C6 /* Pods-VimeoNetworkingExample-tvOS */ = {
@@ -1864,7 +1873,7 @@
 			);
 			name = "Pods-VimeoNetworkingExample-tvOS";
 			productName = "Pods-VimeoNetworkingExample-tvOS";
-			productReference = E5B988DA2B544758CCD18CD02E00812E /* Pods_VimeoNetworkingExample_tvOS.framework */;
+			productReference = 5104E41841C42E1DBCD1D8C5DCFC6B3D /* Pods_VimeoNetworkingExample_tvOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		EC577E04EF8F29E75A1B1E558059AB15 /* OHHTTPStubs-iOS */ = {
@@ -1881,7 +1890,7 @@
 			);
 			name = "OHHTTPStubs-iOS";
 			productName = "OHHTTPStubs-iOS";
-			productReference = A9D379804D5FAA5107DC6D38790AAACC /* OHHTTPStubs.framework */;
+			productReference = 945E94EE93AA9FC917A41894927F6864 /* OHHTTPStubs.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1901,7 +1910,7 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 1B88650AAAF8F76F451EE752B0E88CB9 /* Products */;
+			productRefGroup = 1FA730EFD95BF567C0A2259A69357DEA /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -2376,7 +2385,7 @@
 		};
 		0890FD54B43AD02B0BC5C342751F5050 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9D7170F5DFB378DF9AEEA0091EAF8D3 /* OHHTTPStubs-iOS.xcconfig */;
+			baseConfigurationReference = 37E47978D75B6D1669D965A6F7831F1F /* OHHTTPStubs-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2409,7 +2418,7 @@
 		};
 		13C0992027957A4A71A55039A00E33AB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2CD87A78D6DE7C189BFDDE05A55CAFDB /* OHHTTPStubs-tvOS.xcconfig */;
+			baseConfigurationReference = EA62E9E3D17573D9885A0866C372E2B1 /* OHHTTPStubs-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2505,7 +2514,7 @@
 		};
 		1C9B3CA075FA97B1EB0E9BC5F0964D68 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2FF104EB0D18595B2CF3EE3C4AD6CC7D /* AFNetworking-iOS.xcconfig */;
+			baseConfigurationReference = 86D51C279B459F930381E6BDC96B3A2D /* AFNetworking-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2536,7 +2545,7 @@
 		};
 		331643DBF712D020E4DB46FE33828D29 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C640171416F4884A7E9E809A968F008D /* AFNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = D5FCD41BBCF70210BD5EEA0A41CEE2C7 /* AFNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2627,7 +2636,7 @@
 		};
 		35DB77D70596535BD990F62EEAB5B5D0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 61651A42F365DF165AF11718975F5522 /* VimeoNetworking-iOS.xcconfig */;
+			baseConfigurationReference = 81C2D553F2E2803279FF04C57DFAADD1 /* VimeoNetworking-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2730,7 +2739,7 @@
 		};
 		74EE01DCD7E85B85A4C5B6B44D81E2D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C640171416F4884A7E9E809A968F008D /* AFNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = D5FCD41BBCF70210BD5EEA0A41CEE2C7 /* AFNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2761,7 +2770,7 @@
 		};
 		7C4CB3134FA2E414FDAB0D9D8AE51FB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 021D16BBA71C462F3C78EB912BE6A4E7 /* VimeoNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = D3EF1317C9374F6B7C44808F7CBA15AA /* VimeoNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2793,7 +2802,7 @@
 		};
 		8D6FA7228A1D95105A36128E9DC5540F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 61651A42F365DF165AF11718975F5522 /* VimeoNetworking-iOS.xcconfig */;
+			baseConfigurationReference = 81C2D553F2E2803279FF04C57DFAADD1 /* VimeoNetworking-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2895,7 +2904,7 @@
 		};
 		AFF44D5B0A5DBC8C09FA86D9AA702E5F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9D7170F5DFB378DF9AEEA0091EAF8D3 /* OHHTTPStubs-iOS.xcconfig */;
+			baseConfigurationReference = 37E47978D75B6D1669D965A6F7831F1F /* OHHTTPStubs-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2962,7 +2971,7 @@
 		};
 		C4DE8A171ADD2F1A118C9AD6EDA54C50 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 021D16BBA71C462F3C78EB912BE6A4E7 /* VimeoNetworking-tvOS.xcconfig */;
+			baseConfigurationReference = D3EF1317C9374F6B7C44808F7CBA15AA /* VimeoNetworking-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2995,7 +3004,7 @@
 		};
 		C79CED25890B5F2717EB7E635060CBF6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2CD87A78D6DE7C189BFDDE05A55CAFDB /* OHHTTPStubs-tvOS.xcconfig */;
+			baseConfigurationReference = EA62E9E3D17573D9885A0866C372E2B1 /* OHHTTPStubs-tvOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3098,7 +3107,7 @@
 		};
 		F8FC1323A70AA4717AEE1F11CA0149C6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2FF104EB0D18595B2CF3EE3C4AD6CC7D /* AFNetworking-iOS.xcconfig */;
+			baseConfigurationReference = 86D51C279B459F930381E6BDC96B3A2D /* AFNetworking-iOS.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";

--- a/Pods/SwiftLint/LICENSE
+++ b/Pods/SwiftLint/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown
+++ b/Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS-acknowledgements.markdown
@@ -24,6 +24,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+## SwiftLint
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 ## VimeoNetworking
 
 

--- a/Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS-acknowledgements.plist
+++ b/Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS-acknowledgements.plist
@@ -43,6 +43,37 @@ THE SOFTWARE.
 		</dict>
 		<dict>
 			<key>FooterText</key>
+			<string>The MIT License (MIT)
+
+Copyright (c) 2015 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
 			<string>
 The MIT License (MIT)
 

--- a/Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown
+++ b/Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS-acknowledgements.markdown
@@ -24,6 +24,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+## SwiftLint
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 ## VimeoNetworking
 
 

--- a/Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist
+++ b/Pods/Target Support Files/Pods-VimeoNetworkingExample-tvOS/Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist
@@ -43,6 +43,37 @@ THE SOFTWARE.
 		</dict>
 		<dict>
 			<key>FooterText</key>
+			<string>The MIT License (MIT)
+
+Copyright (c) 2015 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Title</key>
+			<string>SwiftLint</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
 			<string>
 The MIT License (MIT)
 

--- a/VimeoNetworking/Sources/AccountStore.swift
+++ b/VimeoNetworking/Sources/AccountStore.swift
@@ -53,14 +53,14 @@ final class AccountStore
         }
     }
     
-    // MARK: - 
+    // MARK: -
     
     private struct Constants
     {
         static let ErrorDomain = "AccountStoreErrorDomain"
     }
     
-    // MARK: - 
+    // MARK: -
     
     private let keychainStore: KeychainStore
     

--- a/VimeoNetworking/Sources/AuthenticationController.swift
+++ b/VimeoNetworking/Sources/AuthenticationController.swift
@@ -27,9 +27,9 @@
 import Foundation
 
 /**
- `AuthenticationController` is used to authenticate a `VimeoClient` instance, either by loading an account stored in the system keychain, or by interacting with the Vimeo API to authenticate a new account.  The two publicly accessible authentication methods are client credentials grant and code grant.  
+ `AuthenticationController` is used to authenticate a `VimeoClient` instance, either by loading an account stored in the system keychain, or by interacting with the Vimeo API to authenticate a new account.  The two publicly accessible authentication methods are client credentials grant and code grant.
  
- Client credentials grant is a public authentication method with no logged in user, which allows your application to access anything a logged out user could see on Vimeo (public content).  
+ Client credentials grant is a public authentication method with no logged in user, which allows your application to access anything a logged out user could see on Vimeo (public content).
  
  Code grant is a way of logging in with a user account, which can give your application access to that user's private content and permission to interact with Vimeo on their behalf.  This is achieved by first opening a generated URL in Safari which presents a user log in page.  When the user authenticates successfully, control is returned to your app through a redirect link, and you then make a final request to retrieve the authenticated account.
  
@@ -358,7 +358,7 @@ final public class AuthenticationController
     
     /**
      **(PRIVATE: Vimeo Use Only, will not work for third-party applications)**
-     Exchange a saved access token granted to another application for a new token granted to the calling application.  This method will allow an application to re-use credentials from another Vimeo application.  Client credentials must be granted before using this method. 
+     Exchange a saved access token granted to another application for a new token granted to the calling application.  This method will allow an application to re-use credentials from another Vimeo application.  Client credentials must be granted before using this method.
      
      - parameter accessToken: access token granted to the other application
      - parameter completion:  handler for authentication success or failure

--- a/VimeoNetworking/Sources/KeychainStore.swift
+++ b/VimeoNetworking/Sources/KeychainStore.swift
@@ -119,7 +119,7 @@ final class KeychainStore
         }
     }
     
-    // MARK: - 
+    // MARK: -
     
     private func query(for key: String) -> [String: Any]
     {

--- a/VimeoNetworking/Sources/Models/VIMLiveChatUser.swift
+++ b/VimeoNetworking/Sources/Models/VIMLiveChatUser.swift
@@ -46,7 +46,7 @@ public enum AccountType: String
 
 /// An object representing the `user` field in a `chat` response.
 public class VIMLiveChatUser: VIMModelObject
-{    
+{
     private struct Constants
     {
         static let PictureResponseKey = "pictures"

--- a/VimeoNetworking/Sources/Request+Video.swift
+++ b/VimeoNetworking/Sources/Request+Video.swift
@@ -40,7 +40,7 @@ public extension Request
     
     private static var SelectedUsersPrivacyPath: String { return "/privacy/users" }
     
-    // MARK: - 
+    // MARK: -
     
     /**
      Create a `Request` to get a specific video

--- a/VimeoNetworking/Sources/Response.swift
+++ b/VimeoNetworking/Sources/Response.swift
@@ -61,7 +61,7 @@ import Foundation
         /// The request for the last page associated with this collection response, if one exists
     public let lastPageRequest: Request<ModelType>?
     
-    // MARK: - 
+    // MARK: -
     
     /**
      Creates a new `Response`

--- a/VimeoNetworking/Sources/ResponseCache.swift
+++ b/VimeoNetworking/Sources/ResponseCache.swift
@@ -171,7 +171,7 @@ final public class ResponseCache
                 let fileManager = FileManager()
                 let directoryPath = self.cachesDirectoryURL().path
                 
-                guard let filePath = self.fileURL(forKey: key)?.path else 
+                guard let filePath = self.fileURL(forKey: key)?.path else
                 {
                     assertionFailure("No cache path found.")
                     return
@@ -195,7 +195,7 @@ final public class ResponseCache
                 {
                     print("ResponseDiskCache error: \(error)")
                 }
-            }) 
+            })
         }
         
         func responseDictionary(forKey key: String, completion: @escaping (VimeoClient.ResponseDictionary?) -> Void)
@@ -270,7 +270,7 @@ final public class ResponseCache
                 {
                     print("Removal of disk cache for \(key) failed with error \(error)")
                 }
-            }) 
+            })
         }
         
         func removeAllResponseDictionaries()
@@ -294,7 +294,7 @@ final public class ResponseCache
                 {
                     print("Could not clear disk cache.")
                 }
-            }) 
+            })
         }
         
         // MARK: - directories

--- a/VimeoNetworking/Sources/Result.swift
+++ b/VimeoNetworking/Sources/Result.swift
@@ -41,7 +41,7 @@ public enum Result<ResultType>
     case failure(error: NSError)
 }
 
-/// `ResultCompletion` creates a generic typealias to generally define completion blocks that return a `Result` 
+/// `ResultCompletion` creates a generic typealias to generally define completion blocks that return a `Result`
 public enum ResultCompletion<ResultType>
 {
     public typealias T = (Result<ResultType>) -> Void

--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -27,12 +27,12 @@
 import Foundation
 
 /// `VimeoClient` handles a rich assortment of functionality focused around interacting with the Vimeo API.  A client object tracks an authenticated account, handles the low-level execution of requests through a session manager with caching functionality, presents a high-level `Request` and `Response` interface, and notifies of globally relevant events and errors through `Notification`s
-/// 
+///
 /// To start using a client, first instantiate an `AuthenticationController` to load a stored account or authenticate a new one.  Next, create `Request` instances and pass them into the `request` function, which returns `Response`s on success.
 
 final public class VimeoClient
 {
-    // MARK: - 
+    // MARK: -
     
     /// HTTP methods available for requests
     public enum Method: String

--- a/VimeoNetworking/Sources/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoRequestSerializer.swift
@@ -42,7 +42,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
     
     public typealias AccessTokenProvider = () -> String?
     
-    // MARK: 
+    // MARK:
     
     // for authenticated requests
     var accessTokenProvider: AccessTokenProvider?
@@ -197,7 +197,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
         guard let existingUserAgent = request.value(forHTTPHeaderField: Constants.UserAgentKey) else
         {
             // DISCUSSION: AFNetworking doesn't set a User Agent for tvOS (look at the init method in AFHTTPRequestSerializer.m).
-            // So, on tvOS the User Agent will only specify the framework. System information might be something we want to add 
+            // So, on tvOS the User Agent will only specify the framework. System information might be something we want to add
             // in the future if AFNetworking isn't providing it. [ghking] 6/19/17
             
             #if !os(tvOS)

--- a/VimeoNetworking/Sources/VimeoSessionManager.swift
+++ b/VimeoNetworking/Sources/VimeoSessionManager.swift
@@ -31,7 +31,7 @@ import AFNetworking
 /** `VimeoSessionManager` handles networking and serialization for raw HTTP requests.  It is a direct subclass of `AFHTTPSessionManager` and it's designed to be used internally by `VimeoClient`.  For the majority of purposes, it would be better to use `VimeoClient` and a `Request` object to better encapsulate this logic, since the latter provides richer functionality overall.
  */
 final public class VimeoSessionManager: AFHTTPSessionManager
-{    
+{
     // MARK: Initialization
     
     /**
@@ -44,7 +44,7 @@ final public class VimeoSessionManager: AFHTTPSessionManager
      - returns: an initialized `VimeoSessionManager`
      */
     required public init(baseUrl: URL, sessionConfiguration: URLSessionConfiguration, requestSerializer: VimeoRequestSerializer)
-    {        
+    {
         super.init(baseURL: baseUrl, sessionConfiguration: sessionConfiguration)
         
         self.requestSerializer = requestSerializer

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 				13C1F651C572424FF37A05C8 /* [CP] Check Pods Manifest.lock */,
 				018B9F921C9B34050054650E /* Sources */,
 				018B9F931C9B34050054650E /* Frameworks */,
+				0C2A0F8520C5E0E000B29725 /* ShellScript */,
 				018B9F941C9B34050054650E /* Resources */,
 				CA6E2119DFC5EFCAF0C431FA /* [CP] Embed Pods Frameworks */,
 			);
@@ -485,6 +486,7 @@
 				9B613935A5A18428B6721060 /* [CP] Check Pods Manifest.lock */,
 				966F0EF51E09D5740066DCF0 /* Sources */,
 				966F0EF61E09D5740066DCF0 /* Frameworks */,
+				0C2A0F8620C5E0F700B29725 /* ShellScript */,
 				966F0EF71E09D5740066DCF0 /* Resources */,
 				44371D5D7841C6F904AAED4C /* [CP] Embed Pods Frameworks */,
 			);
@@ -625,6 +627,32 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0C2A0F8520C5E0E000B29725 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "WORKSPACE_ROOT=$( cd \"$(dirname \"${SRCROOT[0]}\")\" ; pwd -P )\n\nif which swiftlint >/dev/null; then\n    \"$PODS_ROOT\"/SwiftLint/swiftlint autocorrect --config \"$WORKSPACE_ROOT\"/.swiftlint.yml\nelse\n    echo \"Warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		0C2A0F8620C5E0F700B29725 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "WORKSPACE_ROOT=$( cd \"$(dirname \"${SRCROOT[0]}\")\" ; pwd -P )\n\nif which swiftlint >/dev/null; then\n    \"$PODS_ROOT\"/SwiftLint/swiftlint autocorrect --config \"$WORKSPACE_ROOT\"/.swiftlint.yml\nelse\n    echo \"Warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
 		13C1F651C572424FF37A05C8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Add initial support for SwiftLint

### Implementation Summary
SwiftLint is being included in this project as a Pod, and will run during the script build phase for both the iOS and tvOS targets. 

We pass the `autocorrect` flag to automatically make changes to our source files to ensure consistency.

**Added SwiftLint to Podfile**
Added version 0.25.0 to the Podfile for both the iOS and tvOS targets.

**Enabled initial rules**
To start with only two rules will be autocorrected:
    - trailing_newline
    - trailing_whitespace

`trailing_newline` looks at the end of a file for extra newline characters. It ensures that only a single newline exists at the end of the file.

`trailing_whitespace` looks for extra whitespace at the end of a line. It then removes this whitespace.

These two rules were chosen for their low impact and lack of visible changes. More rules can be added in the future (for example, the `opening_brace` rule might be a fun one try to out 🤔)

### Reviewer Tips
If you want to take a look at what SwiftLint has to offer you can install it locally by running:
`brew install swiftlint`

If you want to see a list all the rules available run `swiftlint rules`.

Lastly, if you want to see the definition for a particular rule, and examples of what violations that will trigger an autocorrection, you can run `swiftlint rules opening_brace`.

### How to Test
- Build and run the example app.
- Build and run tests.
- Ensure that only whitepsace was removed.