### PR TITLE
AF-243: Refactors ResponseCache and related tests

### DIFF
--- a/VimeoNetworking/Sources/VimeoClient.swift
+++ b/VimeoNetworking/Sources/VimeoClient.swift
@@ -176,110 +176,54 @@ final public class VimeoClient
      */
     public func request<ModelType>(_ request: Request<ModelType>, completionQueue: DispatchQueue = DispatchQueue.main, completion: @escaping ResultCompletion<Response<ModelType>>.T) -> RequestToken
     {
-        if request.useCache
-        {
-            self.responseCache.response(forRequest: request) { result in
-                
-                switch result
-                {
-                case .success(let responseDictionary):
-                    
-                    if let responseDictionary = responseDictionary
-                    {
-                        self.handleTaskSuccess(forRequest: request, task: nil, responseObject: responseDictionary, isCachedResponse: true, completionQueue: completionQueue, completion: completion)
-                    }
-                    else
-                    {
-                        let error = NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.cachedResponseNotFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "Cached response not found"])
-                        
-                        self.handleError(error, request: request)
-                        
-                        completionQueue.async {
-                            
-                            completion(.failure(error: error))
-                        }
-                    }
-                    
-                case .failure(let error):
-                    
-                    self.handleError(error, request: request)
-                    
-                    completionQueue.async {
-                        
-                        completion(.failure(error: error))
-                    }
-                }
+        let success: (URLSessionDataTask, Any?) -> Void = { (task, responseObject) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.handleTaskSuccess(forRequest: request, task: task, responseObject: responseObject, completionQueue: completionQueue, completion: completion)
             }
-
+        }
+        
+        let failure: (URLSessionDataTask?, Error) -> Void = { (task, error) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.handleTaskFailure(forRequest: request, task: task, error: error as NSError, completionQueue: completionQueue, completion: completion)
+            }
+        }
+        
+        let path = request.path
+        let parameters = request.parameters
+        
+        let task: URLSessionDataTask?
+        
+        switch request.method
+        {
+        case .GET:
+            task = self.sessionManager?.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
+        case .POST:
+            task = self.sessionManager?.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
+        case .PUT:
+            task = self.sessionManager?.put(path, parameters: parameters, success: success, failure: failure)
+        case .PATCH:
+            task = self.sessionManager?.patch(path, parameters: parameters, success: success, failure: failure)
+        case .DELETE:
+            task = self.sessionManager?.delete(path, parameters: parameters, success: success, failure: failure)
+        }
+        
+        guard let requestTask = task else
+        {
+            let description = "Session manager did not return a task"
+            
+            assertionFailure(description)
+            
+            let error = NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.requestMalformed.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
+            
+            self.handleTaskFailure(forRequest: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
+            
             return RequestToken(path: request.path, task: nil)
         }
-        else
-        {
-            let success: (URLSessionDataTask, Any?) -> Void = { (task, responseObject) in
-                
-                DispatchQueue.global(qos: .userInitiated).async {
-                    
-                    self.handleTaskSuccess(forRequest: request, task: task, responseObject: responseObject, completionQueue: completionQueue, completion: completion)
-                }
-            }
-            
-            let failure: (URLSessionDataTask?, Error) -> Void = { (task, error) in
-                
-                DispatchQueue.global(qos: .userInitiated).async {
-
-                    self.handleTaskFailure(forRequest: request, task: task, error: error as NSError, completionQueue: completionQueue, completion: completion)
-                }
-            }
-            
-            let path = request.path
-            let parameters = request.parameters
-            
-            let task: URLSessionDataTask?
-            
-            switch request.method
-            {
-            case .GET:
-                task = self.sessionManager?.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
-            case .POST:
-                task = self.sessionManager?.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
-            case .PUT:
-                task = self.sessionManager?.put(path, parameters: parameters, success: success, failure: failure)
-            case .PATCH:
-                task = self.sessionManager?.patch(path, parameters: parameters, success: success, failure: failure)
-            case .DELETE:
-                task = self.sessionManager?.delete(path, parameters: parameters, success: success, failure: failure)
-            }
-            
-            guard let requestTask = task else
-            {
-                let description = "Session manager did not return a task"
-                
-                assertionFailure(description)
-                
-                let error = NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.requestMalformed.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
-                
-                self.handleTaskFailure(forRequest: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
-                
-                return RequestToken(path: request.path, task: nil)
-            }
-            
-            return RequestToken(path: request.path, task: requestTask)
-        }
+        
+        return RequestToken(path: request.path, task: requestTask)
     }
     
-    /**
-     Removes any cached responses for a given `Request`
-     
-     - parameter request: the `Request` for which to remove all cached responses
-     */
-    public func removeCachedResponse(forKey key: String)
-    {
-        self.responseCache.removeResponse(forKey: key)
-    }
-    
-    /**
-     Clears a client's cache of all stored responses
-     */
+    /// Clears a client's cache of all stored responses.
     public func removeAllCachedResponses()
     {
         self.responseCache.clear()
@@ -372,12 +316,6 @@ final public class VimeoClient
                 response = Response<ModelType>(model: modelObject, json: responseDictionary, isCachedResponse: isCachedResponse)
             }
             
-            // To avoid a poisoned cache, explicitly wait until model object parsing is successful to store responseDictionary [RH]
-            if request.cacheResponse
-            {
-                self.responseCache.setResponse(responseDictionary: responseDictionary, forRequest: request)
-            }
-            
             completionQueue.async
             {
                 completion(.success(result: response))
@@ -385,7 +323,7 @@ final public class VimeoClient
         }
         catch let error
         {
-            self.responseCache.removeResponse(forKey: request.cacheKey)
+            self.responseCache.clear()
             
             self.handleTaskFailure(forRequest: request, task: task, error: error as NSError, completionQueue: completionQueue, completion: completion)
         }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/ResponseCacheTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/ResponseCacheTests.swift
@@ -37,94 +37,13 @@ class ResponseCacheTests: XCTestCase
         
         responseCache.clear()
     }
-    
-    func test_ResponseCache_CanStoreAndRetrieveResponse()
-    {
-        let request = Request<VIMCategory>(path: "/test/path")
-        let categoryJSONDict = ResponseUtilities.loadResponse(from: "categories-animation-response.json")
-        
-        self.responseCache.setResponse(responseDictionary: categoryJSONDict!, forRequest: request)
-        
-        self.responseCache.response(forRequest: request) { result in
-            switch result
-            {
-            case .success(let responseDictionary):
-                XCTAssertNotNil(responseDictionary)
-                
-            case .failure(let error):
-                XCTFail("\(error.localizedDescription)")
-            }
-        }
-    }
-    
-    func test_ResponseCache_CanRemoveResponseFromCache()
-    {
-        let request1 = Request<VIMCategory>(path: "/test/path1")
-        let request2 = Request<VIMCategory>(path: "/test/path2")
-        
-        let categoryJSONDict = ResponseUtilities.loadResponse(from: "categories-animation-response.json")
-        
-        self.responseCache.setResponse(responseDictionary: categoryJSONDict!, forRequest: request1)
-        self.responseCache.setResponse(responseDictionary: categoryJSONDict!, forRequest: request2)
-        
-        self.responseCache.removeResponse(forKey: request1.cacheKey)
-        
-        self.responseCache.response(forRequest: request1) { result in
-            switch result
-            {
-            case .success(let responseDictionary):
-                XCTAssertNil(responseDictionary)
-                
-            case .failure(let error):
-                XCTFail("\(error.localizedDescription)")
-            }
-        }
-        
-        self.responseCache.response(forRequest: request2) { result in
-            switch result
-            {
-            case .success(let responseDictionary):
-                XCTAssertNotNil(responseDictionary)
-                
-            case .failure(let error):
-                XCTFail("\(error.localizedDescription)")
-            }
-        }
-    }
  
-    func test_ResponseCache_clearRemovesAllEntries()
-    {
-        let request1 = Request<VIMCategory>(path: "/test/path1")
-        let request2 = Request<VIMCategory>(path: "/test/path2")
-        
-        let categoryJSONDict = ResponseUtilities.loadResponse(from: "categories-animation-response.json")
-        
-        self.responseCache.setResponse(responseDictionary: categoryJSONDict!, forRequest: request1)
-        self.responseCache.setResponse(responseDictionary: categoryJSONDict!, forRequest: request2)
-        
+    func test_clear_removesAllEntries()
+    {        
+        // Try adding some data to disk.
+        // Verify that data exists on disk.
+        // Run self.responseCache.clear().
         self.responseCache.clear()
-        
-        self.responseCache.response(forRequest: request1) { result in
-            switch result
-            {
-            case .success(let responseDictionary):
-                XCTAssertNil(responseDictionary)
-                
-            case .failure(let error):
-                XCTFail("\(error.localizedDescription)")
-            }
-        }
-        
-        self.responseCache.response(forRequest: request2) { result in
-            switch result
-            {
-            case .success(let responseDictionary):
-                XCTAssertNil(responseDictionary)
-                
-            case .failure(let error):
-                XCTFail("\(error.localizedDescription)")
-            }
-        }
+        // Verify that data no longer exists on disk.
     }
-
 }


### PR DESCRIPTION
### Ticket
[AF-243](https://vimean.atlassian.net/browse/AF-243)
*Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Removes most of the code for the ResponseCache, leaving its only function to clean up old caches.

### Implementation Summary
**ResponseCache:**
- Removed almost the entire class.
- The only functions left serve to clean up old caches.

**ResponseCacheTests:**
- Removed old tests.
- Added test to verify `clean()` function removes caches on disk as expected.

Also fixed some documentation and formatting things that were bugging me 👋😬👍

Removed references to the **ResponseCache** in **AuthenticationController**, and **VimeoClient**, 

### How to Test
- Build and run.
- Ensure tests pass.