### PR TITLE
VIM-6317: Remove the badgeType Pro Unlimited

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMUserBadge.h
+++ b/VimeoNetworking/Sources/Models/VIMUserBadge.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSInteger, VIMUserBadgeType)
 {
     VIMUserBadgeTypeDefault = 0,
     VIMUserBadgeTypePlus,
+    // PRO and PRO Unlimited have the same BadgeType `PRO` [JL 07/18/2018]
     VIMUserBadgeTypePro,
     VIMUserBadgeTypeBusiness,
     VIMUserBadgeTypeLiveBusiness,
@@ -38,7 +39,6 @@ typedef NS_ENUM(NSInteger, VIMUserBadgeType)
     VIMUserBadgeTypeStaff,
     VIMUserBadgeTypeSupport,
     VIMUserBadgeTypeCuration,
-    VIMUserBadgeTypeProUnlimited,
     VIMUserBadgeTypeProducer
 };
 

--- a/VimeoNetworking/Sources/Models/VIMUserBadge.m
+++ b/VimeoNetworking/Sources/Models/VIMUserBadge.m
@@ -37,7 +37,6 @@ static NSString *const Support = @"support";
 static NSString *const Alum = @"alum";
 static NSString *const LivePro = @"live_pro";
 static NSString *const LiveBusiness = @"live_business";
-static NSString *const ProUnlimited = @"pro_unlimited";
 static NSString *const Producer = @"producer";
 
 - (void)didFinishMapping
@@ -82,10 +81,6 @@ static NSString *const Producer = @"producer";
     else if ([self.type isEqualToString:LiveBusiness])
     {
         self.badgeType = VIMUserBadgeTypeLiveBusiness;
-    }
-    else if ([self.type isEqualToString:ProUnlimited])
-    {
-        self.badgeType = VIMUserBadgeTypeProUnlimited;
     }
     else if ([self.type isEqualToString:Producer])
     {


### PR DESCRIPTION
#### Ticket

[VIM-6317](https://vimean.atlassian.net/browse/VIM-6317)

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

- Remove the badge Type Pro Unlimited because PRO and PRO Unlimited use the same badge type

#### Implementation Summary

- Updated the enum badge type.

#### Reviewer Tips
#### How to Test

See main PR.