### PR TITLE
Replace use of '+' with string interpolation

### DIFF
--- a/VimeoNetworking/Sources/Request+Authentication.swift
+++ b/VimeoNetworking/Sources/Request+Authentication.swift
@@ -232,7 +232,7 @@ extension Request where ModelType: VIMNullResponse
      */
     public static func resetPasswordRequest(withEmail email: String) -> Request
     {
-        let path = "/users/" + email + "/password/reset"
+        let path = "/users/\(email)/password/reset"
         
         return Request(method: .POST, path: path)
     }

--- a/VimeoNetworking/Sources/Request+Cache.swift
+++ b/VimeoNetworking/Sources/Request+Cache.swift
@@ -35,7 +35,7 @@ public extension Request
         let url = NSURL(string: self.path)
         let urlPath = url?.path ?? ""
         
-        var cacheKey = "cached" + urlPath + "." + String(self.path.hashValue)
+        var cacheKey = "cached\(urlPath).\(self.path.hashValue)"
         cacheKey = cacheKey.replacingOccurrences(of: "/", with: ".")
         
         return cacheKey

--- a/VimeoNetworking/Sources/Request+Notifications.swift
+++ b/VimeoNetworking/Sources/Request+Notifications.swift
@@ -51,7 +51,7 @@ public extension Request
 
     private static func subscriptionsURI(forNotificationsURI notificationsURI: String, deviceToken: String) -> String
     {
-        return notificationsURI + "/\(deviceToken)" + SubscriptionsPathComponent
+        return "\(notificationsURI)/\(deviceToken)\(SubscriptionsPathComponent)"
     }
     
     public static func markNotificationAsNotNewRequest(forNotification notification: VIMNotification, notificationsURI: String) -> Request

--- a/VimeoNetworking/Sources/Request+Picture.swift
+++ b/VimeoNetworking/Sources/Request+Picture.swift
@@ -20,7 +20,7 @@ public extension Request
      */
     public static func createPictureRequest(forUserURI userURI: String) -> Request
     {
-        let uri = userURI + "/pictures"
+        let uri = "\(userURI)/pictures"
         
         return Request(method: .POST, path: uri)
     }

--- a/VimeoNetworking/Sources/Request+Trigger.swift
+++ b/VimeoNetworking/Sources/Request+Trigger.swift
@@ -92,6 +92,6 @@ extension Request
     {
         let deviceTypeIdentifier = UIDevice.current.userInterfaceIdiom == .phone ? "iphone" : "ipad"
         
-        return "me/devices/" + deviceTypeIdentifier + "/" + deviceToken
+        return "me/devices/\(deviceTypeIdentifier)/\(deviceToken)"
     }
 }

--- a/VimeoNetworking/Sources/VimeoRequestSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoRequestSerializer.swift
@@ -209,7 +209,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer
             return request
         }
         
-        let modifiedUserAgent = existingUserAgent + " " + frameworkString
+        let modifiedUserAgent = "\(existingUserAgent) \(frameworkString)"
         
         request.setValue(modifiedUserAgent, forHTTPHeaderField: Constants.UserAgentKey)
         


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Ticket Summary

- Using `+` with string literals has poor type-checking performance, see [here](https://github.vimeows.com/MobileApps/Style-Guides/pull/34).

#### Implementation Summary

- Wherever we had `+` used with string literals, use string interpolation instead.

#### Reviewer Tips

- Make sure interpolation replacements preserve semantics!

#### How to Test