### PR TITLE
VIM-6406: In DownloadManager, fetch any text tracks before initiating download

### DIFF
--- a/VimeoNetworking/Sources/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoResponseSerializer.swift
@@ -198,6 +198,7 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "text/html",
             "text/javascript",
             "application/vnd.vimeo.video+json",
+            "application/vnd.vimeo.video.texttrack+json",
             "application/vnd.vimeo.cover+json",
             "application/vnd.vimeo.service+json",
             "application/vnd.vimeo.comment+json",


### PR DESCRIPTION
#### Ticket

[VIM-6406](https://vimean.atlassian.net/browse/VIM-6406)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- We should download the text track objects from the API before we initiate the download if there are any available.

#### Implementation Summary

- Add the content type of the text tracks response to the `acceptableContentTypes()` return value.

#### Reviewer Tips

#### How to Test