### PR TITLE
VIM-6400: Updates privacy model for internal use

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMPrivacy.h
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.h
@@ -43,5 +43,6 @@ extern NSString * __nonnull VIMPrivacy_Disabled;
 @property (nonatomic, copy, nullable) NSString *comments;
 @property (nonatomic, copy, nullable) NSString *embed;
 @property (nonatomic, copy, nullable) NSString *view;
+@property (nonatomic, copy, nullable) NSString *bypassToken;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMPrivacy.m
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.m
@@ -43,7 +43,7 @@ NSString *VIMPrivacy_Disabled = @"disable";
 {
     return @{@"add": @"canAdd",
              @"download" : @"canDownload",
-             @"_bypass_Token" : @"bypassToken"};
+             @"_bypass_token" : @"bypassToken"};
 }
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMPrivacy.m
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.m
@@ -42,7 +42,8 @@ NSString *VIMPrivacy_Disabled = @"disable";
 - (NSDictionary *)getObjectMapping
 {
     return @{@"add": @"canAdd",
-             @"download" : @"canDownload"};
+             @"download" : @"canDownload",
+             @"_bypass_Token" : @"bypassToken"};
 }
 
 @end


### PR DESCRIPTION
## VIM-6400

### Ticket
[VIM-6400](https://vimean.atlassian.net/browse/VIM-6400)

### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Update the **VIMPrivacy** object to add support for a bypass token, allow a user to securely view password-protected videos after they have been authenticated.

### Implementation Summary
Added the new `bypassToken` property and the appropriate mapping.

### How to Test
Should be tested in the context of the client PR (internal only).