### PR TITLE
VIM-6642: Adds support for Albums

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		0839E002B149922976EE44A1631B8E20 /* VIMVideoFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E850E58DC224DD3AD022F86BBD50DF6 /* VIMVideoFile.m */; };
 		0A6C9BDE90C1012FE54242FBAAC2E2B1 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64A597545D5BC043A6907C054056C2C1 /* SystemConfiguration.framework */; };
 		0B46CE63DF1AC42FAE9821AD63D9CB07 /* VIMUploadQuota.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89690FB060ED296D03FBC190714BCF9 /* VIMUploadQuota.swift */; };
+		0CEA219321824E330040ED9F /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA219221824E330040ED9F /* Album.swift */; };
+		0CEA219421824E330040ED9F /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA219221824E330040ED9F /* Album.swift */; };
 		0CFF4C557F7B9AD50EBD6B5FB3FD14A7 /* VIMNotificationsConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 441ED70FC59793A952C675A5624708CC /* VIMNotificationsConnection.m */; };
 		0E9EFE8D070AD6DE7AC92FC203D1A44C /* Request+Toggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12055D483EE17FD06A0376818CA9314 /* Request+Toggle.swift */; };
 		0F27762351650811FC47B9B25906EFC2 /* VIMVideoHLSFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B6CFF4DE786CDC3CF27C9B41E9A66E2 /* VIMVideoHLSFile.m */; };
@@ -541,6 +543,7 @@
 		093BCBD8F7593A78CA51669F7A02F422 /* OHHTTPStubs-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-umbrella.h"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		095DC1D0262151B497FB8B15E856F658 /* OHHTTPStubs-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OHHTTPStubs-iOS-prefix.pch"; sourceTree = "<group>"; };
 		0B2EE5DFD5E1C7FE2716BBA090A85073 /* VIMPicture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMPicture.m; sourceTree = "<group>"; };
+		0CEA219221824E330040ED9F /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
 		0D14ACCEE1C6E9C7BB7A1B7F5B64BF03 /* OHHTTPStubsSwift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OHHTTPStubsSwift.swift; path = OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift; sourceTree = "<group>"; };
 		0E6358FA7C9EE5C5A002DE3D91FB1FDD /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		0ED0CB6B324DC2B0859103021104D71B /* VIMAppeal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMAppeal.m; sourceTree = "<group>"; };
@@ -556,7 +559,7 @@
 		19A1E9CF5A7AB9513FC1BF981E7C88D4 /* VIMVideoFairPlayFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFairPlayFile.h; sourceTree = "<group>"; };
 		19C26EF48DC2C64BA6B0B88F1D07342B /* AccountStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccountStore.swift; path = VimeoNetworking/Sources/AccountStore.swift; sourceTree = "<group>"; };
 		19E6D67D6A83F8E3901EA34C06D5511B /* VIMVODConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVODConnection.m; sourceTree = "<group>"; };
-		1A8A0C98C1E33DDA9336160E18236982 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A8A0C98C1E33DDA9336160E18236982 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B5CB9A17FAD3292C2D1834628D025C7 /* OHHTTPStubs-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "OHHTTPStubs-tvOS.xcconfig"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.xcconfig"; sourceTree = "<group>"; };
 		1B5EC8BA74556E10EC6C58839AB08EF8 /* Objc_ExceptionCatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Objc_ExceptionCatcher.m; path = VimeoNetworking/Sources/Objc_ExceptionCatcher.m; sourceTree = "<group>"; };
 		1BFD6948595AC793E50D657629655AB9 /* VIMThumbnailUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMThumbnailUploadTicket.h; sourceTree = "<group>"; };
@@ -586,7 +589,7 @@
 		38212376C25D32B607F162BD25384DD4 /* VIMVideoDRMFiles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDRMFiles.h; sourceTree = "<group>"; };
 		39113D0BD77A648FE3B6022196A81345 /* VimeoRequestSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoRequestSerializer.swift; path = VimeoNetworking/Sources/VimeoRequestSerializer.swift; sourceTree = "<group>"; };
 		3A3D43639BA8AE0B288A49A2DF38EBAD /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
-		3BF71B69A726D518AD38C04896097A70 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BF71B69A726D518AD38C04896097A70 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DB9F95F175362974D9C05ED9E54009C /* Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3E403018A219B1706367654CD8EF6B8C /* VimeoNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VimeoNetworking.h; path = VimeoNetworking/Sources/VimeoNetworking.h; sourceTree = "<group>"; };
 		3ED81E309C8B1F3F7D2A7631037B5554 /* VIMComment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMComment.h; sourceTree = "<group>"; };
@@ -627,7 +630,7 @@
 		5E96CFB2C90199A00BC2B3195410C55D /* OHHTTPStubsMethodSwizzling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsMethodSwizzling.h; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.h; sourceTree = "<group>"; };
 		614359312042614CD737C5244FDE4995 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
 		61C4C49E650FD660BFDD768A2BF360C7 /* VIMVideoFairPlayFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoFairPlayFile.m; sourceTree = "<group>"; };
-		64103BB120CA8600A536D1946C6C1F50 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		64103BB120CA8600A536D1946C6C1F50 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		645D2DB6B0F2730AD42B8E2531C409A3 /* VIMVideoDASHFile.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoDASHFile.m; sourceTree = "<group>"; };
 		64A597545D5BC043A6907C054056C2C1 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		658F037B5556267038A865F3F3E5C5F3 /* Request+Notifications.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Notifications.swift"; path = "VimeoNetworking/Sources/Request+Notifications.swift"; sourceTree = "<group>"; };
@@ -659,7 +662,7 @@
 		7AC69B3F4EFA7C209AC2EDD06594DB24 /* Pods-VimeoNetworkingExample-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-tvOS.modulemap"; sourceTree = "<group>"; };
 		7B1F2ADE18463F035DF9F9C778747C20 /* VIMVideoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoUtils.m; sourceTree = "<group>"; };
 		7C59CBF3BB7FBFE6BCBBB5EB05D3DA20 /* Pods-VimeoNetworkingExample-iOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOSTests-dummy.m"; sourceTree = "<group>"; };
-		7CD6207175AC324B0E2212FC1A80E95E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7CD6207175AC324B0E2212FC1A80E95E /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D27E538EBF240AA99E95301C5C9352E /* VimeoResponseSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VimeoResponseSerializer.swift; path = VimeoNetworking/Sources/VimeoResponseSerializer.swift; sourceTree = "<group>"; };
 		7D4981BE1FCC680D064A578321B81B60 /* NSError+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSError+Extensions.swift"; path = "VimeoNetworking/Sources/NSError+Extensions.swift"; sourceTree = "<group>"; };
 		7E0A53DBADB8E47787E5EB397CA667D2 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
@@ -670,11 +673,11 @@
 		856C7BF352E4BB019BA1C6D5323A3B09 /* OHHTTPStubs-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-prefix.pch"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-prefix.pch"; sourceTree = "<group>"; };
 		857CF9356091274E466F200C9B3543B9 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8585DE8883414855CDB578EBF2B4A237 /* Pods-VimeoNetworkingExample-iOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-resources.sh"; sourceTree = "<group>"; };
-		8597CE12BCA651E967C9490727A4FF09 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8597CE12BCA651E967C9490727A4FF09 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
 		862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		864A412B89AF5F4736B8C97E681F91F1 /* VIMVideo+VOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+VOD.h"; sourceTree = "<group>"; };
-		867B40B549B9E430533E43E269F7F3DD /* VimeoNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = VimeoNetworking.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		867B40B549B9E430533E43E269F7F3DD /* VimeoNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = VimeoNetworking.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsResponse.h; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.h; sourceTree = "<group>"; };
 		89988ADBCE491EF95E1664A382F4CE9A /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
 		8A60D7C472E5A947ED6BA247241E741B /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
@@ -688,12 +691,12 @@
 		91F8FB41EB9FDFB996D5A1CCB5617871 /* VIMTrigger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTrigger.h; sourceTree = "<group>"; };
 		929039871D87D12B6B28A831411554D3 /* ResponseCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResponseCache.swift; path = VimeoNetworking/Sources/ResponseCache.swift; sourceTree = "<group>"; };
 		9298E1C7A907B19E83A1F8290EB84DEC /* AuthenticationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthenticationController.swift; path = VimeoNetworking/Sources/AuthenticationController.swift; sourceTree = "<group>"; };
-		93192B471CA3AA907EE85122635F21A8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		93192B471CA3AA907EE85122635F21A8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+HTTPBodyTesting.h"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.h"; sourceTree = "<group>"; };
 		937A04B01D07FF37F808ADD2628BCC3D /* Pods-VimeoNetworkingExample-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOS-dummy.m"; sourceTree = "<group>"; };
 		938EAC57C1C57FA15637DDC514C9DFF3 /* VIMVideoFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFile.h; sourceTree = "<group>"; };
 		939C33B6E7B7087872FBB2E521CD392D /* Request+Configs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Configs.swift"; path = "VimeoNetworking/Sources/Request+Configs.swift"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		955797A7BF5E527C23994A443DF3063E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9565AED5201481B8041F99C6C1F97B73 /* VIMUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUser.h; sourceTree = "<group>"; };
 		965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
@@ -720,12 +723,12 @@
 		A7CFD94CC47DDDC0BAD17B949EA25FAD /* VIMInteraction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMInteraction.m; sourceTree = "<group>"; };
 		A89690FB060ED296D03FBC190714BCF9 /* VIMUploadQuota.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMUploadQuota.swift; sourceTree = "<group>"; };
 		A9B2E98DDA7BFD726DDA3C7846F0C4BE /* VIMChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMChannel.m; sourceTree = "<group>"; };
-		A9D379804D5FAA5107DC6D38790AAACC /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9D379804D5FAA5107DC6D38790AAACC /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAD8499AC306AADA1CAFA95222F509E6 /* Request+Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Category.swift"; path = "VimeoNetworking/Sources/Request+Category.swift"; sourceTree = "<group>"; };
 		AAEFDB0E8EB2525580BBC6FE907AD223 /* VIMObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMObjectMapper.h; sourceTree = "<group>"; };
-		AB86201FD0623F5A2BD47444489AEF52 /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB86201FD0623F5A2BD47444489AEF52 /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubs.h; path = OHHTTPStubs/Sources/OHHTTPStubs.h; sourceTree = "<group>"; };
-		AD1DC32941258A7B79378547A6016406 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; name = "digicert-sha2.cer"; path = "VimeoNetworking/Resources/digicert-sha2.cer"; sourceTree = "<group>"; };
+		AD1DC32941258A7B79378547A6016406 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "digicert-sha2.cer"; path = "VimeoNetworking/Resources/digicert-sha2.cer"; sourceTree = "<group>"; };
 		AD7DE981BAAD182DCD8730C425CDEF3B /* VIMUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadTicket.h; sourceTree = "<group>"; };
 		AE85BDA004F7732E66BBE0D0E6A4D4D1 /* VIMNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotification.h; sourceTree = "<group>"; };
 		AFE8A2285C12D490D6301C21E5BB8901 /* Request+Comment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Comment.swift"; path = "VimeoNetworking/Sources/Request+Comment.swift"; sourceTree = "<group>"; };
@@ -766,8 +769,8 @@
 		C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		C8A2780D17E256D269CAD10E410AC192 /* Request+Trigger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Trigger.swift"; path = "VimeoNetworking/Sources/Request+Trigger.swift"; sourceTree = "<group>"; };
 		CA6BBEBA25C16541D73C5FFFFBDC5F87 /* VIMVideo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideo.m; sourceTree = "<group>"; };
-		CA7EF00E6CFA7760304BD228C9F71398 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		CB42D4CDF851CAE05D81CC4AC9E5EB42 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA7EF00E6CFA7760304BD228C9F71398 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		CB42D4CDF851CAE05D81CC4AC9E5EB42 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE2F061F3DE0238EFD713B39005B251F /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
 		D1C935F6EC8D2710207984CA14342E26 /* VIMPicture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPicture.h; sourceTree = "<group>"; };
 		D1DD3C3234EFD0FADF718610DA386FAE /* AFNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
@@ -797,7 +800,7 @@
 		E5A4AFAC6C1D6AAAC0FAF57E08B48781 /* VIMLive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLive.swift; sourceTree = "<group>"; };
 		E5AE3886847960EE7B7CBE6ED50DEF0C /* VIMLiveStreams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveStreams.swift; sourceTree = "<group>"; };
 		E5B24D52DCEF72B39996AAB088C6B57F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E5B988DA2B544758CCD18CD02E00812E /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5B988DA2B544758CCD18CD02E00812E /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5E87C0AC6A9E12C06F30533C33A4885 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
 		E7923A77BEB62549A573A2561ED33CDE /* VIMRecommendation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMRecommendation.m; sourceTree = "<group>"; };
 		E9E13467A11C3C57341954F89E07EFBD /* VIMPolicyDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPolicyDocument.h; sourceTree = "<group>"; };
@@ -810,7 +813,7 @@
 		F161CC053C2B397AFC223C1F6147A031 /* VIMVideoDASHFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoDASHFile.h; sourceTree = "<group>"; };
 		F2784BDE8CCE48D186257C8B63722DC9 /* VIMCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMCategory.m; sourceTree = "<group>"; };
 		F283ABDC10103645EBA859B401258CB5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F3B27B0AB145FB7FFBA28D9E3A1F9B8D /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F3B27B0AB145FB7FFBA28D9E3A1F9B8D /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F679798AC5D474E422555358B3DC455E /* OHHTTPStubs-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OHHTTPStubs-iOS-dummy.m"; sourceTree = "<group>"; };
 		F6EA47483AF2318EB78D455EA5092750 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		F7878F10E87FD41F9A4FF33A5C99C94E /* VIMConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMConnection.m; sourceTree = "<group>"; };
@@ -923,6 +926,7 @@
 		00BB5437057ACC842EDD526342197AEF /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				0CEA219221824E330040ED9F /* Album.swift */,
 				68AEE38E3B1344007C9965A0B9B338DD /* PinCodeInfo.swift */,
 				90C9E43D5D6167989BBC67735167B4E1 /* PlayProgress.swift */,
 				13FAA716BE3752F02DDD14A1E8261CDA /* Spatial.swift */,
@@ -1172,7 +1176,6 @@
 				6DF8FAB3381C5CD456A65F3828E5195E /* Support Files */,
 				732DD4F4E13A76179E5482BAEC27431A /* UIKit */,
 			);
-			name = AFNetworking;
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
@@ -1217,7 +1220,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -1271,7 +1273,6 @@
 				8F00FC54012CD6EC54E765F47391DF8A /* Support Files */,
 				40092B72B740650FB942135BF493FAB7 /* Swift */,
 			);
-			name = OHHTTPStubs;
 			path = OHHTTPStubs;
 			sourceTree = "<group>";
 		};
@@ -2077,6 +2078,7 @@
 				B61D31C35721A83683DECCE3408FB7C4 /* Request+Authentication.swift in Sources */,
 				C4E4F1A54743035D648945CCCD1EB3C5 /* Request+Cache.swift in Sources */,
 				952AA285FC291C03DFC1F82FE3DEC7F7 /* Request+Category.swift in Sources */,
+				0CEA219421824E330040ED9F /* Album.swift in Sources */,
 				7DF760A01B17669878EB0CA5D53F4D5B /* Request+Channel.swift in Sources */,
 				188A7863A53B9F4F4450EAAE9CB2D232 /* Request+Comment.swift in Sources */,
 				397ADBCA8EC16BADB147F7E33D108F95 /* Request+Configs.swift in Sources */,
@@ -2198,6 +2200,7 @@
 				9A1155EECD3EAD4C48883D9E7DF50836 /* Request+Authentication.swift in Sources */,
 				3A3B86F99466DB564D99B82A346D3329 /* Request+Cache.swift in Sources */,
 				44324EE97F77A0470820DEC9BFC49C33 /* Request+Category.swift in Sources */,
+				0CEA219321824E330040ED9F /* Album.swift in Sources */,
 				566AAD3D71052BFBA08BFC3E1711DBC5 /* Request+Channel.swift in Sources */,
 				221249BE12772A686BDC4030F9C0FE35 /* Request+Comment.swift in Sources */,
 				34F248C11324113507CA7F51469CC077 /* Request+Configs.swift in Sources */,

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -39,7 +39,6 @@ import Foundation
             static let Logo = "custom_logo"
             static let CreatedTime = "created_time"
             static let ModifiedTime = "modified_time"
-            static let Pictures = "pictures"
             static let User = "user"
             static let Privacy = "privacy"
             static let Embed = "embed"
@@ -93,8 +92,6 @@ import Foundation
         case Constant.Key.Privacy:
             return Constant.Class.Privacy
         case Constant.Key.Logo:
-            return Constant.Class.PictureCollection
-        case Constant.Key.Pictures:
             return Constant.Class.PictureCollection
         case Constant.Key.Embed:
             return Constant.Class.Embed

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -48,8 +48,8 @@ import Foundation
             static let Name = "albumName"
             static let Description = "albumDescription"
             static let Logo = "albumLogo"
-            static let CreatedTime = "createdTime"
-            static let ModifiedTime = "modifiedTime"
+            static let CreatedTime = "createdTimeString"
+            static let ModifiedTime = "modifiedTimeString"
         }
         
         struct Class {
@@ -64,8 +64,10 @@ import Foundation
     @objc public var albumName: String?
     @objc public var albumDescription: String?
     @objc public var albumLogo: VIMPictureCollection?
-    @objc public var createdTime: NSDate?
-    @objc public var modifiedTime: NSDate?
+    @objc public var createdTimeString: String?
+    @objc public var createdTime: Date?
+    @objc public var modifiedTimeString: String?
+    @objc public var modifiedTime: Date?
     @objc public var privacy: VIMPrivacy?
     @objc public var duration: NSNumber?
     @objc public var uri: String?
@@ -74,6 +76,7 @@ import Foundation
     @objc public var pictures: VIMPictureCollection?
     @objc public var user: VIMUser?
     @objc public var theme: String?
+    
     
     public override func getObjectMapping() -> Any! {
         return [
@@ -98,5 +101,21 @@ import Foundation
         default:
             return nil
         }
+    }
+    
+    public override func didFinishMapping() {
+        self.createdTime = self.formatDate(from: self.createdTimeString)
+        self.modifiedTime = self.formatDate(from: self.modifiedTimeString)
+    }
+    
+    // MARK: - Private
+    
+    private func formatDate(from dateString: String?) -> Date? {
+        guard let dateString = dateString,
+            let date = VIMModelObject.dateFormatter()?.date(from: dateString) else {
+                return nil
+        }
+        
+        return date
     }
 }

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -1,0 +1,8 @@
+//
+//  Album.swift
+//  Pods
+//
+//  Created by Hawkins, Jason on 10/25/18.
+//
+
+import Foundation

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -77,7 +77,6 @@ import Foundation
     @objc public var user: VIMUser?
     @objc public var theme: String?
     
-    
     public override func getObjectMapping() -> Any! {
         return [
             Constant.Key.Name : Constant.Value.Name,

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -1,8 +1,105 @@
 //
 //  Album.swift
-//  Pods
+//  VimeoNetworking
 //
-//  Created by Hawkins, Jason on 10/25/18.
+//  Created on 10/25/2018.
+//  Copyright (c) Vimeo (https://vimeo.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation
+
+@objc public class EmbedShare: VIMObjectMapper {
+    @objc var html: String?
+}
+
+@objc public class Album: VIMModelObject {
+    
+    private struct Constant {
+        struct Key {
+            static let Name = "name"
+            static let Description = "description"
+            static let Logo = "custom_logo"
+            static let CreatedTime = "created_time"
+            static let ModifiedTime = "modified_time"
+            static let Pictures = "pictures"
+            static let User = "user"
+            static let Privacy = "privacy"
+            static let Embed = "embed"
+        }
+        
+        struct Value {
+            static let Name = "albumName"
+            static let Description = "albumDescription"
+            static let Logo = "albumLogo"
+            static let CreatedTime = "createdTime"
+            static let ModifiedTime = "modifiedTime"
+        }
+        
+        struct Class {
+            static let Picture = VIMPicture.self
+            static let PictureCollection = VIMPictureCollection.self
+            static let Privacy = VIMPrivacy.self
+            static let User = VIMUser.self
+            static let Embed = EmbedShare.self
+        }
+    }
+    
+    @objc public var albumName: String?
+    @objc public var albumDescription: String?
+    @objc public var albumLogo: VIMPictureCollection?
+    @objc public var createdTime: NSDate?
+    @objc public var modifiedTime: NSDate?
+    @objc public var privacy: VIMPrivacy?
+    @objc public var duration: NSNumber?
+    @objc public var uri: String?
+    @objc public var link: String?
+    @objc public var embed: EmbedShare?
+    @objc public var pictures: VIMPictureCollection?
+    @objc public var user: VIMUser?
+    @objc public var theme: String?
+    
+    public override func getObjectMapping() -> Any! {
+        return [
+            Constant.Key.Name : Constant.Value.Name,
+            Constant.Key.Description : Constant.Value.Description,
+            Constant.Key.Logo : Constant.Value.Logo,
+            Constant.Key.CreatedTime : Constant.Value.CreatedTime,
+            Constant.Key.ModifiedTime : Constant.Value.ModifiedTime
+        ]
+    }
+    
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
+        switch key {
+        case Constant.Key.User:
+            return Constant.Class.User
+        case Constant.Key.Privacy:
+            return Constant.Class.Privacy
+        case Constant.Key.Logo:
+            return Constant.Class.PictureCollection
+        case Constant.Key.Pictures:
+            return Constant.Class.PictureCollection
+        case Constant.Key.Embed:
+            return Constant.Class.Embed
+        default:
+            return nil
+        }
+    }
+}

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-@objc public class EmbedShare: VIMObjectMapper {
+@objc public class AlbumEmbed: VIMObjectMapper {
     @objc var html: String?
 }
 
@@ -57,7 +57,7 @@ import Foundation
             static let PictureCollection = VIMPictureCollection.self
             static let Privacy = VIMPrivacy.self
             static let User = VIMUser.self
-            static let Embed = EmbedShare.self
+            static let Embed = AlbumEmbed.self
         }
     }
     
@@ -72,7 +72,7 @@ import Foundation
     @objc public var duration: NSNumber?
     @objc public var uri: String?
     @objc public var link: String?
-    @objc public var embed: EmbedShare?
+    @objc public var embed: AlbumEmbed?
     @objc public var pictures: VIMPictureCollection?
     @objc public var user: VIMUser?
     @objc public var theme: String?

--- a/VimeoNetworking/Sources/VimeoResponseSerializer.swift
+++ b/VimeoNetworking/Sources/VimeoResponseSerializer.swift
@@ -216,7 +216,8 @@ final public class VimeoResponseSerializer: AFJSONResponseSerializer
             "application/vnd.vimeo.policydocument+json",
             "application/vnd.vimeo.notification+json",
             "application/vnd.vimeo.notification.subscriptions+json",
-            "application/vnd.vimeo.product+json"]
+            "application/vnd.vimeo.product+json",
+            "application/vnd.vimeo.album+json"]
         )
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -1,0 +1,79 @@
+//
+//  AlbumTests.swift
+//  VimeoNetworkingExample-iOS
+//
+//  Created by Hawkins, Jason on 10/26/18.
+//  Copyright © 2018 Vimeo. All rights reserved.
+//
+
+import XCTest
+@testable import VimeoNetworking
+
+class AlbumTests: XCTestCase {
+    private var testAlbum: Album?
+    private var albumJSONDictionary: VimeoClient.ResponseDictionary?
+
+    override func setUp() {
+        guard let albumJSONDictionary = ResponseUtilities.loadResponse(from: "album-response.json") else {
+            return
+        }
+        
+        self.albumJSONDictionary = albumJSONDictionary
+        self.testAlbum = try! VIMObjectMapper.mapObject(responseDictionary: albumJSONDictionary) as Album
+    }
+
+    override func tearDown() {
+        testAlbum = nil
+        albumJSONDictionary = nil
+    }
+
+    func testAlbumObjectParsesCorrectly() {
+        guard let album = self.testAlbum else {
+            assertionFailure("Failed to unwrap the test album.")
+            return
+        }
+        
+        XCTAssertEqual(album.albumName, "2018")
+        XCTAssertEqual(album.albumDescription, "Favorites from 2018.")
+        XCTAssertEqual(album.albumLogo?.uri, "/users/267176/albums/5451829/logos/18363")
+        XCTAssertNotNil(album.createdTime)
+        XCTAssertNotNil(album.modifiedTime)
+        XCTAssertEqual(album.privacy?.view, "anybody")
+        XCTAssertEqual(album.duration, 1003)
+        XCTAssertEqual(album.uri, "/users/267176/albums/5451829")
+        XCTAssertEqual(album.link, "https://vimeo.com/album/5451829")
+        XCTAssertNotNil(album.embed?.html)
+        XCTAssertNotNil(album.pictures)
+        XCTAssertNotNil(album.user)
+        XCTAssertEqual(album.theme, "dark")
+    }
+    
+    func testAlbumLogoOjbectParsesCorrectly() {
+        guard let album = self.testAlbum else {
+            assertionFailure("Failed to unwrap the test album.")
+            return
+        }
+        
+        guard let logo = album.albumLogo?.pictures?.first as? VIMPicture else {
+            assertionFailure("Failed to unwrap the test album's logo.")
+            return
+        }
+        
+        XCTAssertEqual(logo.width, 200)
+        XCTAssertEqual(logo.height, 200)
+        XCTAssertEqual(logo.link, "https://i.vimeocdn.com/album_custom_logo/18363_200x200")
+    }
+    
+    func testAlbumEmbedObjectParsesCorrectly() {
+        guard let album = self.testAlbum else {
+            assertionFailure("Failed to unwrap the test album.")
+            return
+        }
+        
+        XCTAssertNotNil(album.embed)
+        XCTAssertEqual(album.embed?.html,
+"""
+<div style='padding:56.25% 0 0 0;position:relative;'><iframe src='https://vimeo.com/album/5451829/embed' allowfullscreen frameborder='0' style='position:absolute;top:0;left:0;width:100%;height:100%;'></iframe></div>
+""")
+    }
+}

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -27,7 +27,7 @@ class AlbumTests: XCTestCase {
         self.albumJSONDictionary = nil
     }
 
-    func testAlbumObjectParsesCorrectly() {
+    func test_AlbumObject_ParsesCorrectly() {
         guard let album = self.testAlbum else {
             assertionFailure("Failed to unwrap the test album.")
             return
@@ -48,7 +48,7 @@ class AlbumTests: XCTestCase {
         XCTAssertEqual(album.theme, "dark")
     }
     
-    func testAlbumLogoOjbectParsesCorrectly() {
+    func test_AlbumLogoOjbect_ParsesCorrectly() {
         guard let album = self.testAlbum else {
             assertionFailure("Failed to unwrap the test album.")
             return
@@ -64,7 +64,7 @@ class AlbumTests: XCTestCase {
         XCTAssertEqual(logo.link, "https://i.vimeocdn.com/album_custom_logo/18363_200x200")
     }
     
-    func testAlbumEmbedObjectParsesCorrectly() {
+    func test_AlbumEmbedObject_ParsesCorrectly() {
         guard let album = self.testAlbum else {
             assertionFailure("Failed to unwrap the test album.")
             return

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -82,8 +82,8 @@ class AlbumTests: XCTestCase {
         
         XCTAssertNotNil(album.embed)
         XCTAssertEqual(album.embed?.html,
-"""
-<div style='padding:56.25% 0 0 0;position:relative;'><iframe src='https://vimeo.com/album/5451829/embed' allowfullscreen frameborder='0' style='position:absolute;top:0;left:0;width:100%;height:100%;'></iframe></div>
-""")
+            """
+            <div style='padding:56.25% 0 0 0;position:relative;'><iframe src='https://vimeo.com/album/5451829/embed' allowfullscreen frameborder='0' style='position:absolute;top:0;left:0;width:100%;height:100%;'></iframe></div>
+            """)
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -23,8 +23,8 @@ class AlbumTests: XCTestCase {
     }
 
     override func tearDown() {
-        testAlbum = nil
-        albumJSONDictionary = nil
+        self.testAlbum = nil
+        self.albumJSONDictionary = nil
     }
 
     func testAlbumObjectParsesCorrectly() {

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -36,8 +36,6 @@ class AlbumTests: XCTestCase {
         XCTAssertEqual(album.albumName, "2018")
         XCTAssertEqual(album.albumDescription, "Favorites from 2018.")
         XCTAssertEqual(album.albumLogo?.uri, "/users/267176/albums/5451829/logos/18363")
-        XCTAssertNotNil(album.createdTime)
-        XCTAssertNotNil(album.modifiedTime)
         XCTAssertEqual(album.privacy?.view, "anybody")
         XCTAssertEqual(album.duration, 1003)
         XCTAssertEqual(album.uri, "/users/267176/albums/5451829")
@@ -46,6 +44,18 @@ class AlbumTests: XCTestCase {
         XCTAssertNotNil(album.pictures)
         XCTAssertNotNil(album.user)
         XCTAssertEqual(album.theme, "dark")
+    }
+    
+    func test_AlbumDates_ParseAndFormatCorrectly() {
+        guard let album = self.testAlbum else {
+            assertionFailure("Failed to unwrap the test album.")
+            return
+        }
+        
+        XCTAssertNotNil(album.createdTimeString)
+        XCTAssertEqual(album.createdTime!.timeIntervalSince1970, TimeInterval(1538405413))
+        XCTAssertNotNil(album.modifiedTimeString)
+        XCTAssertEqual(album.modifiedTime!.timeIntervalSince1970, TimeInterval(1540585280))
     }
     
     func test_AlbumLogoOjbect_ParsesCorrectly() {

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CDBEF61CEB9C100093DDF4 /* ModelObjectValidationTests.swift */; };
 		01FD38A71CC9289200326408 /* VimeoNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01FD38A61CC9289200326408 /* VimeoNetworking.framework */; };
 		0C7364351DFF4871000C3585 /* NSErrorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7364331DFF4871000C3585 /* NSErrorExtensionTests.swift */; };
+		0CEA219721838BBD0040ED9F /* album-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CEA219521838BBD0040ED9F /* album-response.json */; };
+		0CEA219921838BEC0040ED9F /* AlbumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA219821838BEC0040ED9F /* AlbumTests.swift */; };
+		0CEA219A21838BEC0040ED9F /* AlbumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA219821838BEC0040ED9F /* AlbumTests.swift */; };
+		0CEA219B21838BF00040ED9F /* album-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CEA219521838BBD0040ED9F /* album-response.json */; };
 		0CF362E21F62E90400B22589 /* VIMVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF362E11F62E90400B22589 /* VIMVideoTests.swift */; };
 		234B183FA295853A0F735D3F /* Pods_VimeoNetworkingExample_tvOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2F770DEBD4E467F7F728F84 /* Pods_VimeoNetworkingExample_tvOSTests.framework */; };
 		3C0DCFBB1ECA775700960774 /* Request+CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0DCFBA1ECA775700960774 /* Request+CategoryTests.swift */; };
@@ -119,6 +123,8 @@
 		097D1643FEAE7486DB0CB7D6 /* Pods-VimeoNetworkingExample-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOSTests/Pods-VimeoNetworkingExample-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		0C7364331DFF4871000C3585 /* NSErrorExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSErrorExtensionTests.swift; sourceTree = "<group>"; };
 		0CAAF25B1E0201F1003C5CBA /* VimeoNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VimeoNetworking.framework; path = "../../../Library/Developer/Xcode/DerivedData/VimeoNetworking-eybwmmbikpeubpbxrlpwzwxtbzfr/Build/Products/Debug-iphonesimulator/VimeoNetworking/VimeoNetworking.framework"; sourceTree = "<group>"; };
+		0CEA219521838BBD0040ED9F /* album-response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "album-response.json"; sourceTree = "<group>"; };
+		0CEA219821838BEC0040ED9F /* AlbumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AlbumTests.swift; path = VimeoNetworkingCommonTests/AlbumTests.swift; sourceTree = "<group>"; };
 		0CF362E11F62E90400B22589 /* VIMVideoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VIMVideoTests.swift; path = VimeoNetworkingCommonTests/VIMVideoTests.swift; sourceTree = "<group>"; };
 		128A8B3EE78B0F2F924E5E24 /* Pods-VimeoNetworkingExample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworkingExample-iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworkingExample-iOS/Pods-VimeoNetworkingExample-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		1CFBEA4F42A23D881BD1C3E2 /* Pods-VimeoNetworking tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VimeoNetworking tvOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-VimeoNetworking tvOSTests/Pods-VimeoNetworking tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -316,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				3C0DCFCA1ECB25C500960774 /* Response JSON */,
+				0CEA219821838BEC0040ED9F /* AlbumTests.swift */,
 				3C0DCFC41ECA825600960774 /* VIMCategory+Tests.swift */,
 				3C1F8E041F14397A00A062D3 /* VIMQuantityQuota+Tests.swift */,
 				3C1F8E071F151B8E00A062D3 /* VIMUploadQuota+Tests.swift */,
@@ -327,6 +334,7 @@
 		3C0DCFCA1ECB25C500960774 /* Response JSON */ = {
 			isa = PBXGroup;
 			children = (
+				0CEA219521838BBD0040ED9F /* album-response.json */,
 				3C1F8DFE1EFC304000A062D3 /* cinema-success-response.json */,
 				3C0DCFCB1ECB25FC00960774 /* categories-animation-response.json */,
 			);
@@ -602,6 +610,7 @@
 				8EDE2D741FDF43CD00143E95 /* user_live_pro.json in Resources */,
 				8EDE2D861FE05B3600143E95 /* user_support.json in Resources */,
 				3C1F8DFF1EFC304000A062D3 /* cinema-success-response.json in Resources */,
+				0CEA219721838BBD0040ED9F /* album-response.json in Resources */,
 				8E3402401F673821001544C4 /* user_live.json in Resources */,
 				8EDE2D7C1FE0210E00143E95 /* user_pro.json in Resources */,
 				BE2D774420FE2FF700B27C24 /* user_producer.json in Resources */,
@@ -632,6 +641,7 @@
 				8E5997042058280900A4A83C /* user_live_premium.json in Resources */,
 				BE2D774720FE2FFC00B27C24 /* user_pro_unlimited.json in Resources */,
 				3C0DCFCD1ECB25FC00960774 /* categories-animation-response.json in Resources */,
+				0CEA219B21838BF00040ED9F /* album-response.json in Resources */,
 				3C1F8E001EFC304000A062D3 /* cinema-success-response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -842,6 +852,7 @@
 				3C0DCFBE1ECA790200960774 /* RequestTestUtilities.swift in Sources */,
 				3C0DCFBB1ECA775700960774 /* Request+CategoryTests.swift in Sources */,
 				8E49138D1FA786DA0061723A /* MockConstants.swift in Sources */,
+				0CEA219921838BEC0040ED9F /* AlbumTests.swift in Sources */,
 				0CF362E21F62E90400B22589 /* VIMVideoTests.swift in Sources */,
 				3CE06FA31ED5B49A007A1AFE /* VimeoSessionManagerTests.swift in Sources */,
 				01CDBEF71CEB9C100093DDF4 /* ModelObjectValidationTests.swift in Sources */,
@@ -879,6 +890,7 @@
 				3C1F8E031EFC311D00A062D3 /* Request+ProgrammedContent.swift in Sources */,
 				3C0DCFBF1ECA790200960774 /* RequestTestUtilities.swift in Sources */,
 				3CAE6FC71EC671540016EF6C /* RequestTests.swift in Sources */,
+				0CEA219A21838BEC0040ED9F /* AlbumTests.swift in Sources */,
 				3C0DCFC91ECB22EC00960774 /* ObjectMappingTestUtilities.swift in Sources */,
 				3C1F8E061F14397A00A062D3 /* VIMQuantityQuota+Tests.swift in Sources */,
 				3C1F8E091F151B8E00A062D3 /* VIMUploadQuota+Tests.swift in Sources */,

--- a/VimeoNetworkingExample-iOS/album-response.json
+++ b/VimeoNetworkingExample-iOS/album-response.json
@@ -1,0 +1,487 @@
+{
+    "uri": "/users/267176/albums/5451829",
+    "name": "2018",
+    "description": "Favorites from 2018.",
+    "link": "https://vimeo.com/album/5451829",
+    "duration": 1003,
+    "created_time": "2018-10-01T14:50:13+00:00",
+    "modified_time": "2018-10-26T20:21:20+00:00",
+    "user": {
+        "uri": "/users/267176",
+        "name": "Jason Hawkins",
+        "link": "https://vimeo.com/jasonhawkins",
+        "location": "Brooklyn, NY",
+        "bio": "I'm a videographer turned iOS developer. But I still like to make videos sometimes.",
+        "created_time": "2007-10-01T04:34:40+00:00",
+        "membership": {
+            "type": "live_pro",
+            "display": "PRO Live",
+            "badge": {
+                "type": "staff",
+                "text": "Staff",
+                "alt_text": "Learn more about Vimeo",
+                "url": "/about"
+            },
+            "subscription": {
+                "renewal": {
+                    "display_date": "2029-10-31"
+                }
+            }
+        },
+        "pictures": {
+            "uri": "/users/267176/pictures/12658746",
+            "active": true,
+            "type": "custom",
+            "sizes": [
+                {
+                    "width": 30,
+                    "height": 30,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_30x30"
+                },
+                {
+                    "width": 75,
+                    "height": 75,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_75x75"
+                },
+                {
+                    "width": 100,
+                    "height": 100,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_100x100"
+                },
+                {
+                    "width": 300,
+                    "height": 300,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_300x300"
+                },
+                {
+                    "width": 72,
+                    "height": 72,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_72x72"
+                },
+                {
+                    "width": 144,
+                    "height": 144,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_144x144"
+                },
+                {
+                    "width": 216,
+                    "height": 216,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_216x216"
+                },
+                {
+                    "width": 288,
+                    "height": 288,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_288x288"
+                },
+                {
+                    "width": 360,
+                    "height": 360,
+                    "link": "https://i.vimeocdn.com/portrait/12658746_360x360"
+                }
+            ],
+            "resource_key": "af93e62379d1a18cbb22851783706055135e7626"
+        },
+        "websites": [],
+        "metadata": {
+            "connections": {
+                "albums": {
+                    "uri": "/users/267176/albums",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 11
+                },
+                "appearances": {
+                    "uri": "/users/267176/appearances",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 43
+                },
+                "categories": {
+                    "uri": "/users/267176/categories",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 4
+                },
+                "channels": {
+                    "uri": "/users/267176/channels",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 10
+                },
+                "feed": {
+                    "uri": "/users/267176/feed",
+                    "options": [
+                        "GET"
+                    ]
+                },
+                "followers": {
+                    "uri": "/users/267176/followers",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 348
+                },
+                "following": {
+                    "uri": "/users/267176/following",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 82
+                },
+                "groups": {
+                    "uri": "/users/267176/groups",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 1
+                },
+                "likes": {
+                    "uri": "/users/267176/likes",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 711
+                },
+                "moderated_channels": {
+                    "uri": "/users/267176/channels?filter=moderated",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 2
+                },
+                "portfolios": {
+                    "uri": "/users/267176/portfolios",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 0
+                },
+                "videos": {
+                    "uri": "/users/267176/videos",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 75
+                },
+                "watchlater": {
+                    "uri": "/users/267176/watchlater",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 246
+                },
+                "shared": {
+                    "uri": "/users/267176/shared/videos",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 67
+                },
+                "pictures": {
+                    "uri": "/users/267176/pictures",
+                    "options": [
+                        "GET",
+                        "POST"
+                    ],
+                    "total": 6
+                },
+                "violations": {
+                    "uri": "/users/267176/violations",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 0
+                },
+                "recommended_users": {
+                    "uri": "/me/recommendations/users",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 30
+                },
+                "recommended_channels": {
+                    "uri": "/me/recommendations/channels",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 27
+                },
+                "watched_videos": {
+                    "uri": "/me/watched/videos",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 1531
+                },
+                "projects": {
+                    "uri": "/me/projects",
+                    "options": [
+                        "GET",
+                        "POST"
+                    ],
+                    "total": 0
+                },
+                "notifications": {
+                    "uri": "/me/notifications",
+                    "total_new": 25,
+                    "new_total": 25,
+                    "unread_total": 25,
+                    "total": 31,
+                    "type_count": {
+                        "comment": 0,
+                        "credit": 0,
+                        "like": 0,
+                        "followed_user_video_available": 23,
+                        "share": 1,
+                        "video_available": 1,
+                        "mention": 0,
+                        "reply": 0,
+                        "storage_warning": 0,
+                        "follow": 0,
+                        "account_expiration_warning": 0,
+                        "vod_purchase": 0,
+                        "vod_preorder_available": 0,
+                        "vod_rental_expiration_warning": 0
+                    },
+                    "type_unseen_count": {
+                        "comment": 0,
+                        "credit": 0,
+                        "like": 0,
+                        "followed_user_video_available": 23,
+                        "share": 1,
+                        "video_available": 1,
+                        "mention": 0,
+                        "reply": 0,
+                        "storage_warning": 0,
+                        "follow": 0,
+                        "account_expiration_warning": 0,
+                        "vod_purchase": 0,
+                        "vod_preorder_available": 0,
+                        "vod_rental_expiration_warning": 0
+                    }
+                },
+                "block": {
+                    "uri": "/me/block",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 0
+                }
+            }
+        },
+        "preferences": {
+            "videos": {
+                "privacy": {
+                    "view": "anybody",
+                    "comments": "anybody",
+                    "embed": "public",
+                    "download": true,
+                    "add": true
+                }
+            }
+        },
+        "content_filter": [
+            "language",
+            "drugs",
+            "violence",
+            "nudity",
+            "safe",
+            "unrated"
+        ],
+        "upload_quota": {
+            "space": {
+                "free": 3295927769826,
+                "max": 3298534883328,
+                "used": 2607113502,
+                "showing": "lifetime"
+            },
+            "periodic": {
+                "free": null,
+                "max": null,
+                "used": null,
+                "reset_date": null
+            },
+            "lifetime": {
+                "free": 3295927769826,
+                "max": 3298534883328,
+                "used": 2607113502
+            }
+        },
+        "emails": [
+            {
+                "email": "hellojason@me.com"
+            }
+        ],
+        "live_quota": {
+            "status": "available",
+            "time": {
+                "monthly_remaining": 36000,
+                "monthly_maximum": 36000,
+                "event_maximum": 36000
+            },
+            "streams": {
+                "remaining": 1,
+                "maximum": 1
+            }
+        },
+        "resource_key": "d225123c73c977976158c1374453a2683b5fc28c"
+    },
+    "privacy": {
+        "view": "anybody"
+    },
+    "pictures": [
+        {
+            "uri": "/videos/248249215/pictures/673727920",
+            "active": true,
+            "type": "custom",
+            "sizes": [
+                {
+                    "width": 100,
+                    "height": 75,
+                    "link": "https://i.vimeocdn.com/video/673727920_100x75.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_100x75.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 200,
+                    "height": 150,
+                    "link": "https://i.vimeocdn.com/video/673727920_200x150.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_200x150.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 295,
+                    "height": 166,
+                    "link": "https://i.vimeocdn.com/video/673727920_295x166.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_295x166.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 640,
+                    "height": 360,
+                    "link": "https://i.vimeocdn.com/video/673727920_640x360.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_640x360.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 960,
+                    "height": 540,
+                    "link": "https://i.vimeocdn.com/video/673727920_960x540.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_960x540.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 1280,
+                    "height": 720,
+                    "link": "https://i.vimeocdn.com/video/673727920_1280x720.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_1280x720.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 1920,
+                    "height": 1080,
+                    "link": "https://i.vimeocdn.com/video/673727920_1920x1080.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F673727920_1920x1080.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                }
+            ],
+            "resource_key": "015113768afd3c937980dd5773ff0e036bea1286"
+        },
+        {
+            "uri": "/videos/190063150/pictures/624750928",
+            "active": true,
+            "type": "custom",
+            "sizes": [
+                {
+                    "width": 100,
+                    "height": 75,
+                    "link": "https://i.vimeocdn.com/video/624750928_100x75.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_100x75.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 200,
+                    "height": 150,
+                    "link": "https://i.vimeocdn.com/video/624750928_200x150.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_200x150.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 295,
+                    "height": 166,
+                    "link": "https://i.vimeocdn.com/video/624750928_295x166.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_295x166.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 640,
+                    "height": 360,
+                    "link": "https://i.vimeocdn.com/video/624750928_640x360.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_640x360.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 960,
+                    "height": 540,
+                    "link": "https://i.vimeocdn.com/video/624750928_960x540.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_960x540.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 1280,
+                    "height": 720,
+                    "link": "https://i.vimeocdn.com/video/624750928_1280x720.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_1280x720.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                },
+                {
+                    "width": 1920,
+                    "height": 1080,
+                    "link": "https://i.vimeocdn.com/video/624750928_1920x1080.jpg?r=pad",
+                    "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F624750928_1920x1080.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                }
+            ],
+            "resource_key": "d7d28d73101b70a1b640f004837d0f229af82aac"
+        }
+    ],
+    "sort": "arranged",
+    "layout": "grid",
+    "theme": "dark",
+    "brand_color": "00adef",
+    "custom_logo": {
+        "uri": "/users/267176/albums/5451829/logos/18363",
+        "active": true,
+        "type": "custom",
+        "sizes": [
+            {
+                "width": 200,
+                "height": 200,
+                "link": "https://i.vimeocdn.com/album_custom_logo/18363_200x200"
+            }
+        ],
+        "resource_key": "8a49a62dcbf914a3b6a45fd986cf062f49fe94b5"
+    },
+    "review_mode": false,
+    "hide_nav": true,
+    "metadata": {
+        "connections": {
+            "videos": {
+                "uri": "/albums/5451829/videos",
+                "options": [
+                    "GET"
+                ],
+                "total": 2
+            }
+        },
+        "interactions": {
+            "add_logos": {
+                "uri": "/users/267176/albums/5451829/logos",
+                "options": [
+                    "GET",
+                    "POST"
+                ]
+            },
+            "add_videos": {
+                "uri": "/users/267176/albums/5451829/videos",
+                "options": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+    },
+    "embed": {
+        "html": "<div style='padding:56.25% 0 0 0;position:relative;'><iframe src='https://vimeo.com/album/5451829/embed' allowfullscreen frameborder='0' style='position:absolute;top:0;left:0;width:100%;height:100%;'></iframe></div>"
+    }
+}


### PR DESCRIPTION
## Adds support for Albums

### Ticket
[VIM-6642](https://vimean.atlassian.net/browse/VIM-6642)

### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Add the Album model object to VimeoNetworking.

### Implementation Summary
- Added **Album.swift** model object.
- Added **album-response.json** fixture for testing.
- Added unit tests covering parsing for the Album object, including date formatting, album logo unwrapping, and embed HTML verification.

### How to Test
- Build & run unit tests.