### PR TITLE
AF-314: Injet `KeyPath` in `mapObject` method

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMObjectMapper.h
+++ b/VimeoNetworking/Sources/Models/VIMObjectMapper.h
@@ -33,5 +33,6 @@
 - (void)addMappingClass:(Class)mappingClass forKeypath:(NSString *)keypath;
 
 - (id)applyMappingToJSON:(id)JSON;
+- (id)applyMappingToJSON:(id)JSON forKeypath:(NSString *)keyPath;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMObjectMapper.m
+++ b/VimeoNetworking/Sources/Models/VIMObjectMapper.m
@@ -341,4 +341,9 @@
     return [self _createObjectsFromJSON:JSON keypath:@"" mappingClass:nil];
 }
 
+- (id)applyMappingToJSON:(id)JSON forKeypath:(NSString *)keyPath;
+{
+    return [self _createObjectsFromJSON:JSON keypath:keyPath mappingClass:nil];
+}
+
 @end

--- a/VimeoNetworking/Sources/VIMObjectMapper+Generic.swift
+++ b/VimeoNetworking/Sources/VIMObjectMapper+Generic.swift
@@ -24,56 +24,80 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-extension VIMObjectMapper {
+extension VIMObjectMapper
+{
     static var ErrorDomain: String { return "ObjectMapperErrorDomain" }
-    
+
     /**
      Deserializes a response dictionary into a model object
-     
+
      - parameter ModelType:          The type of the model object to map `responseDictionary` onto
      - parameter responseDictionary: The JSON dictionary response to deserialize
      - parameter modelKeyPath:       optionally, a nested JSON key path at which to originate parsing
-     
+
      - throws: An NSError if parsing fails or the mapping class is invalid
-     
+
      - returns: A deserialized object of type `ModelType`
      */
-    static func mapObject<ModelType: MappableResponse>(responseDictionary: VimeoClient.ResponseDictionary, modelKeyPath: String? = nil) throws -> ModelType {
-        guard let mappingClass = ModelType.mappingClass
-        else {
+    static func mapObject<ModelType: MappableResponse>(responseDictionary: VimeoClient.ResponseDictionary, modelKeyPath: String? = nil) throws -> ModelType
+    {
+        guard let mappingClass = ModelType.mappingClass else
+        {
             let description = "no mapping class found"
-            
+
             assertionFailure(description)
-            
+
             let error = NSError(domain: self.ErrorDomain, code: LocalErrorCode.noMappingClass.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
-            
+
             throw error
         }
-        
+
+        let modelKeyPath = modelKeyPath ?? ModelType.modelKeyPath ?? ""
+
         let objectMapper = VIMObjectMapper()
-        let modelKeyPath = modelKeyPath ?? ModelType.modelKeyPath
-        objectMapper.addMappingClass(mappingClass, forKeypath: modelKeyPath ?? "")
-        var mappedObject = objectMapper.applyMapping(toJSON: responseDictionary)
-        
-        if let modelKeyPath = modelKeyPath {
-            mappedObject = (mappedObject as? VimeoClient.ResponseDictionary)?[modelKeyPath]
-        }
-        
-        guard let modelObject = mappedObject as? ModelType
-        else {
+        objectMapper.addMappingClass(mappingClass, forKeypath: modelKeyPath)
+
+        let mappedObject = objectMapper.applyMapping(toJSON: responseDictionary, forKeypath: modelKeyPath)
+
+        var modelObjectOrNil: ModelType? = (mappedObject as? ModelType)
+        modelObjectOrNil = modelObjectOrNil ?? findMappedObject(
+            in: (mappedObject as? VimeoClient.ResponseDictionary),
+            using: modelKeyPath.components(separatedBy: ".")
+        )
+
+        guard let modelObject: ModelType = modelObjectOrNil else
+        {
             let description = "couldn't map to ModelType"
-            
+
             assertionFailure(description)
-            
+
             let error = NSError(domain: self.ErrorDomain, code: LocalErrorCode.mappingFailed.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
-            
+
             throw error
         }
-        
+
         try modelObject.validateModel()
-        
+
         return modelObject
+    }
+
+    private static func findMappedObject<MappedObject: MappableResponse>(in responseDictionary: VimeoClient.ResponseDictionary?, using keyPaths: [String]) -> MappedObject?
+    {
+        var keyPaths = keyPaths
+
+        guard keyPaths.isEmpty == false else
+        {
+            return nil
+        }
+
+        let keyPath = keyPaths.removeFirst()
+        let nested: Any? = responseDictionary?[keyPath]
+
+        guard let nestedResponseDictionary = nested as? VimeoClient.ResponseDictionary else
+        {
+            return nested as? MappedObject
+        }
+
+        return findMappedObject(in: nestedResponseDictionary, using: keyPaths)
     }
 }


### PR DESCRIPTION
#### Ticket

[AF-314](https://vimean.atlassian.net/browse/AF-314)

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

```
New findMappedObject(in:) function that recursively goes through the `keyPath` till desired object is returned. Current implementation only drilled down 1 layer
```

#### Implementation Summary

Cherry picking what macOS have done in order to provide the `keyPath` in the apply mapping method.

#### Reviewer Tips
#### How to Test

Make sure `applyMapping:toJSON` still works