### PR TITLE
AF-322: Adds membership information to the VIMUser object

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -109,6 +109,14 @@
 		3B75A6E13DA258E3F9D522C60B18F2A7 /* VimeoSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CABD0774956CB625890320668322DD /* VimeoSessionManager.swift */; };
 		3B7F48BDC21A1ED8C51923CE1CDBE21A /* Request+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E974EB56249EEA98A534420BF8D057 /* Request+Picture.swift */; };
 		3C2DA9917ABED299E812743665B6A00D /* VIMUserBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D4A5AEE1C8D6A701F27E21309134A3F /* VIMUserBadge.m */; };
+		3CBB8E1821B07AE700092D24 /* UserMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1721B07AE700092D24 /* UserMembership.swift */; };
+		3CBB8E1921B07AE700092D24 /* UserMembership.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1721B07AE700092D24 /* UserMembership.swift */; };
+		3CBB8E1B21B1A1D500092D24 /* UserSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1A21B1A1D500092D24 /* UserSubscription.swift */; };
+		3CBB8E1C21B1A1D500092D24 /* UserSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1A21B1A1D500092D24 /* UserSubscription.swift */; };
+		3CBB8E1E21B1A48300092D24 /* UserSubscriptionRenewal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1D21B1A48300092D24 /* UserSubscriptionRenewal.swift */; };
+		3CBB8E1F21B1A48300092D24 /* UserSubscriptionRenewal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E1D21B1A48300092D24 /* UserSubscriptionRenewal.swift */; };
+		3CBB8E2121B1A4A300092D24 /* UserSubscriptionTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E2021B1A4A300092D24 /* UserSubscriptionTrial.swift */; };
+		3CBB8E2221B1A4A300092D24 /* UserSubscriptionTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBB8E2021B1A4A300092D24 /* UserSubscriptionTrial.swift */; };
 		3D204D8A2679BC3FFC5CD08E8421224A /* VIMVODConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 19E6D67D6A83F8E3901EA34C06D5511B /* VIMVODConnection.m */; };
 		3DDB062A7D454DD3F4F3B2659DE0573A /* VIMTag.h in Headers */ = {isa = PBXBuildFile; fileRef = C850C5794E8ED72A44DD3D70929B5D7C /* VIMTag.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E193AD16FFC6FAF727DC56EC48C97F8 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A714259BF8355E2CF37EE17258A289CC /* AFNetworkReachabilityManager.m */; };
@@ -546,7 +554,7 @@
 		124D5039A1F4CEF665FDA222B57DD677 /* Pods-VimeoNetworkingExample-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VimeoNetworkingExample-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		12C5180CE8C0AEED2C554ED751A28E51 /* AFImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFImageDownloader.m; path = "UIKit+AFNetworking/AFImageDownloader.m"; sourceTree = "<group>"; };
 		1321FA5BE51F20152EFEEAD2DF86264D /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		138E683BC81CCB1695E602328599209D /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		138E683BC81CCB1695E602328599209D /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		13FAA716BE3752F02DDD14A1E8261CDA /* Spatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Spatial.swift; sourceTree = "<group>"; };
 		14A0A5D9B0EC8FE2D0B651A193CBE1E6 /* VIMVODItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVODItem.h; sourceTree = "<group>"; };
 		16805C9DFD7B6F444D2425C715B5F737 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -560,7 +568,7 @@
 		1BFD6948595AC793E50D657629655AB9 /* VIMThumbnailUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMThumbnailUploadTicket.h; sourceTree = "<group>"; };
 		1E53BAC736CE51BE9F3B64E399A4BB30 /* AFNetworking-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "AFNetworking-iOS.modulemap"; sourceTree = "<group>"; };
 		1EAABD436AE17C338E12E1FEDCFD6B94 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/CFNetwork.framework; sourceTree = DEVELOPER_DIR; };
-		1EB60D5E72F18CE610B91D2F142A1F39 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOSTests.framework; path = "Pods-VimeoNetworkingExample-tvOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1EB60D5E72F18CE610B91D2F142A1F39 /* Pods_VimeoNetworkingExample_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F5D8A2BF59417627F165C0C14BD75C4 /* Pods-VimeoNetworkingExample-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-tvOS-frameworks.sh"; sourceTree = "<group>"; };
 		1F8A62AAD3DE9342B7F754A7C53C70E7 /* NetworkingNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkingNotification.swift; path = VimeoNetworking/Sources/NetworkingNotification.swift; sourceTree = "<group>"; };
 		20995DE06D0531CE41DA4218EC1D5046 /* VIMLiveTime.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveTime.swift; sourceTree = "<group>"; };
@@ -588,6 +596,10 @@
 		3A27E58C605FB68D440E5FDF152B8B11 /* VimeoNetworking-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-umbrella.h"; sourceTree = "<group>"; };
 		3AC3F18B9D3B165E2C22F9C01C924F93 /* VimeoNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VimeoNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		3B5AD8616028CFB680DB31E587DBC111 /* OHHTTPStubs-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "OHHTTPStubs-iOS.modulemap"; sourceTree = "<group>"; };
+		3CBB8E1721B07AE700092D24 /* UserMembership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMembership.swift; sourceTree = "<group>"; };
+		3CBB8E1A21B1A1D500092D24 /* UserSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSubscription.swift; sourceTree = "<group>"; };
+		3CBB8E1D21B1A48300092D24 /* UserSubscriptionRenewal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSubscriptionRenewal.swift; sourceTree = "<group>"; };
+		3CBB8E2021B1A4A300092D24 /* UserSubscriptionTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSubscriptionTrial.swift; sourceTree = "<group>"; };
 		3DB9F95F175362974D9C05ED9E54009C /* Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3E403018A219B1706367654CD8EF6B8C /* VimeoNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VimeoNetworking.h; path = VimeoNetworking/Sources/VimeoNetworking.h; sourceTree = "<group>"; };
 		3E911C478DE04F75AE4FE191CE6A5D8A /* AFNetworking-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "AFNetworking-tvOS-umbrella.h"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-umbrella.h"; sourceTree = "<group>"; };
@@ -610,7 +622,7 @@
 		4DDFF4DA52A4F6F21983F6455B1BBA00 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
 		4E084F22B1CD0CE1F17D1F886DD98D93 /* VIMLiveChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveChat.swift; sourceTree = "<group>"; };
 		509F7396F2DCDBEF6C4833C26D738EFF /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		5104E41841C42E1DBCD1D8C5DCFC6B3D /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_tvOS.framework; path = "Pods-VimeoNetworkingExample-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5104E41841C42E1DBCD1D8C5DCFC6B3D /* Pods_VimeoNetworkingExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		544FDAA985D72F4FCCC6032A2DA17200 /* Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VimeoNetworkingExample-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
 		54CBB5BB46EA91D92B327F1C5ED6CB35 /* VIMVideoPlayRepresentation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoPlayRepresentation.h; sourceTree = "<group>"; };
 		55414FC27D39F6FE310EA0A1A9B01652 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
@@ -657,7 +669,7 @@
 		77952BCA8B5E4CD22772ED435CC82221 /* VIMSeason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMSeason.m; sourceTree = "<group>"; };
 		7830DB57DE3EA2CFD49FD16DCB51353D /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
 		793FF9824EAE5DCE64516871C8CC9687 /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
-		799C344BC3BC8D05D3ABFB0E2D3A080C /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOS.framework; path = "Pods-VimeoNetworkingExample-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		799C344BC3BC8D05D3ABFB0E2D3A080C /* Pods_VimeoNetworkingExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A6ABC139FB97940A4FEB2AB6F33BC09 /* VIMProgrammedContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMProgrammedContent.swift; sourceTree = "<group>"; };
 		7AC69B3F4EFA7C209AC2EDD06594DB24 /* Pods-VimeoNetworkingExample-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-tvOS.modulemap"; sourceTree = "<group>"; };
 		7B1F2ADE18463F035DF9F9C778747C20 /* VIMVideoUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideoUtils.m; sourceTree = "<group>"; };
@@ -668,14 +680,14 @@
 		7E21A976BFCFD23583CB61A834D05AB7 /* AFNetworking-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-iOS-prefix.pch"; sourceTree = "<group>"; };
 		8077E2A5E3E51DDF0FA2967E5028AAB4 /* VIMConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMConnection.h; sourceTree = "<group>"; };
 		80BDA9ACDE142F74CA4B4F4FE2CC8684 /* VimeoNetworking-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "VimeoNetworking-tvOS.modulemap"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.modulemap"; sourceTree = "<group>"; };
-		8144126DEBAE34BEBAD942C2D49231A7 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8144126DEBAE34BEBAD942C2D49231A7 /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82AF5A796CF2DF0064F511875C788519 /* VIMSizeQuota.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMSizeQuota.swift; sourceTree = "<group>"; };
 		84DC4945F0CE70C8829DE6AABD8B24F8 /* OHHTTPStubsResponse+JSON.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "OHHTTPStubsResponse+JSON.m"; path = "OHHTTPStubs/Sources/JSON/OHHTTPStubsResponse+JSON.m"; sourceTree = "<group>"; };
 		8585DE8883414855CDB578EBF2B4A237 /* Pods-VimeoNetworkingExample-iOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VimeoNetworkingExample-iOS-resources.sh"; sourceTree = "<group>"; };
 		85B67922BBC87E08518F7D7ED8857DC1 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
 		862533C95784F22243E0B55DE6368995 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
 		864A412B89AF5F4736B8C97E681F91F1 /* VIMVideo+VOD.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMVideo+VOD.h"; sourceTree = "<group>"; };
-		867B40B549B9E430533E43E269F7F3DD /* VimeoNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = VimeoNetworking.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		867B40B549B9E430533E43E269F7F3DD /* VimeoNetworking.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = VimeoNetworking.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		86D51C279B459F930381E6BDC96B3A2D /* AFNetworking-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "AFNetworking-iOS.xcconfig"; sourceTree = "<group>"; };
 		877159215B2C4227E622671D5BA217DB /* OHHTTPStubsResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubsResponse.h; path = OHHTTPStubs/Sources/OHHTTPStubsResponse.h; sourceTree = "<group>"; };
 		8988067C241ED04A45672E5B279E399D /* AFNetworking-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "AFNetworking-tvOS-dummy.m"; path = "../AFNetworking-tvOS/AFNetworking-tvOS-dummy.m"; sourceTree = "<group>"; };
@@ -691,13 +703,13 @@
 		91F8FB41EB9FDFB996D5A1CCB5617871 /* VIMTrigger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMTrigger.h; sourceTree = "<group>"; };
 		929039871D87D12B6B28A831411554D3 /* ResponseCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResponseCache.swift; path = VimeoNetworking/Sources/ResponseCache.swift; sourceTree = "<group>"; };
 		9298E1C7A907B19E83A1F8290EB84DEC /* AuthenticationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthenticationController.swift; path = VimeoNetworking/Sources/AuthenticationController.swift; sourceTree = "<group>"; };
-		93192B471CA3AA907EE85122635F21A8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		93192B471CA3AA907EE85122635F21A8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		9362C8E4315D1FD599F85794A99C2E73 /* NSURLRequest+HTTPBodyTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+HTTPBodyTesting.h"; path = "OHHTTPStubs/Sources/NSURLSession/NSURLRequest+HTTPBodyTesting.h"; sourceTree = "<group>"; };
 		937A04B01D07FF37F808ADD2628BCC3D /* Pods-VimeoNetworkingExample-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-iOS-dummy.m"; sourceTree = "<group>"; };
 		938EAC57C1C57FA15637DDC514C9DFF3 /* VIMVideoFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoFile.h; sourceTree = "<group>"; };
 		939C33B6E7B7087872FBB2E521CD392D /* Request+Configs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Configs.swift"; path = "VimeoNetworking/Sources/Request+Configs.swift"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		945E94EE93AA9FC917A41894927F6864 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OHHTTPStubs.framework; path = "OHHTTPStubs-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		945E94EE93AA9FC917A41894927F6864 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHHTTPStubs.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9565AED5201481B8041F99C6C1F97B73 /* VIMUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUser.h; sourceTree = "<group>"; };
 		965D40D9E5004C48D2F2125F2B2839B3 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
 		989BE0813D71894A683809A5FAA975FC /* Pods-VimeoNetworkingExample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VimeoNetworkingExample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -726,7 +738,7 @@
 		AB221E3090D0D4AB624A7F122A4E9AF8 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ABE00CD0B2EEC04C1815A583ACB18DBF /* VimeoNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VimeoNetworking-tvOS.xcconfig"; path = "../VimeoNetworking-tvOS/VimeoNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
 		AC0010BE10FE4D8C36FB5015C687927F /* OHHTTPStubs.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OHHTTPStubs.h; path = OHHTTPStubs/Sources/OHHTTPStubs.h; sourceTree = "<group>"; };
-		AD1DC32941258A7B79378547A6016406 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; name = "digicert-sha2.cer"; path = "VimeoNetworking/Resources/digicert-sha2.cer"; sourceTree = "<group>"; };
+		AD1DC32941258A7B79378547A6016406 /* digicert-sha2.cer */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "digicert-sha2.cer"; path = "VimeoNetworking/Resources/digicert-sha2.cer"; sourceTree = "<group>"; };
 		AD7DE981BAAD182DCD8730C425CDEF3B /* VIMUploadTicket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMUploadTicket.h; sourceTree = "<group>"; };
 		AE85BDA004F7732E66BBE0D0E6A4D4D1 /* VIMNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotification.h; sourceTree = "<group>"; };
 		AE88F26D6FCFDCBB6C5849506BA11320 /* OHHTTPStubs-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "OHHTTPStubs-tvOS.modulemap"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS.modulemap"; sourceTree = "<group>"; };
@@ -764,13 +776,13 @@
 		C88767B3E1DCEAE355787A4133DA29AA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		C8A2780D17E256D269CAD10E410AC192 /* Request+Trigger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Request+Trigger.swift"; path = "VimeoNetworking/Sources/Request+Trigger.swift"; sourceTree = "<group>"; };
 		CA6BBEBA25C16541D73C5FFFFBDC5F87 /* VIMVideo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMVideo.m; sourceTree = "<group>"; };
-		CA7EF00E6CFA7760304BD228C9F71398 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		CA7EF00E6CFA7760304BD228C9F71398 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		CE2F061F3DE0238EFD713B39005B251F /* VIMVideoProgressiveFile.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMVideoProgressiveFile.h; sourceTree = "<group>"; };
 		D1704503384D31AFEC5FAB87C7A56ED9 /* VimeoNetworking-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VimeoNetworking-iOS-dummy.m"; sourceTree = "<group>"; };
 		D1C935F6EC8D2710207984CA14342E26 /* VIMPicture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPicture.h; sourceTree = "<group>"; };
 		D2F9F3D542328AF7EE1EF09EE8CE15A6 /* OHHTTPStubs-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OHHTTPStubs-tvOS-umbrella.h"; path = "../OHHTTPStubs-tvOS/OHHTTPStubs-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		D4469116C20C0DD973D6DE4B43F6C7B5 /* Pods-VimeoNetworkingExample-tvOSTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VimeoNetworkingExample-tvOSTests.modulemap"; sourceTree = "<group>"; };
-		D5C507A361CCF752CAEA4F683158426F /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_VimeoNetworkingExample_iOSTests.framework; path = "Pods-VimeoNetworkingExample-iOSTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5C507A361CCF752CAEA4F683158426F /* Pods_VimeoNetworkingExample_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VimeoNetworkingExample_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5FCD41BBCF70210BD5EEA0A41CEE2C7 /* AFNetworking-tvOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "AFNetworking-tvOS.xcconfig"; path = "../AFNetworking-tvOS/AFNetworking-tvOS.xcconfig"; sourceTree = "<group>"; };
 		D68BC1F974E81C4E33197B3E237F4984 /* Pods-VimeoNetworkingExample-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VimeoNetworkingExample-tvOS-dummy.m"; sourceTree = "<group>"; };
 		D69AC695FE34E29299BAB039258B9F72 /* SubscriptionCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionCollection.swift; sourceTree = "<group>"; };
@@ -796,7 +808,7 @@
 		E5A4AFAC6C1D6AAAC0FAF57E08B48781 /* VIMLive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLive.swift; sourceTree = "<group>"; };
 		E5AE3886847960EE7B7CBE6ED50DEF0C /* VIMLiveStreams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VIMLiveStreams.swift; sourceTree = "<group>"; };
 		E5E87C0AC6A9E12C06F30533C33A4885 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		E74114B938D09E9B95B2A232D842310D /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E74114B938D09E9B95B2A232D842310D /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7923A77BEB62549A573A2561ED33CDE /* VIMRecommendation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VIMRecommendation.m; sourceTree = "<group>"; };
 		E9E13467A11C3C57341954F89E07EFBD /* VIMPolicyDocument.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMPolicyDocument.h; sourceTree = "<group>"; };
 		E9F05DE481CDC69674B5A1C383C049F4 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = VimeoNetworking/Sources/Constants.swift; sourceTree = "<group>"; };
@@ -816,8 +828,8 @@
 		F81CD5839C62F5729EA4AACC894337D4 /* VIMNotificationsConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMNotificationsConnection.h; sourceTree = "<group>"; };
 		F8CA2C4FD1904E6B2333DF41641DB450 /* AppConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppConfiguration.swift; path = VimeoNetworking/Sources/AppConfiguration.swift; sourceTree = "<group>"; };
 		F9A61B3A1B1F36E1336BC9A695FC14E2 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
-		F9EC6CD01086A1A77AF274418AA446F1 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VimeoNetworking.framework; path = "VimeoNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FCCC1DC113B8BE0D5CB23BC822459F5F /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AFNetworking.framework; path = "AFNetworking-tvOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9EC6CD01086A1A77AF274418AA446F1 /* VimeoNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VimeoNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCCC1DC113B8BE0D5CB23BC822459F5F /* AFNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AFNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD6065E2CD8C16A7ED3169909A4BFB5E /* NSURLSessionConfiguration+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSessionConfiguration+Extensions.swift"; path = "VimeoNetworking/Sources/NSURLSessionConfiguration+Extensions.swift"; sourceTree = "<group>"; };
 		FD7B9178F0FD81F563954F2BBDC9061C /* VIMSeason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VIMSeason.h; sourceTree = "<group>"; };
 		FD8EECBE5AC34543AC0DA54CBA417F94 /* OHHTTPStubsMethodSwizzling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OHHTTPStubsMethodSwizzling.m; path = OHHTTPStubs/Sources/NSURLSession/OHHTTPStubsMethodSwizzling.m; sourceTree = "<group>"; };
@@ -1030,6 +1042,10 @@
 				19E6D67D6A83F8E3901EA34C06D5511B /* VIMVODConnection.m */,
 				14A0A5D9B0EC8FE2D0B651A193CBE1E6 /* VIMVODItem.h */,
 				328B55382A716D58F07640B437D1A3C5 /* VIMVODItem.m */,
+				3CBB8E1721B07AE700092D24 /* UserMembership.swift */,
+				3CBB8E1A21B1A1D500092D24 /* UserSubscription.swift */,
+				3CBB8E1D21B1A48300092D24 /* UserSubscriptionRenewal.swift */,
+				3CBB8E2021B1A4A300092D24 /* UserSubscriptionTrial.swift */,
 			);
 			name = Models;
 			path = VimeoNetworking/Sources/Models;
@@ -1172,7 +1188,6 @@
 				457CB66F660F7AFBBB12B847822E9544 /* Support Files */,
 				732DD4F4E13A76179E5482BAEC27431A /* UIKit */,
 			);
-			name = AFNetworking;
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
@@ -1217,7 +1232,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -1271,7 +1285,6 @@
 				D43A524074B4CE8EEB302A500F4C4BC3 /* Support Files */,
 				40092B72B740650FB942135BF493FAB7 /* Swift */,
 			);
-			name = OHHTTPStubs;
 			path = OHHTTPStubs;
 			sourceTree = "<group>";
 		};
@@ -2067,10 +2080,12 @@
 				FDCBBEFD8587CF6F339E2A7D1C73968F /* ErrorCode.swift in Sources */,
 				36ACF5A1A9ACDE69B20AC55F9365CACA /* ExceptionCatcher+Swift.swift in Sources */,
 				842D8C3559940FB73D4149202D7E93FB /* KeychainStore.swift in Sources */,
+				3CBB8E1C21B1A1D500092D24 /* UserSubscription.swift in Sources */,
 				158BA46C0FF30222ADF7ED2DDD777339 /* Mappable.swift in Sources */,
 				45283666B4838A00817F4F84A357B5F1 /* NetworkingNotification.swift in Sources */,
 				AB06FE9B6DA7CD017C603C662FBA7151 /* NSError+Extensions.swift in Sources */,
 				7E2FB1985FC9858857CF91E73AC0AEE1 /* NSURLSessionConfiguration+Extensions.swift in Sources */,
+				3CBB8E1F21B1A48300092D24 /* UserSubscriptionRenewal.swift in Sources */,
 				46871B7640F43948DA935C85793A4F5B /* Objc_ExceptionCatcher.m in Sources */,
 				C79A88EED11ECA7B10C7532F003D8A88 /* PinCodeInfo.swift in Sources */,
 				8EB07D89CBBC88297BDC6D36599ED729 /* PlayProgress.swift in Sources */,
@@ -2086,6 +2101,7 @@
 				BDA3BE2CE360EAF856126B8775CAA1C6 /* Request+ProgrammedContent.swift in Sources */,
 				3F0D757CBC63D688689BE12410FA15BA /* Request+Soundtrack.swift in Sources */,
 				0E9EFE8D070AD6DE7AC92FC203D1A44C /* Request+Toggle.swift in Sources */,
+				3CBB8E1921B07AE700092D24 /* UserMembership.swift in Sources */,
 				A2F0D4F65FC6F62803CA7ED0AF0756B9 /* Request+Trigger.swift in Sources */,
 				AA0090B83067F0AB559431E550C15995 /* Request+User.swift in Sources */,
 				50B719AE987A86B2DF40C148C69D59AE /* Request+Video.swift in Sources */,
@@ -2107,6 +2123,7 @@
 				C7252B03D99D5E6A446418CAA292920D /* VIMComment.m in Sources */,
 				BF0B5B112014F85912B2F96CB7824742 /* VIMConnection.m in Sources */,
 				6B116E1310493DBFFE0DEE166C029B11 /* VIMCredit.m in Sources */,
+				3CBB8E2221B1A4A300092D24 /* UserSubscriptionTrial.swift in Sources */,
 				F60B40202B9DE8E018A5ECD5E2C408AE /* VimeoClient.swift in Sources */,
 				741925686A6CC53FAFAABC82B13A8510 /* VimeoNetworking-tvOS-dummy.m in Sources */,
 				9DB4A0EBFC6318D940B134452B7FB93E /* VimeoReachability.swift in Sources */,
@@ -2188,10 +2205,12 @@
 				54B60C71AE1B863060B8F906FF53C126 /* ErrorCode.swift in Sources */,
 				052DF6CFE29DB29D56CF08ABD31EF0EA /* ExceptionCatcher+Swift.swift in Sources */,
 				35E5F7D16CBCA867C1CEF1A6A7F450AA /* KeychainStore.swift in Sources */,
+				3CBB8E1B21B1A1D500092D24 /* UserSubscription.swift in Sources */,
 				1A661CBD29242F100D2F5037284EED35 /* Mappable.swift in Sources */,
 				4B25265EAB2841A6EA05689281E8DB4D /* NetworkingNotification.swift in Sources */,
 				EAE3FE01DB9AA553E1B02B36AEC67E96 /* NSError+Extensions.swift in Sources */,
 				1611C33DD407A05CE051FEE803A5ABED /* NSURLSessionConfiguration+Extensions.swift in Sources */,
+				3CBB8E1E21B1A48300092D24 /* UserSubscriptionRenewal.swift in Sources */,
 				4814D743A6F1125DDA1588665D2928DE /* Objc_ExceptionCatcher.m in Sources */,
 				EAE712C50A61CCD90F7D8B75182C87AE /* PinCodeInfo.swift in Sources */,
 				687728FC90EBB4CC990D754E7041A0E3 /* PlayProgress.swift in Sources */,
@@ -2207,6 +2226,7 @@
 				C56FBC15300FD787C2969FAE9105532D /* Request+ProgrammedContent.swift in Sources */,
 				CCFE56F9F98FACC44ED90E955876570B /* Request+Soundtrack.swift in Sources */,
 				5508AE244F60A5AAF966F29E0B77C017 /* Request+Toggle.swift in Sources */,
+				3CBB8E1821B07AE700092D24 /* UserMembership.swift in Sources */,
 				D93B75B071D9D1752AF28C4F95854152 /* Request+Trigger.swift in Sources */,
 				65B6E9E7A3DD113861C0B74EFDA7DCE0 /* Request+User.swift in Sources */,
 				B52A0E446670267A6348FFC2127F0D13 /* Request+Video.swift in Sources */,
@@ -2228,6 +2248,7 @@
 				D328346E28EF4D26419A8E011B1CB3C8 /* VIMComment.m in Sources */,
 				FE05E458DF0C231CEDE29C1A22AC9D18 /* VIMConnection.m in Sources */,
 				26C81221E38BEDB7BEE6161723C60038 /* VIMCredit.m in Sources */,
+				3CBB8E2121B1A4A300092D24 /* UserSubscriptionTrial.swift in Sources */,
 				8FC6A05B739C54BD3C46684F82C92C41 /* VimeoClient.swift in Sources */,
 				F79240A730BCD933648579F393815D83 /* VimeoNetworking-iOS-dummy.m in Sources */,
 				C88F492C0EB6FFF243D130F3E51A8356 /* VimeoReachability.swift in Sources */,

--- a/VimeoNetworking/Sources/Models/Spatial.swift
+++ b/VimeoNetworking/Sources/Models/Spatial.swift
@@ -3,8 +3,25 @@
 //  Pods
 //
 //  Created by Lim, Jennifer on 1/6/17.
+//  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 /// Spatial stores all information related to threesixty video

--- a/VimeoNetworking/Sources/Models/Subscription.swift
+++ b/VimeoNetworking/Sources/Models/Subscription.swift
@@ -3,7 +3,25 @@
 //  Pods
 //
 //  Created by Lim, Jennifer on 2/8/17.
+//  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 /// Represents all the notifications that the user is Subscribed to.

--- a/VimeoNetworking/Sources/Models/SubscriptionCollection.swift
+++ b/VimeoNetworking/Sources/Models/SubscriptionCollection.swift
@@ -43,7 +43,7 @@ public class SubscriptionCollection: VIMModelObject {
         return ["subscriptions": "subscription"]
     }
     
-    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "subscriptions" {
             return Subscription.self
         }

--- a/VimeoNetworking/Sources/Models/UserMembership.swift
+++ b/VimeoNetworking/Sources/Models/UserMembership.swift
@@ -41,7 +41,7 @@ public class UserMembership: VIMModelObject {
     /// - remark: This property replaces the VIMUser.account property.
     @objc dynamic public private(set) var type: String?
     
-    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "badge" {
             return VIMUserBadge.self
         }

--- a/VimeoNetworking/Sources/Models/UserMembership.swift
+++ b/VimeoNetworking/Sources/Models/UserMembership.swift
@@ -1,0 +1,54 @@
+//
+//  UserMembership.swift
+//  VimeoNetworking
+//
+//  Created by Westendorf, Michael on 11/29/18.
+//  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+/// Class containing details about a user's membership, including what badge should be displayed for them, their subscription status, and account information.
+public class UserMembership: VIMModelObject {
+    
+    /// Object describing the visual badge to display to indicate the user's account type.
+    @objc dynamic public private(set) var badge: VIMUserBadge?
+    
+    /// A non-localized string representation of the user's account type that can be used for display purposes.
+    @objc dynamic public private(set) var display: String?
+
+    /// An object containing information about the user's subscription status.  This information will only be available for the current logged in user.
+    /// - remark: This information is only available for the current logged in user.
+    @objc dynamic public private(set) var subscription: UserSubscription?
+    
+    /// A string representation of the user's account type.  This value should not be used for display purposes, use the **display** property instead.
+    /// - remark: This property replaces the VIMUser.account property.
+    @objc dynamic public private(set) var type: String?
+    
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+        if key == "badge" {
+            return VIMUserBadge.self
+        }
+        if key == "subscription" {
+            return UserSubscription.self
+        }
+        
+        return nil
+    }
+}

--- a/VimeoNetworking/Sources/Models/UserSubscription.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscription.swift
@@ -1,8 +1,8 @@
 //
-//  Progress.swift
-//  Pods
+//  UserSubscription.swift
+//  VimeoNetworking
 //
-//  Created by Hawkins, Jason on 3/2/17.
+//  Created by Westendorf, Michael on 11/30/18.
 //  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,10 +24,23 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-/// An object representing the amount of progress for which a video has been played.
-public class PlayProgress: VIMModelObject {
-    /// The time, in seconds, that the video has been viewed.
-    @objc dynamic public var seconds: NSNumber?
+/// This class contains information about the logged in user's subscription status, including information about any free trials the user may be in and information
+/// about the user's renewal date.
+public class UserSubscription: VIMModelObject {
+    /// Object containing information about the logged in user's renewal date
+    @objc dynamic public private(set) var renewal: UserSubscriptionRenewal?
+    
+    /// Object containing information about the logged in user's free trial status
+    @objc dynamic public private(set) var trial: UserSubscriptionTrial?
+    
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+        if key == "renewal" {
+            return UserSubscriptionRenewal.self
+        }
+        if key == "trial" {
+            return UserSubscriptionTrial.self
+        }
+        
+        return nil
+    }
 }

--- a/VimeoNetworking/Sources/Models/UserSubscription.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscription.swift
@@ -33,7 +33,7 @@ public class UserSubscription: VIMModelObject {
     /// Object containing information about the logged in user's free trial status
     @objc dynamic public private(set) var trial: UserSubscriptionTrial?
     
-    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "renewal" {
             return UserSubscriptionRenewal.self
         }

--- a/VimeoNetworking/Sources/Models/UserSubscriptionRenewal.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscriptionRenewal.swift
@@ -1,8 +1,8 @@
 //
-//  SubscriptionCollection.swift
-//  Pods
+//  UserSubscriptionRenewal.swift
+//  VimeoNetworking
 //
-//  Created by Lim, Jennifer on 1/20/17.
+//  Created by Westendorf, Michael on 11/30/18.
 //  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,30 +24,30 @@
 //  THE SOFTWARE.
 //
 
-/// Represents all the subscriptions with extra informations
-public class SubscriptionCollection: VIMModelObject {
-    // MARK: - Properties
-
-    /// Represents the uri
-    @objc dynamic public private(set) var uri: String?
+/// This class contains information about the renewal dates for the logged in user, including when their subscription will auto-renew (if auto-renewal is enabled)
+public class UserSubscriptionRenewal: VIMModelObject {
+    /// A string representation of the subscription renewal date to use for UI display purposes.
+    /// - remark: The date is displayed in *YYYY-MM-DD* format
+    @objc dynamic public private(set) var displayDate: String?
     
-    /// Represents the subscription
-    @objc dynamic public private(set) var subscription: Subscription?
+    /// A **Date** object representing the subscription renewal date.
+    @objc dynamic public private(set) var renewalDate: Date?
     
-    /// Represents the migration that indicates whether the user has migrated from the old system `VIMTrigger` to new new system `Localytics`.
-    @objc dynamic public private(set) var migrated: NSNumber?
+    @objc dynamic private var renewalDateString: String?
     
-    // MARK: - VIMMappable
-    
-    public override func getObjectMapping() -> Any {
-        return ["subscriptions": "subscription"]
+    override public func getObjectMapping() -> Any {
+        return [ "renewal_date": "renewalDateString" ]
     }
     
-    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
-        if key == "subscriptions" {
-            return Subscription.self
+    override public func didFinishMapping() {
+        self.formatDisplayDate()
+    }
+    
+    private func formatDisplayDate() {
+        guard let renewalDateString = self.renewalDateString, let dateFormatter = VIMModelObject.dateFormatter() else {
+            return
         }
         
-        return nil
+        self.renewalDate = dateFormatter.date(from: renewalDateString)
     }
 }

--- a/VimeoNetworking/Sources/Models/UserSubscriptionRenewal.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscriptionRenewal.swift
@@ -31,23 +31,19 @@ public class UserSubscriptionRenewal: VIMModelObject {
     @objc dynamic public private(set) var displayDate: String?
     
     /// A **Date** object representing the subscription renewal date.
-    @objc dynamic public private(set) var renewalDate: Date?
+    @objc dynamic public private(set) var formattedRenewalDate: Date?
     
-    @objc dynamic private var renewalDateString: String?
-    
-    override public func getObjectMapping() -> Any {
-        return [ "renewal_date": "renewalDateString" ]
-    }
+    @objc dynamic private var renewalDate: String?
     
     override public func didFinishMapping() {
-        self.formatDisplayDate()
+        self.formatRenewalDate()
     }
     
-    private func formatDisplayDate() {
-        guard let renewalDateString = self.renewalDateString, let dateFormatter = VIMModelObject.dateFormatter() else {
+    private func formatRenewalDate() {
+        guard let renewalDate = self.renewalDate, let dateFormatter = VIMModelObject.dateFormatter() else {
             return
         }
         
-        self.renewalDate = dateFormatter.date(from: renewalDateString)
+        self.formattedRenewalDate = dateFormatter.date(from: renewalDate)
     }
 }

--- a/VimeoNetworking/Sources/Models/UserSubscriptionTrial.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscriptionTrial.swift
@@ -24,16 +24,35 @@
 //  THE SOFTWARE.
 //
 
+/// Enumeration indicating the user's current trial status
+@objc public enum TrialStatus: Int {
+    /// the user is not in a trial period
+    case none
+    
+    /// the user is currently in a free trial
+    case freeTrial
+}
+
 /// This class represents the free trial status for the logged in user, including the status of their trial (if they are in one) and whether or not
 /// they have ever had a free trial.
 public class UserSubscriptionTrial: VIMModelObject {
     /// The status of a user's free trial.
     ///
     /// This property will have a value of `free_trial` if the user is currently in a trial period, otherwise this field will be nil.
-    @objc dynamic public private(set) var status: String?
+    @objc dynamic private var status: String?
     
     /// Indicates whether the user has ever been in a free trial.
     ///
     /// A value of 0 indicates the user has never had a free trial, a value of 1 indicates that the user has had a free trial at some point.
     @objc dynamic public private(set) var hasBeenInFreeTrial: NSNumber?
+    
+    /// A property indicating the user's current trial status.
+    @objc public var trialStatus: TrialStatus {
+        switch self.status {
+        case "free_trial":
+            return .freeTrial
+        default:
+            return .none
+        }
+    }
 }

--- a/VimeoNetworking/Sources/Models/UserSubscriptionTrial.swift
+++ b/VimeoNetworking/Sources/Models/UserSubscriptionTrial.swift
@@ -1,8 +1,8 @@
 //
-//  Progress.swift
-//  Pods
+//  UserSubscriptionTrial.swift
+//  VimeoNetworking
 //
-//  Created by Hawkins, Jason on 3/2/17.
+//  Created by Westendorf, Michael on 11/30/18.
 //  Copyright (c) 2014-2018 Vimeo (https://vimeo.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,10 +24,16 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-/// An object representing the amount of progress for which a video has been played.
-public class PlayProgress: VIMModelObject {
-    /// The time, in seconds, that the video has been viewed.
-    @objc dynamic public var seconds: NSNumber?
+/// This class represents the free trial status for the logged in user, including the status of their trial (if they are in one) and whether or not
+/// they have ever had a free trial.
+public class UserSubscriptionTrial: VIMModelObject {
+    /// The status of a user's free trial.
+    ///
+    /// This property will have a value of `free_trial` if the user is currently in a trial period, otherwise this field will be nil.
+    @objc dynamic public private(set) var status: String?
+    
+    /// Indicates whether the user has ever been in a free trial.
+    ///
+    /// A value of 0 indicates the user has never had a free trial, a value of 1 indicates that the user has had a free trial at some point.
+    @objc dynamic public private(set) var hasBeenInFreeTrial: NSNumber?
 }

--- a/VimeoNetworking/Sources/Models/VIMLiveQuota.swift
+++ b/VimeoNetworking/Sources/Models/VIMLiveQuota.swift
@@ -40,7 +40,7 @@ public class VIMLiveQuota: VIMModelObject {
     /// The `time` field in a `live_quota` response.
     @objc dynamic public private(set) var time: VIMLiveTime?
     
-    override public func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    override public func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == Constants.StreamsKey {
             return VIMLiveStreams.self
         }

--- a/VimeoNetworking/Sources/Models/VIMProgrammedContent.swift
+++ b/VimeoNetworking/Sources/Models/VIMProgrammedContent.swift
@@ -57,7 +57,7 @@ public class VIMProgrammedContent: VIMModelObject {
     }
     
     //Note: No super call in this method, see explanation in didFinishMapping() [MW] 10/19/16
-    override public func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    override public func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == Constants.MetadataKey {
             return NSMutableDictionary.self
         }

--- a/VimeoNetworking/Sources/Models/VIMUploadQuota.swift
+++ b/VimeoNetworking/Sources/Models/VIMUploadQuota.swift
@@ -37,7 +37,7 @@ public class VIMUploadQuota: VIMModelObject {
     /// Represents the lifetime quota period
     @objc dynamic public private(set) var lifetime: VIMSizeQuota?
     
-    public override func getClassForObjectKey(_ key: String!) -> AnyClass! {
+    public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "space" {
             return VIMSpace.self
         }

--- a/VimeoNetworking/Sources/Models/VIMUser.h
+++ b/VimeoNetworking/Sources/Models/VIMUser.h
@@ -34,9 +34,9 @@
 @class VIMUploadQuota;
 @class VIMUserBadge;
 @class VIMLiveQuota;
+@class UserMembership;
 
-typedef NS_ENUM(NSInteger, VIMUserAccountType)
-{
+typedef NS_ENUM(NSInteger, VIMUserAccountType) {
     VIMUserAccountTypeBasic = 0,
     VIMUserAccountTypePro,
     VIMUserAccountTypePlus,
@@ -51,7 +51,12 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
 @interface VIMUser : VIMModelObject
 
 @property (nonatomic, assign, readonly) VIMUserAccountType accountType;
-@property (nonatomic, strong, nullable) VIMUserBadge *badge;
+
+/// Object storing information about the badge to display for the user's account type
+/// DEPRECATED: Use membership.badge instead
+/// - seealso: UserMembership
+//@property (nonatomic, strong, nullable) VIMUserBadge *badge;
+
 @property (nonatomic, copy, nullable) NSString *bio;
 @property (nonatomic, copy, nullable) NSArray *contentFilter;
 @property (nonatomic, strong, nullable) NSDate *createdTime;
@@ -66,8 +71,15 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
 @property (nonatomic, strong, nullable) NSArray *userEmails;
 @property (nonatomic, strong, nullable) VIMPreference *preferences;
 @property (nonatomic, strong, nullable) VIMUploadQuota *uploadQuota;
-@property (nonatomic, copy, nullable) NSString *account;
+
+/// A string representation of the user's account type, not to be used for display purposes.
+/// DEPRECATED: use membership.type instead for this information, use membership.display for a non-localized string for use in UI displays,
+/// Note: It is better to use the accountType property to retrieve an enum value representing the user's account type rather than working with the string representations directly.
+/// -seealso: UserMembership
+//@property (nonatomic, copy, nullable) NSString *account;
+
 @property (nonatomic, strong, nullable) VIMLiveQuota *liveQuota;
+@property (nonatomic, strong, nullable) UserMembership *membership;
 
 - (nullable VIMConnection *)connectionWithName:(nonnull NSString *)connectionName;
 - (nullable VIMNotificationsConnection *)notificationsConnection;
@@ -78,5 +90,10 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType)
 
 - (nullable NSString *)accountTypeAnalyticsIdentifier;
 - (BOOL)hasSameBadgeCount:(nullable VIMUser *)newUser;
+
+/// @brief Method for determining whether or not the user has ever had a free trial on Vimeo.
+/// @return true if the user has ever been in a free trial, otherwise it will return false
+/// @attention THIS METHOD IS FOR VIMEO INTERNAL USE ONLY
+- (BOOL)hasBeenInFreeTrial;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMUser.m
+++ b/VimeoNetworking/Sources/Models/VIMUser.m
@@ -108,6 +108,10 @@ static NSString *const Producer = @"producer";
         return [VIMLiveQuota class];
     }
 
+    if ([key isEqualToString:@"membership"]) {
+        return [UserMembership class];
+    }
+    
     return nil;
 }
 
@@ -214,39 +218,39 @@ static NSString *const Producer = @"producer";
 
 - (void)parseAccountType
 {
-    if ([self.account isEqualToString:Plus])
+    if ([self.membership.type isEqualToString:Plus])
     {
         self.accountType = VIMUserAccountTypePlus;
     }
-    else if ([self.account isEqualToString:Pro])
+    else if ([self.membership.type isEqualToString:Pro])
     {
         self.accountType = VIMUserAccountTypePro;
     }
-    else if ([self.account isEqualToString:Basic])
+    else if ([self.membership.type isEqualToString:Basic])
     {
         self.accountType = VIMUserAccountTypeBasic;
     }
-    else if ([self.account isEqualToString:Business])
+    else if ([self.membership.type isEqualToString:Business])
     {
         self.accountType = VIMUserAccountTypeBusiness;
     }
-    else if ([self.account isEqualToString:LivePro])
+    else if ([self.membership.type isEqualToString:LivePro])
     {
         self.accountType = VIMUserAccountTypeLivePro;
     }
-    else if ([self.account isEqualToString:LiveBusiness])
+    else if ([self.membership.type isEqualToString:LiveBusiness])
     {
         self.accountType = VIMUserAccountTypeLiveBusiness;
     }
-    else if ([self.account isEqualToString:LivePremium])
+    else if ([self.membership.type isEqualToString:LivePremium])
     {
         self.accountType = VIMUserAccountTypeLivePremium;
     }
-    else if ([self.account isEqualToString:ProUnlimited])
+    else if ([self.membership.type isEqualToString:ProUnlimited])
     {
         self.accountType = VIMUserAccountTypeProUnlimited;
     }
-    else if ([self.account isEqualToString:Producer])
+    else if ([self.membership.type isEqualToString:Producer])
     {
         self.accountType = VIMUserAccountTypeProducer;
     }
@@ -374,6 +378,10 @@ static NSString *const Producer = @"producer";
     NSInteger responseTotal = [responseConnection supportedNotificationNewTotal];
     
     return currentAccountTotal == responseTotal;
+}
+
+- (BOOL)hasBeenInFreeTrial {
+    return self.membership.subscription.trial.hasBeenInFreeTrial.boolValue;
 }
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMUser.m
+++ b/VimeoNetworking/Sources/Models/VIMUser.m
@@ -380,7 +380,14 @@ static NSString *const Producer = @"producer";
     return currentAccountTotal == responseTotal;
 }
 
-- (BOOL)hasBeenInFreeTrial {
+- (BOOL)hasBeenInFreeTrial
+{
+    if([self.membership.subscription.trial.hasBeenInFreeTrial respondsToSelector: @selector(boolValue)] == NO)
+    {
+        NSAssert(NO, @"hasBeenInFreeTrial is expected to be an NSNumber and should respond to boolValue!");
+        return NO;
+    }
+    
     return self.membership.subscription.trial.hasBeenInFreeTrial.boolValue;
 }
 

--- a/VimeoNetworkingExample-iOS/VIMUser/VIMUserBadgeTests.swift
+++ b/VimeoNetworkingExample-iOS/VIMUser/VIMUserBadgeTests.swift
@@ -65,7 +65,7 @@ class VIMUserBadgeTests: XCTestCase
             switch response
             {
             case .success(let result):
-                XCTAssertEqual(result.model.badge?.badgeType, expectedType)
+                XCTAssertEqual(result.model.membership?.badge?.badgeType, expectedType)
                 
             case .failure(let error):
                 XCTFail("\(error)")

--- a/VimeoNetworkingExample-iOS/VIMUser/VIMUserTests.swift
+++ b/VimeoNetworkingExample-iOS/VIMUser/VIMUserTests.swift
@@ -65,7 +65,7 @@ class VIMUserTests: XCTestCase
         return Request<VIMUser>(path: TestConstants.UserUri)
     }
     
-    private func checkReturnedAccountType(for user: VIMUser, withExpectedType expectedType: VIMUserAccountType)
+    private func checkAccountTypeAnalyticsIdentifier(for user: VIMUser, withExpectedType expectedType: VIMUserAccountType)
     {
         XCTAssertEqual(user.accountType, expectedType)
         
@@ -115,7 +115,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_live_pro.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Live Pro User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .livePro)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .livePro)
         }
     }
     
@@ -124,7 +124,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_live_business.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Live Business User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .liveBusiness)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .liveBusiness)
         }
     }
     
@@ -133,7 +133,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_live_premium.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Live Premium User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .livePremium)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .livePremium)
         }
     }
     
@@ -142,7 +142,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_basic.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Basic User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .basic)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .basic)
         }
     }
     
@@ -151,7 +151,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_plus.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Plus User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .plus)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .plus)
         }
     }
     
@@ -160,7 +160,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_pro.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Pro User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .pro)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .pro)
         }
     }
     
@@ -169,7 +169,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_business.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Business User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .business)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .business)
         }
     }
 
@@ -178,7 +178,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_pro_unlimited.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Pro Unlimited User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .proUnlimited)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .proUnlimited)
         }
     }
 
@@ -187,7 +187,7 @@ class VIMUserTests: XCTestCase
         self.stubResponse(withFile: "user_producer.json")
         let request = self.userRequest()
         self.send(request: request, withDescription: "Expectation for Pro Unlimited User Object") { user in
-            self.checkReturnedAccountType(for: user!, withExpectedType: .producer)
+            self.checkAccountTypeAnalyticsIdentifier(for: user!, withExpectedType: .producer)
         }
     }
     
@@ -210,7 +210,7 @@ class VIMUserTests: XCTestCase
             XCTAssertEqual(user?.membership?.subscription?.renewal?.displayDate, "2019-06-12")
             
             let testDate = VIMModelObject.dateFormatter()?.date(from: "2019-06-12T04:00:00+00:00")
-            XCTAssertEqual(user?.membership?.subscription?.renewal?.renewalDate, testDate)
+            XCTAssertEqual(user?.membership?.subscription?.renewal?.formattedRenewalDate, testDate)
         }
     }
     

--- a/VimeoNetworkingExample-iOS/VIMUser/VIMUserTests.swift
+++ b/VimeoNetworkingExample-iOS/VIMUser/VIMUserTests.swift
@@ -30,6 +30,11 @@ import OHHTTPStubs
 
 class VIMUserTests: XCTestCase
 {
+    private struct TestConstants {
+        static let UserUri = "/users/" + Constants.CensoredId
+        static let MeUri = "/me"
+    }
+    
     override func setUp()
     {
         super.setUp()
@@ -48,47 +53,53 @@ class VIMUserTests: XCTestCase
         OHHTTPStubs.removeAllStubs()
     }
     
-    private func stubResponse(withFile fileName: String)
+    private func stubResponse(for uri: String = TestConstants.UserUri, withFile fileName: String)
     {
-        stub(condition: isPath("/users/" + Constants.CensoredId)) { _ in
+        stub(condition: isPath(uri)) { _ in
             let stubPath = OHPathForFile(fileName, type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type":"application/json"])
         }
     }
     
-    private func checkReturnedAccountType(withExpectedType expectedType: VIMUserAccountType, andExpectation expectation: XCTestExpectation)
+    private func userRequest() -> Request<VIMUser> {
+        return Request<VIMUser>(path: TestConstants.UserUri)
+    }
+    
+    private func checkReturnedAccountType(for user: VIMUser, withExpectedType expectedType: VIMUserAccountType)
     {
-        let request = Request<VIMUser>(path: "/users/" + Constants.CensoredId)
+        XCTAssertEqual(user.accountType, expectedType)
         
-        _ = VimeoClient.sharedClient.request(request, completion: { (response) in
-            switch response
-            {
+        let analyticsIdentifier = user.accountTypeAnalyticsIdentifier()
+        switch expectedType
+        {
+        case .basic:
+            XCTAssertEqual(analyticsIdentifier, "basic")
+        case .plus:
+            XCTAssertEqual(analyticsIdentifier, "plus")
+        case .pro:
+            XCTAssertEqual(analyticsIdentifier, "pro")
+        case .business:
+            XCTAssertEqual(analyticsIdentifier, "business")
+        case .livePro:
+            XCTAssertEqual(analyticsIdentifier, "live_pro")
+        case .liveBusiness:
+            XCTAssertEqual(analyticsIdentifier, "live_business")
+        case .livePremium:
+            XCTAssertEqual(analyticsIdentifier, "live_premium")
+        case .proUnlimited:
+            XCTAssertEqual(analyticsIdentifier, "pro_unlimited")
+        case .producer:
+            XCTAssertEqual(analyticsIdentifier, "producer")
+        }
+    }
+    
+    private func send(request: Request<VIMUser>, withDescription: String, validationClosure: @escaping ((VIMUser?) -> Void)) {
+        let expectation = self.expectation(description: withDescription)
+        
+        _ = VimeoClient.sharedClient.request(request, completion: { response in
+            switch response {
             case .success(let result):
-                XCTAssertEqual(result.model.accountType, expectedType)
-                
-                let analyticsIdentifier = result.model.accountTypeAnalyticsIdentifier()
-                switch expectedType
-                {
-                case .basic:
-                    XCTAssertEqual(analyticsIdentifier, "basic")
-                case .plus:
-                    XCTAssertEqual(analyticsIdentifier, "plus")
-                case .pro:
-                    XCTAssertEqual(analyticsIdentifier, "pro")
-                case .business:
-                    XCTAssertEqual(analyticsIdentifier, "business")
-                case .livePro:
-                    XCTAssertEqual(analyticsIdentifier, "live_pro")
-                case .liveBusiness:
-                    XCTAssertEqual(analyticsIdentifier, "live_business")
-                case .livePremium:
-                    XCTAssertEqual(analyticsIdentifier, "live_premium")
-                case .proUnlimited:
-                    XCTAssertEqual(analyticsIdentifier, "pro_unlimited")
-                case .producer:
-                    XCTAssertEqual(analyticsIdentifier, "producer")
-                }
-                
+                validationClosure(result.model)
             case .failure(let error):
                 XCTFail("\(error)")
             }
@@ -102,63 +113,128 @@ class VIMUserTests: XCTestCase
     func testUserObjectReturningLiveProForAccountType()
     {
         self.stubResponse(withFile: "user_live_pro.json")
-        let expectation = self.expectation(description: "Expectation for Live Pro User Object")
-        self.checkReturnedAccountType(withExpectedType: .livePro, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Live Pro User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .livePro)
+        }
     }
     
     func testUserObjectReturningLiveBusinessForAccountType()
     {
         self.stubResponse(withFile: "user_live_business.json")
-        let expectation = self.expectation(description: "Expectation for Live Business User Object")
-        self.checkReturnedAccountType(withExpectedType: .liveBusiness, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Live Business User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .liveBusiness)
+        }
     }
     
     func testUserObjectReturningLivePremiumForAccountType()
     {
         self.stubResponse(withFile: "user_live_premium.json")
-        let expectation = self.expectation(description: "Expectation for Live Premium User Object")
-        self.checkReturnedAccountType(withExpectedType: .livePremium, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Live Premium User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .livePremium)
+        }
     }
     
     func testUserObjectReturningBasicForAccountType()
     {
         self.stubResponse(withFile: "user_basic.json")
-        let expectation = self.expectation(description: "Expectation for Basic User Object")
-        self.checkReturnedAccountType(withExpectedType: .basic, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Basic User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .basic)
+        }
     }
     
     func testUserObjectReturningPlusForAccountType()
     {
         self.stubResponse(withFile: "user_plus.json")
-        let expectation = self.expectation(description: "Expectation for Plus User Object")
-        self.checkReturnedAccountType(withExpectedType: .plus, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Plus User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .plus)
+        }
     }
     
     func testUserObjectReturningProForAccountType()
     {
         self.stubResponse(withFile: "user_pro.json")
-        let expectation = self.expectation(description: "Expectation for Pro User Object")
-        self.checkReturnedAccountType(withExpectedType: .pro, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Pro User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .pro)
+        }
     }
     
     func testUserObjectReturningBusinessForAccountType()
     {
         self.stubResponse(withFile: "user_business.json")
-        let expectation = self.expectation(description: "Expectation for Business User Object")
-        self.checkReturnedAccountType(withExpectedType: .business, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Business User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .business)
+        }
     }
 
     func testUserObjectReturningProUnlimitedForAccountType()
     {
         self.stubResponse(withFile: "user_pro_unlimited.json")
-        let expectation = self.expectation(description: "Expectation for Pro Unlimited User Object")
-        self.checkReturnedAccountType(withExpectedType: .proUnlimited, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Pro Unlimited User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .proUnlimited)
+        }
     }
 
     func testUserObjectReturningProducerForAccountType()
     {
         self.stubResponse(withFile: "user_producer.json")
-        let expectation = self.expectation(description: "Expectation for Pro Unlimited User Object")
-        self.checkReturnedAccountType(withExpectedType: .producer, andExpectation: expectation)
+        let request = self.userRequest()
+        self.send(request: request, withDescription: "Expectation for Pro Unlimited User Object") { user in
+            self.checkReturnedAccountType(for: user!, withExpectedType: .producer)
+        }
+    }
+    
+    func testUserObjectHasMembershipInfo() {
+        self.stubResponse(for: TestConstants.MeUri, withFile: "user_plus.json")
+        
+        let request = Request<VIMUser>.getMeRequest()
+        self.send(request: request, withDescription: "Expectation for validating membership info") { user in
+            XCTAssertNotNil(user?.membership)
+            XCTAssertNotNil(user?.membership?.subscription)
+            XCTAssertNotNil(user?.membership?.subscription?.renewal)
+            XCTAssertNotNil(user?.membership?.subscription?.trial)
+        }
+    }
+    
+    func testSubscriptionDatesAreValid() {
+        self.stubResponse(for: TestConstants.MeUri, withFile: "user_plus.json")
+        let request = Request<VIMUser>.getMeRequest()
+        self.send(request: request, withDescription: "expectation for validating subscription dates") { user in
+            XCTAssertEqual(user?.membership?.subscription?.renewal?.displayDate, "2019-06-12")
+            
+            let testDate = VIMModelObject.dateFormatter()?.date(from: "2019-06-12T04:00:00+00:00")
+            XCTAssertEqual(user?.membership?.subscription?.renewal?.renewalDate, testDate)
+        }
+    }
+    
+    func testUserHasBeenInTrialFlag_IsSet() {
+        self.stubResponse(for: TestConstants.MeUri, withFile: "user_basic_had_free_trial.json")
+        let request = Request<VIMUser>.getMeRequest()
+        self.send(request: request, withDescription: "expectation for validating trial flag is set") { user in
+            XCTAssertTrue(user!.hasBeenInFreeTrial())
+        }
+    }
+    
+    func testUserHasBeenInTrialFlag_NotSet() {
+        self.stubResponse(for: TestConstants.MeUri, withFile: "user_basic.json")
+        let request = Request<VIMUser>.getMeRequest()
+        self.send(request: request, withDescription: "expectation for validating trial flag is not set") { user in
+            XCTAssertFalse(user!.hasBeenInFreeTrial())
+        }
+    }
+    
+    func testMembershipDisplayValue() {
+        self.stubResponse(for: TestConstants.MeUri, withFile: "user_pro.json")
+        let request = Request<VIMUser>.getMeRequest()
+        self.send(request: request, withDescription: "expectation for validating membership display") { user in
+            XCTAssertEqual(user?.membership?.display, "Pro")
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_alum.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_alum.json
@@ -1,10 +1,18 @@
 {
     "uri": "mock_uri",
-    "account": "basic",
-    "badge": {
-        "type": "alum",
-        "text": "Alum",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+    "membership": {
+        "type": "basic",
+        "display": "Basic",
+        "badge": {
+            "type": "alum",
+            "text": "Alum",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_basic.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_basic.json
@@ -1,10 +1,18 @@
 {
     "uri": "mock_uri",
-    "account": "basic",
-    "badge": {
+    "membership": {
         "type": "basic",
-        "text": "Basic",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Basic",
+        "badge": {
+            "type": "basic",
+            "text": "Basic",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_basic_had_free_trial.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_basic_had_free_trial.json
@@ -4,14 +4,14 @@
         "type": "basic",
         "display": "Basic",
         "badge": {
-            "type": "support",
-            "text": "Support",
+            "type": "basic",
+            "text": "Basic",
             "alt_text": "mock_alt_text",
             "url": "mock_url"
         },
         "subscription": {
             "trial": {
-                "has_been_in_free_trial": false
+                "has_been_in_free_trial": true
             }
         }
     }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_business.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_business.json
@@ -1,10 +1,22 @@
 {
-    "uri": "mock_uri",
-    "account": "business",
-    "badge": {
+    "uri": "mock_uri",    
+    "membership": {
         "type": "business",
-        "text": "Business",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Business",
+        "badge": {
+            "type": "business",
+            "text": "Business",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_curation.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_curation.json
@@ -1,10 +1,18 @@
 {
-    "uri": "mock_uri",
-    "account": "basic",
-    "badge": {
-        "type": "curation",
-        "text": "Curation",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+    "uri": "mock_uri",    
+    "membership": {
+        "type": "basic",
+        "display": "Basic",
+        "badge": {
+            "type": "curation",
+            "text": "Curation",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_live_business.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_live_business.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "live_business",
-    "badge": {
+    "membership": {
         "type": "live_business",
-        "text": "Live Business",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Live Business",
+        "badge": {
+            "type": "live_business",
+            "text": "Live Business",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_live_premium.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_live_premium.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "live_premium",
-    "badge": {
+    "membership": {
         "type": "live_premium",
-        "text": "Live Premium",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Live Premium",
+        "badge": {
+            "type": "live_premium",
+            "text": "Live Premium",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_live_pro.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_live_pro.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "live_pro",
-    "badge": {
+    "membership": {
         "type": "live_pro",
-        "text": "Live Pro",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Live Pro",
+        "badge": {
+            "type": "live_pro",
+            "text": "Live Pro",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_plus.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_plus.json
@@ -1,11 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "plus",
-    "badge": {
+    "membership": {
         "type": "plus",
-        "text": "Plus",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Plus",
+        "badge": {
+            "type": "plus",
+            "text": "Plus",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }
-

--- a/VimeoNetworkingExample-iOS/VIMUser/user_pro.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_pro.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "pro",
-    "badge": {
+    "membership": {
         "type": "pro",
-        "text": "Pro",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Pro",
+        "badge": {
+            "type": "pro",
+            "text": "Pro",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_pro_unlimited.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_pro_unlimited.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "pro_unlimited",
-    "badge": {
+    "membership": {
         "type": "pro_unlimited",
-        "text": "Pro Unlimited",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Pro Unlimited",
+        "badge": {
+            "type": "pro_unlimited",
+            "text": "Pro Unlimited",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_producer.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_producer.json
@@ -1,10 +1,22 @@
 {
     "uri": "mock_uri",
-    "account": "producer",
-    "badge": {
+    "membership": {
         "type": "producer",
-        "text": "Producer",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+        "display": "Producer",
+        "badge": {
+            "type": "producer",
+            "text": "Producer",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VIMUser/user_staff.json
+++ b/VimeoNetworkingExample-iOS/VIMUser/user_staff.json
@@ -1,10 +1,18 @@
 {
     "uri": "mock_uri",
-    "account": "basic",
-    "badge": {
-        "type": "staff",
-        "text": "Staff",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
+    "membership": {
+        "type": "basic",
+        "display": "Basic",
+        "badge": {
+            "type": "staff",
+            "text": "Staff",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
     }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOS.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		3C1F8E061F14397A00A062D3 /* VIMQuantityQuota+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F8E041F14397A00A062D3 /* VIMQuantityQuota+Tests.swift */; };
 		3C1F8E081F151B8E00A062D3 /* VIMUploadQuota+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F8E071F151B8E00A062D3 /* VIMUploadQuota+Tests.swift */; };
 		3C1F8E091F151B8E00A062D3 /* VIMUploadQuota+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F8E071F151B8E00A062D3 /* VIMUploadQuota+Tests.swift */; };
+		3C325ABE21C141C800F88BDB /* user_basic_had_free_trial.json in Resources */ = {isa = PBXBuildFile; fileRef = 3CBB8E2321C0287D00092D24 /* user_basic_had_free_trial.json */; };
+		3C325ABF21C141C900F88BDB /* user_basic_had_free_trial.json in Resources */ = {isa = PBXBuildFile; fileRef = 3CBB8E2321C0287D00092D24 /* user_basic_had_free_trial.json */; };
 		3C6F88841D999878006A24F4 /* programmed_cinema.json in Resources */ = {isa = PBXBuildFile; fileRef = 3C6F88821D999878006A24F4 /* programmed_cinema.json */; };
 		3C6F88851D999878006A24F4 /* FakeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6F88831D999878006A24F4 /* FakeDataSource.swift */; };
 		3CAE6FC61EC671540016EF6C /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAE6FC51EC671540016EF6C /* RequestTests.swift */; };
@@ -138,6 +140,7 @@
 		3C6F88821D999878006A24F4 /* programmed_cinema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = programmed_cinema.json; sourceTree = "<group>"; };
 		3C6F88831D999878006A24F4 /* FakeDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeDataSource.swift; sourceTree = "<group>"; };
 		3CAE6FC51EC671540016EF6C /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestTests.swift; path = VimeoNetworkingCommonTests/RequestTests.swift; sourceTree = "<group>"; };
+		3CBB8E2321C0287D00092D24 /* user_basic_had_free_trial.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = user_basic_had_free_trial.json; sourceTree = "<group>"; };
 		3CE06F991ED30D80007A1AFE /* Dictionary+ExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Dictionary+ExtensionTests.swift"; path = "VimeoNetworkingCommonTests/Dictionary+ExtensionTests.swift"; sourceTree = "<group>"; };
 		3CE06F9C1ED31200007A1AFE /* ExceptionCatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExceptionCatcherTests.swift; path = VimeoNetworkingCommonTests/ExceptionCatcherTests.swift; sourceTree = "<group>"; };
 		3CE06F9F1ED3AE5F007A1AFE /* ResponseCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResponseCacheTests.swift; path = VimeoNetworkingCommonTests/ResponseCacheTests.swift; sourceTree = "<group>"; };
@@ -355,6 +358,7 @@
 			children = (
 				8EDE2D871FE05B7500143E95 /* user_alum.json */,
 				8EDE2D771FE0203300143E95 /* user_basic.json */,
+				3CBB8E2321C0287D00092D24 /* user_basic_had_free_trial.json */,
 				8EDE2D7D1FE0214E00143E95 /* user_business.json */,
 				8EDE2D831FE05AA900143E95 /* user_curation.json */,
 				8EDE2D751FDF474B00143E95 /* user_live_business.json */,
@@ -606,6 +610,7 @@
 				BE2D774420FE2FF700B27C24 /* user_producer.json in Resources */,
 				8EDE2D7E1FE0214E00143E95 /* user_business.json in Resources */,
 				3C0DCFCC1ECB25FC00960774 /* categories-animation-response.json in Resources */,
+				3C325ABE21C141C800F88BDB /* user_basic_had_free_trial.json in Resources */,
 				8E5997032058280900A4A83C /* user_live_premium.json in Resources */,
 				8EDE2D821FE05A2500143E95 /* user_staff.json in Resources */,
 				8EDE2D841FE05AA900143E95 /* user_curation.json in Resources */,
@@ -631,6 +636,7 @@
 				8E5997042058280900A4A83C /* user_live_premium.json in Resources */,
 				BE2D774720FE2FFC00B27C24 /* user_pro_unlimited.json in Resources */,
 				3C0DCFCD1ECB25FC00960774 /* categories-animation-response.json in Resources */,
+				3C325ABF21C141C900F88BDB /* user_basic_had_free_trial.json in Resources */,
 				3C1F8E001EFC304000A062D3 /* cinema-success-response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/user_live.json
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingExample-iOSTests/user_live.json
@@ -5,7 +5,25 @@
     "location": "New York",
     "bio": "mock_bio",
     "created_time": "mock_created_time",
-    "account": "basic",
+    "membership": {
+        "type": "basic",
+        "display": "Basic",
+        "badge": {
+            "type": "staff",
+            "text": "Staff",
+            "alt_text": "mock_alt_text",
+            "url": "mock_url"
+        },
+        "subscription": {
+            "renewal": {
+                "display_date": "2019-06-12",
+                "renewal_date": "2019-06-12T04:00:00+00:00"
+            },
+            "trial": {
+                "has_been_in_free_trial": false
+            }
+        }
+    },
     "pictures": {
         "uri": "mock_uri",
         "active": true,
@@ -155,12 +173,6 @@
                 "total": 0
             }
         }
-    },
-    "badge": {
-        "type": "staff",
-        "text": "Staff",
-        "alt_text": "mock_alt_text",
-        "url": "mock_url"
     },
     "preferences": {
         "videos": {


### PR DESCRIPTION
#### Ticket

[AF-322](https://vimean.atlassian.net/browse/AF-322)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR updates the VIMUser object to represent the data returned by the Vimeo API version 3.4.2.  This includes adding a new Membership object which contains information about the user's badge, account type, and subscription status, as well as removing deprecated properties like account and badge from the root of the VIMUser object.  I've also updated a few files that were missing our license information.

#### Implementation Summary

UserMembership.swift
- A new class that represents the account and membership information for a user. 
- Added a property for VIMUserBadge which replaces the VIMUser.badge property
- Added a type property which replaces the VIMUser.account property
- Added a UserSubscription object which holds information about the user's subscription status

UserSubscription.swift
- A new class that holds the subscription information for a user including auto-renewal dates and free trial info.

UserSubscriptionRenewal.swift
- A class that holds information about the auto-renewal date for the logged in user
- adds displayDate property which holds a date in YYYY-MM-DD format that can be used in UI displays
- adds renewalDate which is a Date object that represents the auto-renewal date.

UserSubscriptionTrial.swift
- A class that holds information about a user's free trial
- Adds a status property that will be set to "free_trial" if the user is currently in a free trial, otherwise this property will be nil.
- Adds a hasBeenInFreeTrial property which will be set to true if the user has ever been in a trial.

VIMUser.h / VIMUser.m
- Commented out and marked account and badge properties as deprecated.
- added a convenience method for getting whether or not a user has had a free trial
- added a property for the new UserMembership class
- updated the code to switch from using deprecated properties to using the UserMembership class.

Other
- Updated unit tests / test data

#### How to Test

- Make sure unit tests continue to pass