### PR TITLE
VIM-6817: Adds migration code to VIMUser object to update membership info

### DIFF
--- a/VimeoNetworking/Sources/Models/UserMembership.swift
+++ b/VimeoNetworking/Sources/Models/UserMembership.swift
@@ -28,18 +28,18 @@
 public class UserMembership: VIMModelObject {
     
     /// Object describing the visual badge to display to indicate the user's account type.
-    @objc dynamic public internal(set) var badge: VIMUserBadge?
+    @objc dynamic public var badge: VIMUserBadge?
     
     /// A non-localized string representation of the user's account type that can be used for display purposes.
-    @objc dynamic public internal(set) var display: String?
+    @objc dynamic public var display: String?
 
     /// An object containing information about the user's subscription status.  This information will only be available for the current logged in user.
     /// - remark: This information is only available for the current logged in user.
-    @objc dynamic public internal(set) var subscription: UserSubscription?
+    @objc dynamic public var subscription: UserSubscription?
     
     /// A string representation of the user's account type.  This value should not be used for display purposes, use the **display** property instead.
     /// - remark: This property replaces the VIMUser.account property.
-    @objc dynamic public internal(set) var type: String?
+    @objc dynamic public var type: String?
     
     public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "badge" {

--- a/VimeoNetworking/Sources/Models/UserMembership.swift
+++ b/VimeoNetworking/Sources/Models/UserMembership.swift
@@ -28,18 +28,18 @@
 public class UserMembership: VIMModelObject {
     
     /// Object describing the visual badge to display to indicate the user's account type.
-    @objc dynamic public private(set) var badge: VIMUserBadge?
+    @objc dynamic public internal(set) var badge: VIMUserBadge?
     
     /// A non-localized string representation of the user's account type that can be used for display purposes.
-    @objc dynamic public private(set) var display: String?
+    @objc dynamic public internal(set) var display: String?
 
     /// An object containing information about the user's subscription status.  This information will only be available for the current logged in user.
     /// - remark: This information is only available for the current logged in user.
-    @objc dynamic public private(set) var subscription: UserSubscription?
+    @objc dynamic public internal(set) var subscription: UserSubscription?
     
     /// A string representation of the user's account type.  This value should not be used for display purposes, use the **display** property instead.
     /// - remark: This property replaces the VIMUser.account property.
-    @objc dynamic public private(set) var type: String?
+    @objc dynamic public internal(set) var type: String?
     
     public override func getClassForObjectKey(_ key: String!) -> AnyClass? {
         if key == "badge" {

--- a/VimeoNetworking/Sources/Models/VIMModelObject.h
+++ b/VimeoNetworking/Sources/Models/VIMModelObject.h
@@ -45,7 +45,7 @@ extern NSInteger const VIMModelObjectValidationErrorCode;
 
 - (NSDictionary *)keyValueDictionary;
 
-- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion;
+- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion withCoder:(NSCoder *)aDecoder;
 
 - (void)validateModel:(NSError **)error;
 

--- a/VimeoNetworking/Sources/Models/VIMModelObject.m
+++ b/VimeoNetworking/Sources/Models/VIMModelObject.m
@@ -28,7 +28,14 @@
 
 #import <objc/runtime.h>
 
-static NSUInteger const VIMModelObjectVersion = 3;
+/*
+ Model Changelog
+ 
+ Version 4: Updated VIMUser object based on API version 3.4.2
+    - Removes user badge & account string from root level of VIMUser object
+    - Adds UserMembership object which now holds badge & account info along with new subscription info
+ */
+static NSUInteger const VIMModelObjectVersion = 4;
 
 NSString *const VIMModelObjectErrorDomain = @"VIMModelObjectErrorDomain";
 NSString *const VIMConnectionKey = @"connections";
@@ -135,7 +142,9 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
     {
         if (modelVersion.unsignedIntegerValue < self.class.modelVersion)
         {
-            [self upgradeFromModelVersion:modelVersion.unsignedIntegerValue toModelVersion:self.class.modelVersion];
+            [self upgradeFromModelVersion: modelVersion.unsignedIntegerValue
+                           toModelVersion: self.class.modelVersion
+                                withCoder: aDecoder];
         }
     }
 	
@@ -156,7 +165,7 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
 	}];
 }
 
-- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion
+- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion withCoder:(NSCoder *)aDecoder
 {
     // Override in subclasses
 }

--- a/VimeoNetworking/Sources/Models/VIMVODItem.m
+++ b/VimeoNetworking/Sources/Models/VIMVODItem.m
@@ -167,7 +167,7 @@
 
 // This is only called for unarchived model objects [AH]
 
-- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion
+- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion withCoder:(NSCoder *)aDecoder
 {
     if (fromVersion == 2 && toVersion == 3)
     {

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -213,7 +213,7 @@ NSString *VIMContentRating_Safe = @"safe";
 
 // This is only called for unarchived model objects [AH]
 
-- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion
+- (void)upgradeFromModelVersion:(NSUInteger)fromVersion toModelVersion:(NSUInteger)toVersion withCoder:(NSCoder *)aDecoder
 {
     if (fromVersion == 2 && toVersion == 3)
     {


### PR DESCRIPTION
#### Ticket

[VIM-6817](https://vimean.atlassian.net/browse/VIM-6817)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

A crash was found in Vimeo iOS due to a lack of migration code from the previous VIMUser object which contained the VIMUserBadge object and a NSString property called "account" in the root of the object to the current object which has a UserMembership object that nests the badge and account info.  This problem occurred when we attempted to read a serialized user object from disk and decoded it using NSCoder. 

#### Implementation Summary

VIMModelObject.h
- Updated the declaration for upgradeFromModelVersion to include the NSCoder object being used to deserialize the object.  This is needed if we're attempting to read in information from the stored object that no longer exists in the current model.

VIMModelObject.m
- Added a changelog comment section for the VIMModelObjectVersion constant so we can track why model version numbers have been bumped.
- Updated definition for upgradeFromModelVersion and made sure we're passing the aDecoder parameter along.

VIMUser.m
- Added a new updateMembershipInfo method which handles the migration from previous model versions to version 4.

UserMembership.swift
- Had to update the setter for the properties from private to internal so we can set them from VIMUser.m when we re-create this object during a migration.

VIMVodItem & VIMVideo
- Updated definition for upgradeFromModelVersion method.

#### How to Test

- Needs to be tested from the Vimeo-iOS PR.