### PR TITLE
VIM-6828: Add free trial copy to purchase flow UI

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMUser.m
+++ b/VimeoNetworking/Sources/Models/VIMUser.m
@@ -382,13 +382,19 @@ static NSString *const Producer = @"producer";
 
 - (BOOL)hasBeenInFreeTrial
 {
-    if([self.membership.subscription.trial.hasBeenInFreeTrial respondsToSelector: @selector(boolValue)] == NO)
+    if (@available(iOS 11.2, *))
     {
-        NSAssert(NO, @"hasBeenInFreeTrial is expected to be an NSNumber and should respond to boolValue!");
-        return NO;
+        if ([self.membership.subscription.trial.hasBeenInFreeTrial respondsToSelector: @selector(boolValue)] == NO)
+        {
+            NSAssert(NO, @"hasBeenInFreeTrial is expected to be an NSNumber and should respond to boolValue!");
+            return NO;
+        }
+        return self.membership.subscription.trial.hasBeenInFreeTrial.boolValue;
     }
-    
-    return self.membership.subscription.trial.hasBeenInFreeTrial.boolValue;
+    else
+    {
+        return true;
+    }
 }
 
 @end


### PR DESCRIPTION
#### Ticket

[VIM-6828](https://vimean.atlassian.net/browse/VIM-6828)


#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Display the free trial UI to eligible users in the upgrade flow.

#### Implementation Summary

- Add an availability check so that users before iOS 11.2 will not be considered eligible for the free trial.

#### Reviewer Tips

#### How to Test
