### PR TITLE
VIM-XXXX: Add Method to Check If There's File Transfer Page

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -171,6 +171,15 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (void)setIsLiked:(BOOL)isLiked;
 - (void)setIsWatchLater:(BOOL)isWatchLater;
 - (BOOL)hasReviewPage;
+/**
+ Determines if the video has a file transfer page. A video has a file
+ transfer page if @p canDownload privacy is @p true and there is a
+ @p file_transfer response.
+ 
+ 
+ @return @p true if the video has a file transfer page.
+ */
+- (BOOL)hasVideoTransferPage;
 - (BOOL)canDownloadFromDesktop;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -179,7 +179,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
  
  @return @p true if the video has a file transfer page.
  */
-- (BOOL)hasVideoTransferPage;
+- (BOOL)hasFileTransferPage;
 - (BOOL)canDownloadFromDesktop;
 
 @end

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -572,7 +572,7 @@ NSString *VIMContentRating_Safe = @"safe";
     return false;
 }
 
-- (BOOL)hasVideoTransferPage
+- (BOOL)hasFileTransferPage
 {
     return self.fileTransfer != nil && self.fileTransfer.url != nil && [self canDownloadFromDesktop] == YES;
 }

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -572,4 +572,9 @@ NSString *VIMContentRating_Safe = @"safe";
     return false;
 }
 
+- (BOOL)hasVideoTransferPage
+{
+    return self.fileTransfer != nil && self.fileTransfer.url != nil && [self canDownloadFromDesktop] == YES;
+}
+
 @end


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR adds a method to check if there's a file transfer page.

#### Implementation Summary

The implementation of this method checks:
- If `fileTransfer` response is `nil`.
- If the URL inside the response exists.
- If `canDownload` privacy setting is enabled.

#### Reviewer Tips

N/A

#### How to Test

N/A
