### PR TITLE
VIM-6694: Moving outdated PR to a new branch after a bad rebase attempt

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMObjectMapper.m
+++ b/VimeoNetworking/Sources/Models/VIMObjectMapper.m
@@ -317,7 +317,15 @@
 				
 				for (id jsonArrayItem in jsonArray)
                 {
-                    [resultArray addObject:[self _createObjectsFromJSON:jsonArrayItem keypath:keypath mappingClass:jsonClass]];
+                    id object = [self _createObjectsFromJSON:jsonArrayItem keypath:keypath mappingClass:jsonClass];
+                    if (object != nil)
+                    {
+                        [resultArray addObject:object];
+                    }
+                    else
+                    {
+                        NSLog(@"Error: The object resulting from `_createObjectsFromJSON:` is nil.");
+                    }
                 }
 				
 				result = resultArray;

--- a/VimeoNetworking/Sources/Models/VIMObjectMapper.m
+++ b/VimeoNetworking/Sources/Models/VIMObjectMapper.m
@@ -318,13 +318,11 @@
 				for (id jsonArrayItem in jsonArray)
                 {
                     id object = [self _createObjectsFromJSON:jsonArrayItem keypath:keypath mappingClass:jsonClass];
+                    NSAssert(object != nil, @"Error: The object resulting from `_createObjectsFromJSON:` is nil.");
+                    
                     if (object != nil)
                     {
                         [resultArray addObject:object];
-                    }
-                    else
-                    {
-                        NSLog(@"Error: The object resulting from `_createObjectsFromJSON:` is nil.");
                     }
                 }
 				
@@ -337,7 +335,7 @@
         }
         else
         {
-			NSLog(@"_createObjectsFromJSON: Encountered an unknown object type '%@' in JSON", [JSON class]);
+            NSAssert(NO, @"_createObjectsFromJSON: Encountered an unknown object type '%@' in JSON", [JSON class]);
         }
     }
     


### PR DESCRIPTION
#### Ticket

[VIM-6694](https://vimean.atlassian.net/browse/VIM-6694)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This branch moves the changes from this PR (https://github.com/vimeo/VimeoNetworking/pull/282) into a new branch from develop.  The old PR branch had a bad rebase on it which is making the diff look weird.  The only change that should be coming back to develop is the check for nil before adding an object into an array in VIMObjectMapper.  I changed the code from using NSLogs to NSAsserts, which was my feedback on the last PR. 

#### Implementation Summary

- Adds a nil check before attempting to add an object into an NSArray
- Replaces NSLog usage with NSAssert.

#### How to Test

- make sure unit tests continue to pass
