### PR TITLE
Added video_files scope as .VideoFiles to Scope enum in Scope.swift

### DIFF
--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -55,6 +55,9 @@ public enum Scope: String {
     /// Receive live-related statistics.
     case Stats = "stats"
     
+    /// Receive video files of the video.
+    case VideoFiles = "video_files"
+    
     /**
      Combines an array of scopes into a scope string as expected by the api
      


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced

#### Issue Summary

Now users can request the videos files with the video_files scope.

#### Implementation Summary

Added video_files scope as .VideoFiles to Scope enum in Scope.swift.

#### Reviewer Tips

Only the Scope.swift file was changed.

```
    /// Receive video files of the video.
    case VideoFiles = "video_files"
```

#### How to Test

Just try to use the Scope.VideoFiles, to access the needed videos files URLs like:

```
appConfiguration = AppConfiguration(
            clientIdentifier: "[CLIENT_IDENTIFIER]",
            clientSecret: "[CLIENT_SECRET],
            scopes: [.Public, .VideoFiles],
            keychainService: "[KEYCHAIN_SERVICE]")
```
`...`
```
let videoRequest = Request<VIMVideo>(path: "/me/videos/[VIDEO_ID]"))
vimeoClient.request(videoRequest) { result in
            switch result
            {
            case .success(let response):
                let video: VIMVideo = response.model
                print("retrieved video: \(video)")
                if let files = video.files as? [VIMVideoFile] {
                    print("retrieving video with files:  \(files)")
                }
            case .failure(let error):
                print("error retrieving video: \(error)")
            }
        }
```