### PR TITLE
VIM-6642: Creates generalized method for creating password-protected requests

### DIFF
--- a/VimeoNetworking/Sources/Request+Album.swift
+++ b/VimeoNetworking/Sources/Request+Album.swift
@@ -29,13 +29,28 @@ public typealias AlbumRequest = Request<Album>
 /// `Request` that returns an array of `Album` objects.
 public typealias AlbumListRequest = Request<[Album]>
 
+fileprivate struct Constants {
+    static let PasswordKey = "password"
+}
+
 public extension Request {
     
-    /// Create a new request to get a specific album.
+    /// Returns a new request to fetch a specific album.
     ///
     /// - Parameter albumURI: The album's URI.
-    /// - Returns: A new `Request`.
+    /// - Returns: Returns a new `Request` for an individual album.
     public static func getAlbumRequest(forAlbumURI albumURI: String) -> Request {
         return Request(path: albumURI)
+    }
+    
+    /// Returns a new request to fetch a password protected album.
+    ///
+    /// - Parameters:
+    ///   - albumURI: The password protected album's URI.
+    ///   - password: The password used to attempt to unlock the album.
+    /// - Returns: Returns a new `Request` for a password protected album.
+    public static func getPasswordProtectedAlbumRequest(forAlbumURI albumURI: String, password: String) -> Request {
+        let parameters = [Constants.PasswordKey: password]
+        return Request(path: albumURI, parameters: parameters)
     }
 }

--- a/VimeoNetworking/Sources/Request+Album.swift
+++ b/VimeoNetworking/Sources/Request+Album.swift
@@ -29,10 +29,6 @@ public typealias AlbumRequest = Request<Album>
 /// `Request` that returns an array of `Album` objects.
 public typealias AlbumListRequest = Request<[Album]>
 
-fileprivate struct Constants {
-    static let PasswordKey = "password"
-}
-
 public extension Request {
     
     /// Returns a new request to fetch a specific album.

--- a/VimeoNetworking/Sources/Request+Album.swift
+++ b/VimeoNetworking/Sources/Request+Album.swift
@@ -37,20 +37,9 @@ public extension Request {
     
     /// Returns a new request to fetch a specific album.
     ///
-    /// - Parameter albumURI: The album's URI.
+    /// - Parameter uri: The album's URI.
     /// - Returns: Returns a new `Request` for an individual album.
-    public static func getAlbumRequest(forAlbumURI albumURI: String) -> Request {
-        return Request(path: albumURI)
-    }
-    
-    /// Returns a new request to fetch a password protected album.
-    ///
-    /// - Parameters:
-    ///   - albumURI: The password protected album's URI.
-    ///   - password: The password used to attempt to unlock the album.
-    /// - Returns: Returns a new `Request` for a password protected album.
-    public static func getPasswordProtectedAlbumRequest(forAlbumURI albumURI: String, password: String) -> Request {
-        let parameters = [Constants.PasswordKey: password]
-        return Request(path: albumURI, parameters: parameters)
+    public static func albumRequest(for uri: String) -> Request {
+        return Request(path: uri)
     }
 }

--- a/VimeoNetworking/Sources/Request+PasswordProtected.swift
+++ b/VimeoNetworking/Sources/Request+PasswordProtected.swift
@@ -23,6 +23,10 @@
 //  THE SOFTWARE.
 //
 
+fileprivate struct Constants {
+    static let PasswordKey = "password"
+}
+
 extension Request {
     
     /// Returns a new request for a password-protected item, such as a video or an album.
@@ -32,7 +36,7 @@ extension Request {
     ///   - password: The password for the item that will be sent to the server.
     /// - Returns: Returns a `Request` for a password-protected item.
     public static func passwordProtectedRequest(for uri: String, password: String) -> Request {
-        let parameters = ["password": password]
+        let parameters = [Constants.PasswordKey: password]
         return Request(path: uri, parameters: parameters)
     }
 }

--- a/VimeoNetworking/Sources/Request+PasswordProtected.swift
+++ b/VimeoNetworking/Sources/Request+PasswordProtected.swift
@@ -2,6 +2,26 @@
 //  Request+PasswordProtected.swift
 //  VimeoNetworking
 //
+//  Copyright (c) 2019 Vimeo (https://vimeo.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 extension Request {
     

--- a/VimeoNetworking/Sources/Request+PasswordProtected.swift
+++ b/VimeoNetworking/Sources/Request+PasswordProtected.swift
@@ -1,0 +1,18 @@
+//
+//  Request+PasswordProtected.swift
+//  VimeoNetworking
+//
+
+extension Request {
+    
+    /// Returns a new request for a password-protected item, such as a video or an album.
+    ///
+    /// - Parameters:
+    ///   - uri: The URI for the item.
+    ///   - password: The password for the item that will be sent to the server.
+    /// - Returns: Returns a `Request` for a password-protected item.
+    public static func passwordProtectedRequest(for uri: String, password: String) -> Request {
+        let parameters = ["password": password]
+        return Request(path: uri, parameters: parameters)
+    }
+}

--- a/VimeoNetworking/Sources/Request+Video.swift
+++ b/VimeoNetworking/Sources/Request+Video.swift
@@ -53,20 +53,6 @@ public extension Request {
     }
     
     /**
-     Create a `Request` to get a password protected video
-     
-     - parameter videoURI: the URI of the video
-     - parameter password: the password for the video
-     
-     - returns: a new `Request`
-     */
-    static func passwordProtectedVideoRequest(forVideoURI videoURI: String, password: String) -> Request {
-        let parameters = ["password": password]
-        
-        return Request(path: videoURI, parameters: parameters)
-    }
-    
-    /**
      Create a `Request` to get a specific VOD video
      
      - parameter vodVideoURI: the VOD video's URI


### PR DESCRIPTION
### Ticket
[VIM-6642](https://vimean.atlassian.net/browse/VIM-6642)

### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Add support for access password-protected albums.

### Implementation Summary
**Request+PasswordProtected.swift**: 
Created a new extension on `Request` to return a request object for both `VIMVideo` and `Album` requests that require sending a password for access.

**Request+Album.swift**: 
Update the API and documentation for that static `albumRequest(for uri: String)` method.

### How to Test
n/a