### PR TITLE
VIM-6849: Adds support for identifying stock videos

### DIFF
--- a/VimeoNetworking/Sources/Models/VIMPrivacy.h
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.h
@@ -34,6 +34,7 @@ extern NSString * __nonnull VIMPrivacy_Following;
 extern NSString * __nonnull VIMPrivacy_Password;
 extern NSString * __nonnull VIMPrivacy_Unlisted;
 extern NSString * __nonnull VIMPrivacy_Disabled;
+extern NSString * __nonnull VIMPrivacy_Stock;
 
 @interface VIMPrivacy : VIMModelObject
 

--- a/VimeoNetworking/Sources/Models/VIMPrivacy.m
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.m
@@ -34,6 +34,7 @@ NSString *VIMPrivacy_Following = @"contacts";
 NSString *VIMPrivacy_Password = @"password";
 NSString *VIMPrivacy_Unlisted = @"unlisted";
 NSString *VIMPrivacy_Disabled = @"disable";
+NSString *VIMPrivacy_Stock = @"stock";
 
 @implementation VIMPrivacy
 

--- a/VimeoNetworking/Sources/Models/VIMVideo.h
+++ b/VimeoNetworking/Sources/Models/VIMVideo.h
@@ -109,6 +109,7 @@ typedef NS_ENUM(NSUInteger, VIMVideoProcessingStatus) {
 - (BOOL)isAvailable;
 - (BOOL)isTranscoding;
 - (BOOL)isUploading;
+- (BOOL)isStock;
 
 - (BOOL)isLiked;
 - (BOOL)isWatchLater;

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -386,7 +386,7 @@ NSString *VIMContentRating_Safe = @"safe";
 - (BOOL)isPrivate
 {
     NSString *privacy = self.privacy.view;
-    return ![privacy isEqualToString:VIMPrivacy_Public] && ![privacy isEqualToString:VIMPrivacy_VOD];
+    return ![privacy isEqualToString:VIMPrivacy_Public] && ![privacy isEqualToString:VIMPrivacy_VOD] && ![privacy isEqualToString:VIMPrivacy_Stock];
 }
 
 - (BOOL)isAvailable

--- a/VimeoNetworking/Sources/Models/VIMVideo.m
+++ b/VimeoNetworking/Sources/Models/VIMVideo.m
@@ -404,6 +404,12 @@ NSString *VIMContentRating_Safe = @"safe";
     return self.videoStatus == VIMVideoProcessingStatusUploading;
 }
 
+- (BOOL)isStock
+{
+    NSString *privacy = self.privacy.view;
+    return [privacy isEqualToString:VIMPrivacy_Stock];
+}
+
 // New
 
 - (void)setIsLiked:(BOOL)isLiked

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -189,4 +189,22 @@ class VIMVideoTests: XCTestCase
         let canDownload = testVideoObject.canDownloadFromDesktop()
         XCTAssertFalse(canDownload, "canDownloadFromDesktop unexpectedly returns true")
     }
+    
+    func test_isStock_returnsTrue_whenPrivacyViewIsStock()
+    {
+        let privacyDictionary: [String: Any] = ["view": "stock"]
+        let privacy = VIMPrivacy(keyValueDictionary: privacyDictionary)!
+        let videoDictionary: [String: Any] = ["privacy": privacy as Any]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        XCTAssertTrue(testVideoObject.isStock(), "Test video object was stock but unexpectedly returned false.")
+    }
+    
+    func test_isStock_returnsFalse_whenPrivacyViewIsNotStock()
+    {
+        let privacyDictionary: [String: Any] = ["view": "unlisted"]
+        let privacy = VIMPrivacy(keyValueDictionary: privacyDictionary)!
+        let videoDictionary: [String: Any] = ["privacy": privacy as Any]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        XCTAssertFalse(testVideoObject.isStock(), "Test video object was not stock but unexpectedly returned true.")
+    }
 }

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/VIMVideoTests.swift
@@ -207,4 +207,13 @@ class VIMVideoTests: XCTestCase
         let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
         XCTAssertFalse(testVideoObject.isStock(), "Test video object was not stock but unexpectedly returned true.")
     }
+    
+    func test_isPrivate_returnsFalse_whenPrivacyViewIsStock()
+    {
+        let privacyDictionary: [String: Any] = ["view": "stock"]
+        let privacy = VIMPrivacy(keyValueDictionary: privacyDictionary)!
+        let videoDictionary: [String: Any] = ["privacy": privacy as Any]
+        let testVideoObject = VIMVideo(keyValueDictionary: videoDictionary)!
+        XCTAssertFalse(testVideoObject.isPrivate(), "Test video object is stock and should not return as private.")
+    }
 }


### PR DESCRIPTION
### Ticket
[VIM-6849](https://vimean.atlassian.net/browse/VIM-6849)

### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Add support for allowing `VIMVideo` objects to report whether or not they represent a stock video clip.

### Implementation Summary
**VIMPrivacy**:
Added a new string to the existing privacy options.

**VIMVideo**:
Added a convenience method to return whether a video is stock or not. Also updated the `isPrivate()` method to ensure that stock videos are not considered private.

### How to Test
Build and run the example project, ensure tests pass.