### PR TITLE
Adds the VideoFiles and PromoCodes scopes, updates documentation

### DIFF
--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -54,6 +54,7 @@ public enum Scope: String {
     
     /// Receive live-related statistics.
     case Stats = "stats"
+    case VideoFiles = "video_files"
     
     /**
      Combines an array of scopes into a scope string as expected by the api

--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -40,8 +40,8 @@
 /// - Stats: Receive live-related statistics.
 /// - VideoFiles: Access video files belonging to members with Vimeo PRO membership or higher.
 ///
-/// - Note: An authenticated access token with the `publi`c scope is identical to an unauthenticated access token,
-///         except that you can use the /me endpoint to refer to the currently logged-in user. Accessing /me with
+/// - Note: An authenticated access token with the `public` scope is identical to an unauthenticated access token,
+///         except that you can use the `/me` endpoint to refer to the currently logged-in user. Accessing `/me` with
 ///         an unauthenticated access token generates an error.
 public enum Scope: String, CaseIterable {
     case Public = "public"

--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -38,6 +38,7 @@
 /// - Interact: Interact with Vimeo resources, such as liking a video or following a member.
 /// - Upload: Upload videos.
 /// - Stats: Receive live-related statistics.
+/// - PromoCodes: Add, remove, and review Vimeo On Demand promotions.
 /// - VideoFiles: Access video files belonging to members with Vimeo PRO membership or higher.
 ///
 /// - Note: An authenticated access token with the `public` scope is identical to an unauthenticated access token,
@@ -53,6 +54,7 @@ public enum Scope: String, CaseIterable {
     case Interact = "interact"
     case Upload = "upload"
     case Stats = "stats"
+    case PromoCodes = "promo_codes"
     case VideoFiles = "video_files"
     
     /// Combines an array of scopes into a scope string as expected by the API.

--- a/VimeoNetworking/Sources/Scope.swift
+++ b/VimeoNetworking/Sources/Scope.swift
@@ -24,45 +24,41 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
-
-/// `Scope` describes a permission that your application requests from the API
-public enum Scope: String {
-    /// View public videos
+/// An access token has one or more scopes, or general domains. The scopes determine the types of access that token
+/// does and doesn't permit. During the authentication process, you can specify exactly which scopes your app needs
+/// based on the cases below. If you try to make an API request with an access token that doesn't have the right scope,
+/// the API will deny the request.
+///
+/// - Public: Access public member data.
+/// - Private: Access private member data. Required for any scope other than public.
+/// - Purchased: Access a member's Vimeo On Demand purchase history.
+/// - Create: Create new Vimeo resources like albums, groups, channels, and portfolios. To create new videos, you need the upload scope.
+/// - Edit: Edit existing Vimeo resources, including videos.
+/// - Delete: Delete existing Vimeo resources, including videos.
+/// - Interact: Interact with Vimeo resources, such as liking a video or following a member.
+/// - Upload: Upload videos.
+/// - Stats: Receive live-related statistics.
+/// - VideoFiles: Access video files belonging to members with Vimeo PRO membership or higher.
+///
+/// - Note: An authenticated access token with the `publi`c scope is identical to an unauthenticated access token,
+///         except that you can use the /me endpoint to refer to the currently logged-in user. Accessing /me with
+///         an unauthenticated access token generates an error.
+public enum Scope: String, CaseIterable {
     case Public = "public"
-    
-    /// View private videos
     case Private = "private"
-    
-    /// View Vimeo On Demand purchase history
     case Purchased = "purchased"
-    
-    /// Create new videos, groups, albums, etc.
     case Create = "create"
-    
-    /// Edit videos, groups, albums, etc.
     case Edit = "edit"
-    
-    /// Delete videos, groups, albums, etc.
     case Delete = "delete"
-    
-    /// Interact with a video on behalf of a user, such as liking a video or adding it to your watch later queue
     case Interact = "interact"
-    
-    /// Upload a video
     case Upload = "upload"
-    
-    /// Receive live-related statistics.
     case Stats = "stats"
     case VideoFiles = "video_files"
     
-    /**
-     Combines an array of scopes into a scope string as expected by the api
-     
-     - parameter scopes: an array of `Scope` values
-     
-     - returns: a string of space-separated scope strings
-     */
+    /// Combines an array of scopes into a scope string as expected by the API.
+    ///
+    /// - Parameter scopes: An array of `Scope` values
+    /// - Returns: A string of space-separated scope strings
     public static func combine(_ scopes: [Scope]) -> String {
         return scopes.map({ $0.rawValue }).joined(separator: " ")
     }


### PR DESCRIPTION
### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Numerous requests have been made ([here](https://github.com/vimeo/VimeoNetworking/issues/207), [here](https://github.com/vimeo/VimeoNetworking/issues/259), and [here](https://github.com/vimeo/VimeoNetworking/issues/306)) to add the `video_files` scope to VimeoNetworking, as this is the only way for an API app to access video files on a `VIMVideo` object. 

### Implementation Summary
This pull request updates the implementation of the `Scope` enum in the following ways:
- Adds the `video_files` scope and maps it to the `VideoFiles` case.
- Adds the `promo_codes` scope and maps it to the `PromoCodes` case.
- Declares `Scope` as `CaseIterable`.
- Updated documentation to match the copy found at [developer.vimeo.com](https://developer.vimeo.com/api/authentication).

More information about scopes can be found [here](https://developer.vimeo.com/api/authentication#table-1).