### PR TITLE
VIM-6975: Add password field to VIMPrivacy

### DIFF
--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -79,7 +79,6 @@ import Foundation
     @objc public var modifiedTimeString: String?
     @objc public var modifiedTime: Date?
     @objc public var privacy: VIMPrivacy?
-    @objc public var password: String?
     @objc public var duration: NSNumber?
     @objc public var uri: String?
     @objc public var link: String?

--- a/VimeoNetworking/Sources/Models/Album.swift
+++ b/VimeoNetworking/Sources/Models/Album.swift
@@ -79,6 +79,7 @@ import Foundation
     @objc public var modifiedTimeString: String?
     @objc public var modifiedTime: Date?
     @objc public var privacy: VIMPrivacy?
+    @objc public var password: String?
     @objc public var duration: NSNumber?
     @objc public var uri: String?
     @objc public var link: String?

--- a/VimeoNetworking/Sources/Models/VIMPrivacy.h
+++ b/VimeoNetworking/Sources/Models/VIMPrivacy.h
@@ -45,5 +45,6 @@ extern NSString * __nonnull VIMPrivacy_Stock;
 @property (nonatomic, copy, nullable) NSString *embed;
 @property (nonatomic, copy, nullable) NSString *view;
 @property (nonatomic, copy, nullable) NSString *bypassToken;
+@property (nonatomic, copy, nullable) NSString *password;
 
 @end

--- a/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
+++ b/VimeoNetworkingExample-iOS/VimeoNetworkingCommonTests/AlbumTests.swift
@@ -119,9 +119,19 @@ class AlbumTests: XCTestCase {
     {
         let privacyDictionary: [String: Any] = ["view": "password"]
         let privacy = VIMPrivacy(keyValueDictionary: privacyDictionary)!
-        let videoDictionary: [String: Any] = ["privacy": privacy as Any]
-        let testAlbum = Album(keyValueDictionary: videoDictionary)!
+        let albumDictionary: [String: Any] = ["privacy": privacy as Any]
+        let testAlbum = Album(keyValueDictionary: albumDictionary)!
         XCTAssertTrue(testAlbum.isPasswordProtected(), "Test album should return as password protected.")
+    }
+
+    func test_privacyPassword_isEqualToExpectedValue_whenPrivacyViewIsPassword()
+    {
+        let privacyDictionary: [String: Any] = ["view": "password", "password": "test"]
+        let privacy = VIMPrivacy(keyValueDictionary: privacyDictionary)!
+        let albumDictionary: [String: Any] = ["privacy": privacy as Any]
+        let testAlbum = Album(keyValueDictionary: albumDictionary)!
+        XCTAssertTrue(testAlbum.isPasswordProtected(), "Test album should return as password protected.")
+        XCTAssertEqual(testAlbum.privacy?.password, "test", "Password should be 'test'.")
     }
     
     func test_isPasswordProtected_returnsFalse_whenPrivacyViewIsEmbedOnly()


### PR DESCRIPTION
#### Ticket

[VIM-6975](https://vimean.atlassian.net/browse/VIM-6975)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Showcases store the password directly on the VIMPrivacy object, rather than as a field on the showcase model

#### Implementation Summary

- Add a new `password` field to `VIMPrivacy`
- Add new test

#### How to Test

- Will be tested as part of main Vimeo-iOS PR
- Project should build and unit tests should pass
