### PR TITLE
Fixes issue with crashes on 32 bit devices

### DIFF
--- a/Sources/Shared/Models/VIMModelObject.m
+++ b/Sources/Shared/Models/VIMModelObject.m
@@ -250,6 +250,15 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
 
 @end
 
+
+// On 32 bit devices, BOOL is defined as char, whereas on other devices it is defined as bool.
+// This causes VIMModelObject to trip on true/false values passed by the API. 
+// When we call set(value, forKey:key) where the key type is a BOOL, the OS
+// automatically tries to call charValue on NSString (thinking it is a BOOL), 
+// which causes the app to crash with an unrecognized selector sent to instance message.
+// For more information on OBJC_BOOL_IS_CHAR see the Objective-C runtime header `objc.h`
+// For discussion, comments and proposed solutions see stackoverflow.com/a/32146513
+//
 #if defined(OBJC_BOOL_IS_CHAR)
 @implementation NSString (BoolIsChar32Bit)
 - (BOOL)charValue {

--- a/Sources/Shared/Models/VIMModelObject.m
+++ b/Sources/Shared/Models/VIMModelObject.m
@@ -249,3 +249,11 @@ NSInteger const VIMModelObjectValidationErrorCode = 10101;
 }
 
 @end
+
+#if defined(OBJC_BOOL_IS_CHAR)
+@implementation NSString (BoolIsChar32Bit)
+- (BOOL)charValue {
+    return [self boolValue];
+}
+@end
+#endif

--- a/Tests/iOS/NSStringCharValueTests.m
+++ b/Tests/iOS/NSStringCharValueTests.m
@@ -31,6 +31,22 @@
     XCTAssertTrue(respondsToSelector);
 }
 
+- (void)testCharValueIsTrue {
+    id trueString = @"true";
+    BOOL trueValue = [trueString charValue];
+    XCTAssertTrue(trueValue);
+}
+
+- (void)testCharValueIsFalse {
+    id falseString = @"false";
+    BOOL falseValue = [falseString charValue];
+    XCTAssertFalse(falseValue);
+    
+    falseString = @"other value";
+    falseValue = [falseString charValue];
+    XCTAssertFalse(falseValue);
+}
+
 #else
 
 - (void)testNSString_DOES_NOT_RespondsToCharValueOnOtherDevices {

--- a/Tests/iOS/NSStringCharValueTests.m
+++ b/Tests/iOS/NSStringCharValueTests.m
@@ -1,0 +1,44 @@
+//
+//  NSStringCharValueTests.m
+//  VimeoNetworking-iOSTests
+//
+//  Created by Rogerio de Paula Assis on 7/8/19.
+//  Copyright © 2019 Vimeo. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface NSStringCharValueTests : XCTestCase
+@end
+
+/// This class tests for device compatibility with the dynamic parsing done through `VIMModelObject`.
+/// On 32 bit devices, BOOL is defined as `char`, whereas on other devices it is defined as `bool`.
+/// This causes our dynamic parser to trip on `true` values passed by the API. These get bridged
+/// as `__NSCFString`. When we call `set(value, forKey:key)` where the key type is a BOOL, the system
+/// automatically tries to call `charValue` on NSString which causes the app to crash with an
+/// unrecognized selector sent to instance message.
+/// The solution we found was to extend `NSString` vai category to respond to `charValue` only in
+/// environments where `OBJC_BOOL_IS_CHAR` is defined.
+/// For more information on `OBJC_BOOL_IS_CHAR` see the Objective-C runtime header `objc.h`
+/// More discussion, comments and proposed solutions here https://stackoverflow.com/a/32146513
+
+@implementation NSStringCharValueTests
+
+#if defined(OBJC_BOOL_IS_CHAR)
+
+- (void)testNSStringRespondsToCharValueOn32BitDevices {
+    BOOL respondsToSelector = [[NSString new] respondsToSelector:@selector(charValue)];
+    XCTAssertTrue(respondsToSelector);
+}
+
+#else
+
+- (void)testNSString_DOES_NOT_RespondsToCharValueOnOtherDevices {
+    BOOL respondsToSelector = [[NSString new] respondsToSelector:@selector(charValue)];
+    XCTAssertFalse(respondsToSelector);
+}
+
+#endif
+
+@end
+

--- a/VimeoNetworking.xcodeproj/project.pbxproj
+++ b/VimeoNetworking.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		5B1DF37B22B41C90007F2416 /* categories-animation-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B1DF2DD22B41C90007F2416 /* categories-animation-response.json */; };
 		5B1DF37C22B41C90007F2416 /* categories-animation-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B1DF2DD22B41C90007F2416 /* categories-animation-response.json */; };
 		5B1DF38B22B41F2B007F2416 /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5B1DF01C22B409B5007F2416 /* digicert-sha2.cer */; };
+		5B21352722D3DD6200C0C889 /* NSStringCharValueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B21352622D3DD6200C0C889 /* NSStringCharValueTests.m */; };
 		5B5EEF1D22B425C9005C66BE /* MockConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1DF2B922B41C90007F2416 /* MockConstants.swift */; };
 		5B5EEF1E22B425CA005C66BE /* MockConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1DF2B922B41C90007F2416 /* MockConstants.swift */; };
 		5B5EEF5622B428DC005C66BE /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EEF4C22B428DC005C66BE /* DetailViewController.swift */; };
@@ -781,6 +782,7 @@
 		5B1DF2DD22B41C90007F2416 /* categories-animation-response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-animation-response.json"; sourceTree = "<group>"; };
 		5B1DF37E22B41D7B007F2416 /* VimeoNetworkingTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = VimeoNetworkingTests.plist; sourceTree = "<group>"; };
 		5B1DF37F22B41D7B007F2416 /* VimeoNetworking.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = VimeoNetworking.plist; sourceTree = "<group>"; };
+		5B21352622D3DD6200C0C889 /* NSStringCharValueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSStringCharValueTests.m; sourceTree = "<group>"; };
 		5B5EEF4C22B428DC005C66BE /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		5B5EEF4D22B428DC005C66BE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5B5EEF4F22B428DC005C66BE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -1187,6 +1189,7 @@
 		5B1DF2B622B41C90007F2416 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				5B21352622D3DD6200C0C889 /* NSStringCharValueTests.m */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -2558,6 +2561,7 @@
 				5B1DF30822B41C90007F2416 /* ScopeTests.swift in Sources */,
 				5B1DF32322B41C90007F2416 /* VimeoSessionManagerTests.swift in Sources */,
 				5B1DF31A22B41C90007F2416 /* VIMLiveHeartbeatTests.swift in Sources */,
+				5B21352722D3DD6200C0C889 /* NSStringCharValueTests.m in Sources */,
 				5B1DF32622B41C90007F2416 /* VIMLiveQuotaTests.swift in Sources */,
 				5B1DF30E22B41C90007F2416 /* AlbumTests.swift in Sources */,
 				5B1DF2F322B41C90007F2416 /* VIMUserBadgeTests.swift in Sources */,


### PR DESCRIPTION
#### Ticket

[VIM-7111](https://vimean.atlassian.net/browse/VIM-7111)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers

#### Implementation Summary

This PR adds tests for device compatibility with the dynamic parsing done through `VIMModelObject`.

On 32 bit devices, BOOL is defined as `char`, whereas on other devices it is defined as `bool`.

This causes our dynamic parser to trip on `true` values passed by the API. These get bridged as `__NSCFString`. When we call `set(value, forKey:key)` where the key type is a BOOL, the system
automatically tries to call `charValue` on NSString which causes the app to crash with an unrecognized selector sent to instance message.

The solution we found was to extend `NSString` vai category to respond to `charValue` only in environments where `OBJC_BOOL_IS_CHAR` is defined.

For more information on `OBJC_BOOL_IS_CHAR` see the Objective-C runtime header `objc.h`

More discussion, comments and proposed solutions here https://stackoverflow.com/a/32146513