### PR TITLE
VIM-7124: Adds enterprise account type to user

### DIFF
--- a/Sources/Shared/Models/VIMLiveChatUser.swift
+++ b/Sources/Shared/Models/VIMLiveChatUser.swift
@@ -33,15 +33,7 @@
 /// - plus: "Vimeo Plus" tier.
 /// - pro: "Vimeo PRO" tier.
 /// - proUnlimited: "Custom Live" tier.
-public enum AccountType: String {
-    case basic = "basic"
-    case business = "business"
-    case liveBusiness = "live_business"
-    case livePro = "live_pro"
-    case plus = "plus"
-    case pro = "pro"
-    case proUnlimited = "pro_unlimited"
-}
+public typealias AccountType = VIMUserAccountType
 
 /// An object representing the `user` field in a `chat` response.
 public class VIMLiveChatUser: VIMModelObject {
@@ -60,7 +52,7 @@ public class VIMLiveChatUser: VIMModelObject {
             return nil
         }
         
-        return AccountType(rawValue: accountValue)
+        return AccountType(string: accountValue)
     }
     
     /// The user's ID.

--- a/Sources/Shared/Models/VIMLiveChatUser.swift
+++ b/Sources/Shared/Models/VIMLiveChatUser.swift
@@ -24,17 +24,6 @@
 //  THE SOFTWARE.
 //
 
-/// The user's account type.
-///
-/// - basic: "Vimeo Basic" tier.
-/// - business: "Vimeo Business" tier.
-/// - liveBusiness: "Business Live" tier.
-/// - livePro: "PRO Live" tier.
-/// - plus: "Vimeo Plus" tier.
-/// - pro: "Vimeo PRO" tier.
-/// - proUnlimited: "Custom Live" tier.
-public typealias AccountType = VIMUserAccountType
-
 /// An object representing the `user` field in a `chat` response.
 public class VIMLiveChatUser: VIMModelObject {
     private struct Constants {
@@ -47,12 +36,11 @@ public class VIMLiveChatUser: VIMModelObject {
     @objc public private(set) var account: String?
     
     /// The user's account type in `AccountType`.
-    public var accountType: AccountType? {
+    public var accountType: VIMUserAccountType? {
         guard let accountValue = self.account else {
             return nil
-        }
-        
-        return AccountType(string: accountValue)
+        }        
+        return VIMUserAccountType(string: accountValue)
     }
     
     /// The user's ID.

--- a/Sources/Shared/Models/VIMLiveChatUser.swift
+++ b/Sources/Shared/Models/VIMLiveChatUser.swift
@@ -39,7 +39,7 @@ public class VIMLiveChatUser: VIMModelObject {
     public var accountType: VIMUserAccountType? {
         guard let accountValue = self.account else {
             return nil
-        }        
+        }
         return VIMUserAccountType(string: accountValue)
     }
     

--- a/Sources/Shared/Models/VIMUser.h
+++ b/Sources/Shared/Models/VIMUser.h
@@ -36,20 +36,10 @@
 @class VIMLiveQuota;
 @class UserMembership;
 
-typedef NS_ENUM(NSInteger, VIMUserAccountType) {
-    VIMUserAccountTypeBasic = 0,
-    VIMUserAccountTypePro,
-    VIMUserAccountTypePlus,
-    VIMUserAccountTypeBusiness,
-    VIMUserAccountTypeLivePro,
-    VIMUserAccountTypeLiveBusiness,
-    VIMUserAccountTypeLivePremium,
-    VIMUserAccountTypeProUnlimited,
-    VIMUserAccountTypeProducer,
-    VIMUserAccountTypeEnterprise
-};
+typedef NS_ENUM(NSInteger, VIMUserAccountType);
 
 @interface VIMUser : VIMModelObject
+
 
 @property (nonatomic, assign, readonly) VIMUserAccountType accountType;
 

--- a/Sources/Shared/Models/VIMUser.h
+++ b/Sources/Shared/Models/VIMUser.h
@@ -45,7 +45,8 @@ typedef NS_ENUM(NSInteger, VIMUserAccountType) {
     VIMUserAccountTypeLiveBusiness,
     VIMUserAccountTypeLivePremium,
     VIMUserAccountTypeProUnlimited,
-    VIMUserAccountTypeProducer
+    VIMUserAccountTypeProducer,
+    VIMUserAccountTypeEnterprise
 };
 
 @interface VIMUser : VIMModelObject

--- a/Sources/Shared/Models/VIMUser.m
+++ b/Sources/Shared/Models/VIMUser.m
@@ -34,17 +34,6 @@
 #import "VIMPreference.h"
 #import "VIMUserBadge.h"
 
-static NSString *const Basic = @"basic";
-static NSString *const Plus = @"plus";
-static NSString *const Pro = @"pro";
-static NSString *const Business = @"business";
-static NSString *const LivePro = @"live_pro";
-static NSString *const LiveBusiness = @"live_business";
-static NSString *const LivePremium = @"live_premium";
-static NSString *const ProUnlimited = @"pro_unlimited";
-static NSString *const Producer = @"producer";
-static NSString *const Enterprise = @"enterprise";
-
 @interface VIMUser ()
 
 @property (nonatomic, strong) NSDictionary *metadata;
@@ -219,45 +208,9 @@ static NSString *const Enterprise = @"enterprise";
 
 - (void)parseAccountType
 {
-    if ([self.membership.type isEqualToString:Plus])
-    {
-        self.accountType = VIMUserAccountTypePlus;
-    }
-    else if ([self.membership.type isEqualToString:Pro])
-    {
-        self.accountType = VIMUserAccountTypePro;
-    }
-    else if ([self.membership.type isEqualToString:Basic])
-    {
-        self.accountType = VIMUserAccountTypeBasic;
-    }
-    else if ([self.membership.type isEqualToString:Business])
-    {
-        self.accountType = VIMUserAccountTypeBusiness;
-    }
-    else if ([self.membership.type isEqualToString:LivePro])
-    {
-        self.accountType = VIMUserAccountTypeLivePro;
-    }
-    else if ([self.membership.type isEqualToString:LiveBusiness])
-    {
-        self.accountType = VIMUserAccountTypeLiveBusiness;
-    }
-    else if ([self.membership.type isEqualToString:LivePremium])
-    {
-        self.accountType = VIMUserAccountTypeLivePremium;
-    }
-    else if ([self.membership.type isEqualToString:ProUnlimited])
-    {
-        self.accountType = VIMUserAccountTypeProUnlimited;
-    }
-    else if ([self.membership.type isEqualToString:Producer])
-    {
-        self.accountType = VIMUserAccountTypeProducer;
-    }
-    else if ([self.membership.type isEqualToString:Enterprise])
-    {
-        self.accountType = VIMUserAccountTypeEnterprise;
+    NSString *membershipType = self.membership.type;
+    if (membershipType) {
+        self.accountType = [VIMUserAccountTypeBridge accountFromString:membershipType];
     }
 }
 
@@ -310,30 +263,7 @@ static NSString *const Enterprise = @"enterprise";
 
 - (NSString *)accountTypeAnalyticsIdentifier
 {
-    switch (self.accountType)
-    {
-        default:
-        case VIMUserAccountTypeBasic:
-            return Basic;
-        case VIMUserAccountTypePlus:
-            return Plus;
-        case VIMUserAccountTypePro:
-            return Pro;
-        case VIMUserAccountTypeBusiness:
-            return Business;
-        case VIMUserAccountTypeLivePro:
-            return LivePro;
-        case VIMUserAccountTypeLiveBusiness:
-            return LiveBusiness;
-        case VIMUserAccountTypeLivePremium:
-            return LivePremium;
-        case VIMUserAccountTypeProUnlimited:
-            return ProUnlimited;
-        case VIMUserAccountTypeProducer:
-            return Producer;
-        case VIMUserAccountTypeEnterprise:
-            return Enterprise;
-    }
+    return [VIMUserAccountTypeBridge stringFrom:self.accountType];
 }
 
 #pragma mark - Model Versioning

--- a/Sources/Shared/Models/VIMUser.m
+++ b/Sources/Shared/Models/VIMUser.m
@@ -43,6 +43,7 @@ static NSString *const LiveBusiness = @"live_business";
 static NSString *const LivePremium = @"live_premium";
 static NSString *const ProUnlimited = @"pro_unlimited";
 static NSString *const Producer = @"producer";
+static NSString *const Enterprise = @"enterprise";
 
 @interface VIMUser ()
 
@@ -254,6 +255,10 @@ static NSString *const Producer = @"producer";
     {
         self.accountType = VIMUserAccountTypeProducer;
     }
+    else if ([self.membership.type isEqualToString:Enterprise])
+    {
+        self.accountType = VIMUserAccountTypeEnterprise;
+    }
 }
 
 - (void)parseEmails
@@ -326,6 +331,8 @@ static NSString *const Producer = @"producer";
             return ProUnlimited;
         case VIMUserAccountTypeProducer:
             return Producer;
+        case VIMUserAccountTypeEnterprise:
+            return Enterprise;
     }
 }
 

--- a/Sources/Shared/Models/VIMUserAccountType.swift
+++ b/Sources/Shared/Models/VIMUserAccountType.swift
@@ -73,8 +73,6 @@ extension VIMUserAccountType: CustomStringConvertible {
             return .producer
         case .enterprise:
             return .enterprise
-        @unknown default:
-            return .unknown
         }
     }
     
@@ -91,7 +89,6 @@ private extension String {
     static let proUnlimited = "pro_unlimited"
     static let producer = "producer"
     static let enterprise = "enterprise"
-    static let unknown = "unknown"
 }
 
 // Objective-C convenience bridge

--- a/Sources/Shared/Models/VIMUserAccountType.swift
+++ b/Sources/Shared/Models/VIMUserAccountType.swift
@@ -1,0 +1,109 @@
+//
+//  VIMUserAccountType.swift
+//  VimeoNetworking
+//
+//  Created by Rogerio de Paula Assis on 7/16/19.
+//  Copyright © 2019 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+@objc public enum VIMUserAccountType: Int {
+    
+    case basic = 0
+    case pro
+    case plus
+    case business
+    case livePro
+    case liveBusiness
+    case livePremium
+    case proUnlimited
+    case producer
+    case enterprise
+    
+    init(string: String) {
+        switch string {
+        case .basic:
+            self = .basic
+        case .pro:
+            self = .pro
+        case .plus:
+            self = .plus
+        case .business:
+            self = .business
+        case .livePro:
+            self = .livePro
+        case .liveBusiness:
+            self = .liveBusiness
+        case .livePremium:
+            self = .livePremium
+        case .proUnlimited:
+            self = .proUnlimited
+        case .producer:
+            self = .producer
+        case .enterprise:
+            self = .enterprise
+        default:
+            self = .basic
+        }
+    }
+}
+
+extension VIMUserAccountType: CustomStringConvertible {
+    
+    public var description: String {
+        switch self {
+        case .basic:
+            return .basic
+        case .pro:
+            return .pro
+        case .plus:
+            return .plus
+        case .business:
+            return .business
+        case .livePro:
+            return .livePro
+        case .liveBusiness:
+            return .liveBusiness
+        case .livePremium:
+            return .livePremium
+        case .proUnlimited:
+            return .proUnlimited
+        case .producer:
+            return .producer
+        case .enterprise:
+            return .enterprise
+        @unknown default:
+            return .unknown
+        }
+    }
+    
+}
+
+private extension String {
+    static let basic = "basic"
+    static let plus = "plus"
+    static let pro = "pro"
+    static let business = "business"
+    static let livePro = "live_pro"
+    static let liveBusiness = "live_business"
+    static let livePremium = "live_premium"
+    static let proUnlimited = "pro_unlimited"
+    static let producer = "producer"
+    static let enterprise = "enterprise"
+    static let unknown = "unknown"
+}
+
+// Objective-C convenience bridge
+@objc public class VIMUserAccountTypeBridge: NSObject {
+    
+    override private init() {}
+    
+    @objc public static func account(fromString string: String) -> VIMUserAccountType {
+        return VIMUserAccountType(string: string)
+    }
+    
+    @objc public static func string(from accountType: VIMUserAccountType) -> String {
+        return accountType.description
+    }
+}

--- a/Tests/Shared/VIMLiveTests.swift
+++ b/Tests/Shared/VIMLiveTests.swift
@@ -63,7 +63,7 @@ class VIMLiveTests: XCTestCase {
     
     private func assert(liveChatUserObject user: VIMLiveChatUser?) {
         XCTAssertNotNil(user)
-        XCTAssertEqual(user?.account, AccountType.liveBusiness.rawValue)
+        XCTAssertEqual(user?.account, AccountType.liveBusiness.description)
         XCTAssertEqual(user?.id?.int64Value, MockLiveChatUser.Id)
         XCTAssertEqual(user?.name, MockLiveChatUser.Name)
         XCTAssertEqual(user?.isStaff?.boolValue, true)

--- a/Tests/Shared/VIMLiveTests.swift
+++ b/Tests/Shared/VIMLiveTests.swift
@@ -63,7 +63,7 @@ class VIMLiveTests: XCTestCase {
     
     private func assert(liveChatUserObject user: VIMLiveChatUser?) {
         XCTAssertNotNil(user)
-        XCTAssertEqual(user?.account, AccountType.liveBusiness.description)
+        XCTAssertEqual(user?.account, VIMUserAccountType.liveBusiness.description)
         XCTAssertEqual(user?.id?.int64Value, MockLiveChatUser.Id)
         XCTAssertEqual(user?.name, MockLiveChatUser.Name)
         XCTAssertEqual(user?.isStaff?.boolValue, true)

--- a/Tests/Shared/VIMUserAccountTypeTests.swift
+++ b/Tests/Shared/VIMUserAccountTypeTests.swift
@@ -1,0 +1,56 @@
+//
+//  VIMUserAccountTypeTests.swift
+//  VimeoNetworking
+//
+//  Created by Rogerio de Paula Assis on 7/16/19.
+//  Copyright © 2019 Vimeo. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import VimeoNetworking
+
+class VIMUserAccountTypeTests: XCTestCase {
+    
+    func testAccountFromString() {
+        // For a given string key and account type value pair
+        accountTypes.forEach { key, value in
+            // When I create an account type from the string key
+            let accountType = VIMUserAccountType(string: key)
+            // Then the account type should equal the value pair value
+            XCTAssertEqual(accountType, value)
+        }
+    }
+    
+    func testUnknownStringValue() {
+        // Given an unknown string value
+        let stringValue = "unknownABC123test"
+        // When I create an account type from it
+        let accountType = VIMUserAccountType(string: stringValue)
+        // Then the account type should equal .basic
+        XCTAssertEqual(accountType, .basic)
+    }
+    
+    func testCustomStringConvertible() {
+        // For a given string key and account type value pair
+        accountTypes.forEach { key, value in
+            // When I get the string representation of the account type value
+            let stringValue = value.description
+            // Then it should equal the key pair value
+            XCTAssertEqual(stringValue, key)
+        }
+    }
+    
+    private let accountTypes: [String: VIMUserAccountType] = [
+        "basic": .basic,
+        "plus": .plus,
+        "pro": .pro,
+        "business": .business,
+        "live_pro": .livePro,
+        "live_business": .liveBusiness,
+        "live_premium": .livePremium,
+        "pro_unlimited": .proUnlimited,
+        "producer": .producer,
+        "enterprise": .enterprise,
+    ]
+}

--- a/Tests/Shared/VIMUserTests.swift
+++ b/Tests/Shared/VIMUserTests.swift
@@ -84,6 +84,8 @@ class VIMUserTests: XCTestCase {
             XCTAssertEqual(analyticsIdentifier, "pro_unlimited")
         case .producer:
             XCTAssertEqual(analyticsIdentifier, "producer")
+        case .enterprise:
+            XCTAssertEqual(analyticsIdentifier, "enterprise")
         @unknown default:
             XCTFail("Unhandled switch case. Please fix this and re-run the tests")
         }

--- a/VimeoNetworking.xcodeproj/project.pbxproj
+++ b/VimeoNetworking.xcodeproj/project.pbxproj
@@ -170,6 +170,9 @@
 		5B1DF38B22B41F2B007F2416 /* digicert-sha2.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5B1DF01C22B409B5007F2416 /* digicert-sha2.cer */; };
 		5B21352E22D4382300C0C889 /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EEFF622B441A3005C66BE /* VimeoResponseSerializer.swift */; };
 		5B21352F22D4382400C0C889 /* VimeoResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EEFF622B441A3005C66BE /* VimeoResponseSerializer.swift */; };
+		5B3D4FE222DE24DD002D937B /* VIMUserAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3D4FE122DE24DD002D937B /* VIMUserAccountType.swift */; };
+		5B3D4FE322DE24DD002D937B /* VIMUserAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3D4FE122DE24DD002D937B /* VIMUserAccountType.swift */; };
+		5B3D4FE422DE24DD002D937B /* VIMUserAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3D4FE122DE24DD002D937B /* VIMUserAccountType.swift */; };
 		5B5EEF1D22B425C9005C66BE /* MockConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1DF2B922B41C90007F2416 /* MockConstants.swift */; };
 		5B5EEF1E22B425CA005C66BE /* MockConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1DF2B922B41C90007F2416 /* MockConstants.swift */; };
 		5B5EEF5622B428DC005C66BE /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EEF4C22B428DC005C66BE /* DetailViewController.swift */; };
@@ -657,6 +660,9 @@
 		5B5EF1E622B441A4005C66BE /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EF00B22B441A3005C66BE /* Request+Notifications.swift */; };
 		5B5EF1E722B441A4005C66BE /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EF00B22B441A3005C66BE /* Request+Notifications.swift */; };
 		5B5EF1E822B441A4005C66BE /* Request+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EF00B22B441A3005C66BE /* Request+Notifications.swift */; };
+		5B69E4E922DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
+		5B69E4EA22DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
+		5B69E4EB22DE2E2A009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
 		7AB0DEA0BCE9DBC1B80BA3D3 /* Pods_VimeoNetworking_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E51D879667F81EB014A0C506 /* Pods_VimeoNetworking_iOS.framework */; };
 		A03F5F894DFF832C9C91F658 /* Pods_VimeoNetworking_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D830AC559AEFE2220E4AA901 /* Pods_VimeoNetworking_macOS.framework */; };
 		D89F012C8915580FDB120B6E /* Pods_VimeoNetworking_iOS_VimeoNetworking_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8EF61C4E6269B97B747D537 /* Pods_VimeoNetworking_iOS_VimeoNetworking_iOSTests.framework */; };
@@ -782,6 +788,7 @@
 		5B1DF2DD22B41C90007F2416 /* categories-animation-response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-animation-response.json"; sourceTree = "<group>"; };
 		5B1DF37E22B41D7B007F2416 /* VimeoNetworkingTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = VimeoNetworkingTests.plist; sourceTree = "<group>"; };
 		5B1DF37F22B41D7B007F2416 /* VimeoNetworking.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = VimeoNetworking.plist; sourceTree = "<group>"; };
+		5B3D4FE122DE24DD002D937B /* VIMUserAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VIMUserAccountType.swift; sourceTree = "<group>"; };
 		5B5EEF4C22B428DC005C66BE /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		5B5EEF4D22B428DC005C66BE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5B5EEF4F22B428DC005C66BE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -950,6 +957,7 @@
 		5B5EF00922B441A3005C66BE /* AuthenticationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationController.swift; sourceTree = "<group>"; };
 		5B5EF00A22B441A3005C66BE /* Request+Picture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Request+Picture.swift"; sourceTree = "<group>"; };
 		5B5EF00B22B441A3005C66BE /* Request+Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Request+Notifications.swift"; sourceTree = "<group>"; };
+		5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VIMUserAccountTypeTests.swift; sourceTree = "<group>"; };
 		5B79213A22C2A58A00FC1928 /* AFNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AFNetworking.framework; sourceTree = "<group>"; };
 		5B79213D22C2A59300FC1928 /* AFNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AFNetworking.framework; sourceTree = "<group>"; };
 		5B79214022C2A59B00FC1928 /* AFNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AFNetworking.framework; sourceTree = "<group>"; };
@@ -1141,6 +1149,7 @@
 				5B1DF2A522B41C90007F2416 /* RequestTests.swift */,
 				5B1DF2A622B41C90007F2416 /* VIMCategory+Tests.swift */,
 				5B1DF2A722B41C90007F2416 /* VIMUserTests.swift */,
+				5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */,
 				5B1DF2A822B41C90007F2416 /* ExceptionCatcherTests.swift */,
 				5B1DF2A922B41C90007F2416 /* VIMUploadQuota+Tests.swift */,
 				5B1DF2AA22B41C90007F2416 /* VIMUploadTests.swift */,
@@ -1313,6 +1322,7 @@
 				5B5EEFA822B441A3005C66BE /* VIMTrigger.h */,
 				5B5EEFD022B441A3005C66BE /* VIMUploadTicket.h */,
 				5B5EEFDC22B441A3005C66BE /* VIMUser.h */,
+				5B3D4FE122DE24DD002D937B /* VIMUserAccountType.swift */,
 				5B5EEFA622B441A3005C66BE /* VIMUserBadge.h */,
 				5B5EEFCC22B441A3005C66BE /* VIMVideo.h */,
 				5B5EEFCD22B441A3005C66BE /* VIMVideo+VOD.h */,
@@ -2286,6 +2296,7 @@
 				5B5EF0E122B441A4005C66BE /* VIMActivity.m in Sources */,
 				5B5EF1C822B441A4005C66BE /* Dictionary+Extension.swift in Sources */,
 				5B5EF16222B441A4005C66BE /* VIMObjectMapper.m in Sources */,
+				5B3D4FE222DE24DD002D937B /* VIMUserAccountType.swift in Sources */,
 				5B5EF0ED22B441A4005C66BE /* VIMSoundtrack.m in Sources */,
 				5B5EF19B22B441A4005C66BE /* PinCodeInfo.swift in Sources */,
 				5B5EF02722B441A3005C66BE /* Objc_ExceptionCatcher.m in Sources */,
@@ -2407,6 +2418,7 @@
 				5B5EF09122B441A3005C66BE /* VIMSeason.m in Sources */,
 				5B5EF0E222B441A4005C66BE /* VIMActivity.m in Sources */,
 				5B5EF1C922B441A4005C66BE /* Dictionary+Extension.swift in Sources */,
+				5B3D4FE322DE24DD002D937B /* VIMUserAccountType.swift in Sources */,
 				5B5EF16322B441A4005C66BE /* VIMObjectMapper.m in Sources */,
 				5B5EF0EE22B441A4005C66BE /* VIMSoundtrack.m in Sources */,
 				5B5EF19C22B441A4005C66BE /* PinCodeInfo.swift in Sources */,
@@ -2609,6 +2621,7 @@
 				5B5EF08C22B441A3005C66BE /* VIMNotificationsConnection.m in Sources */,
 				5B5EF15222B441A4005C66BE /* VIMTrigger.m in Sources */,
 				5B5EF14322B441A4005C66BE /* VIMPolicyDocument.m in Sources */,
+				5B3D4FE422DE24DD002D937B /* VIMUserAccountType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2643,6 +2656,7 @@
 				5B1DF31D22B41C90007F2416 /* FileTransferTests.swift in Sources */,
 				5B1DF33222B41C90007F2416 /* UploadGCSTests.swift in Sources */,
 				5B1DF30522B41C90007F2416 /* Request+CategoryTests.swift in Sources */,
+				5B69E4E922DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */,
 				5B1DF2F022B41C90007F2416 /* Request+ProgrammedContent.swift in Sources */,
 				5B1DF2DE22B41C90007F2416 /* RequestTests.swift in Sources */,
 			);
@@ -2679,6 +2693,7 @@
 				5B1AE5CA22B5AA1400FE120E /* FileTransferTests.swift in Sources */,
 				5B1AE5D122B5AA1400FE120E /* UploadGCSTests.swift in Sources */,
 				5B5EEF1D22B425C9005C66BE /* MockConstants.swift in Sources */,
+				5B69E4EA22DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */,
 				5B1DF2F122B41C90007F2416 /* Request+ProgrammedContent.swift in Sources */,
 				5B1DF2DF22B41C90007F2416 /* RequestTests.swift in Sources */,
 			);
@@ -2715,6 +2730,7 @@
 				5B1AE5D522B5AA1500FE120E /* FileTransferTests.swift in Sources */,
 				5B1AE5DC22B5AA1500FE120E /* UploadGCSTests.swift in Sources */,
 				5B5EEF1E22B425CA005C66BE /* MockConstants.swift in Sources */,
+				5B69E4EB22DE2E2A009E84B6 /* VIMUserAccountTypeTests.swift in Sources */,
 				5B1DF2F222B41C90007F2416 /* Request+ProgrammedContent.swift in Sources */,
 				5B1DF2E022B41C90007F2416 /* RequestTests.swift in Sources */,
 			);


### PR DESCRIPTION
#### Ticket

[VIM-7124](https://vimean.atlassian.net/browse/VIM-7124

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR adds a new account type `Enterprise` to the `VIMAccountType` model.

It also modifies a switch case on account type returning the appropriate string for enterprise users.

While making this change I've taken the opportunity to improve some of the logic related to handling account types. 

We had some code duplication under `VIMLiveChatUser.swift` that has been removed in favor of a refactored `VIMUserAccountType` that is now migrated to Swift.

Due to the fact that this enum is used across both Swift and Objective-C, its raw type must be `Int`. We have also forward declared the enum in the `VIMUser` header file, and created a couple of Objective-C bridging methods for convenience.

Finally, unit tests have been added to verify the `VIMUserAccounType` behavior in isolation.
