### PR TITLE
Fixes issue with fork PRs never succeeding

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,7 +40,6 @@ platform :ios do
     if is_ci? && !is_fork_pr
       danger(use_bundle_exec: false)
     end
-
   end
 
   desc "bumps the project and podspec version"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,9 +34,13 @@ platform :ios do
 
     pretty_junit(file_pattern: "fastlane/test_output/report.junit")
 
-    if is_ci?
+    # Fork PRs cannot use danger because CircleCI (rightly) doesn't expose sensitive environment vars which danger makes use of to comment on PRs.
+    # So we opt out of danger for fork PRs by checking the `CIRCLE_BRANCH` environment var and matching it against pull/XXXX where XXXX == numeric chars    
+    is_fork_pr = (ENV["CIRCLE_BRANCH"] =~ /pull\/[0-9]+/) != nil
+    if is_ci? && !is_fork_pr
       danger(use_bundle_exec: false)
     end
+
   end
 
   desc "bumps the project and podspec version"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,6 +39,8 @@ platform :ios do
     is_fork_pr = (ENV["CIRCLE_BRANCH"] =~ /pull\/[0-9]+/) != nil
     if is_ci? && !is_fork_pr
       danger(use_bundle_exec: false)
+    else 
+      UI.message "Skipping danger: is_ci? #{is_ci?}, is_fork_pr? #{is_fork_pr}"
     end
   end
 


### PR DESCRIPTION
#### Ticket

[VIM-XXXX](https://vimean.atlassian.net/browse/VIM-XXXX)


#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

This PR address an issue with fork PRs that always fail due to Circle CI correctly not exposing sensitive environment variables.

Danger uses a github access token to comment on pull requests. The access token is set and obtained via an environment variable that is not available to forks.

Because of that, all PR builds that come from forks fail and are not mergeable, requiring us to manually cherry pick changes, create a new PR and give credit to
the person that originally submitted it.

#### Implementation Summary

This PR makes changes to our build lane on `fastlane` so we opt out of running `danger` on fork PRs.
We achieve this by checking the CIRCLE_BRANCH environment variable, and searching for a pattern of `pull/XXXX` where XXXX is a numeric value.
If a matching value is found we can safely assume this is a forked pull request.

#### How to Test

- Fork VimeoNetworking
- Checkout the branch for this PR
- Create a new pull request from your fork into VimeoNetworking
- Ensure that the `danger` step does not fail