### PR TITLE
Removes custom Result type in favor of built in version from Swift 5

### DIFF
--- a/Example/iOS/MasterViewController.swift
+++ b/Example/iOS/MasterViewController.swift
@@ -175,9 +175,9 @@ class MasterViewController: UITableViewController
         }
         else
         {
-            let URL = authenticationController.codeGrantAuthorizationURL()
+            let url = authenticationController.codeGrantAuthorizationURL()
             
-            UIApplication.shared.openURL(URL)
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
 

--- a/Sources/Shared/AuthenticationController.swift
+++ b/Sources/Shared/AuthenticationController.swift
@@ -53,7 +53,7 @@ final public class AuthenticationController {
     private static let PinCodeRequestInterval: TimeInterval = 5
     
         /// Completion closure type for authentication requests
-    public typealias AuthenticationCompletion = ResultCompletion<VIMAccount, Error>.T
+    public typealias AuthenticationCompletion = ResultCompletion<VIMAccount, NSError>.T
     
         /// State is tracked for the code grant request/response cycle, to avoid interception
     static let state = ProcessInfo.processInfo.globallyUniqueString
@@ -310,7 +310,7 @@ final public class AuthenticationController {
      - parameter completion:                handler for authentication success or failure
      */
     public func authenticate(withResponse accountResponseDictionary: VimeoClient.ResponseDictionary, completion: AuthenticationCompletion) {
-        let result: Result<Response<VIMAccount>, Error>
+        let result: Result<Response<VIMAccount>, NSError>
         
         do {
             let account: VIMAccount = try VIMObjectMapper.mapObject(responseDictionary: accountResponseDictionary)
@@ -410,7 +410,7 @@ final public class AuthenticationController {
                 completion(result)
                 
             case .failure(let error):
-                if (error as NSError).statusCode == HTTPStatusCode.badRequest.rawValue // 400: Bad Request implies the code hasn't been activated yet, so try again.
+                if error.statusCode == HTTPStatusCode.badRequest.rawValue // 400: Bad Request implies the code hasn't been activated yet, so try again.
                 {
                     guard let strongSelf = self
                         else {
@@ -497,12 +497,12 @@ final public class AuthenticationController {
         }
     }
     
-    private func handleAuthenticationResult(_ result: Result<Response<VIMAccount>, Error>) -> Result<VIMAccount, Error> {
+    private func handleAuthenticationResult(_ result: Result<Response<VIMAccount>, NSError>) -> Result<VIMAccount, NSError> {
         guard case .success(let accountResponse) = result
         else {
             let resultError: NSError
             if case .failure(let error) = result {
-                resultError = error as NSError
+                resultError = error
             }
             else {
                 let errorDescription = "Authentication result malformed"
@@ -528,7 +528,7 @@ final public class AuthenticationController {
             
             try self.accountStore.save(account, ofType: accountType)
         }
-        catch let error {
+        catch let error as NSError {
             return .failure(error)
         }
         

--- a/Sources/Shared/ResponseCache.swift
+++ b/Sources/Shared/ResponseCache.swift
@@ -73,18 +73,18 @@ final public class ResponseCache {
      - parameter request:    the request for which the cache should be queried
      - parameter completion: returns `.Success(ResponseDictionary)`, if found in cache, or `.Success(nil)` for a cache miss.  Returns `.Failure(NSError)` if an error occurred.
      */
-    func response<ModelType>(forRequest request: Request<ModelType>, completion: @escaping ResultCompletion<VimeoClient.ResponseDictionary?>.T) {
+    func response<ModelType>(forRequest request: Request<ModelType>, completion: @escaping ResultCompletion<VimeoClient.ResponseDictionary?, Error>.T) {
         let key = request.cacheKey
         
         self.memoryCache.responseDictionary(forKey: key) { (responseDictionary) in
             
             if responseDictionary != nil {
-                completion(.success(result: responseDictionary))
+                completion(.success(responseDictionary))
             }
             else {
                 self.diskCache.responseDictionary(forKey: key, completion: { (responseDictionary) in
                     
-                    completion(.success(result: responseDictionary))
+                    completion(.success(responseDictionary))
                 })
             }
         }

--- a/Sources/Shared/ResponseCache.swift
+++ b/Sources/Shared/ResponseCache.swift
@@ -73,7 +73,7 @@ final public class ResponseCache {
      - parameter request:    the request for which the cache should be queried
      - parameter completion: returns `.Success(ResponseDictionary)`, if found in cache, or `.Success(nil)` for a cache miss.  Returns `.Failure(NSError)` if an error occurred.
      */
-    func response<ModelType>(forRequest request: Request<ModelType>, completion: @escaping ResultCompletion<VimeoClient.ResponseDictionary?, Error>.T) {
+    func response<ModelType>(forRequest request: Request<ModelType>, completion: @escaping ResultCompletion<VimeoClient.ResponseDictionary?, NSError>.T) {
         let key = request.cacheKey
         
         self.memoryCache.responseDictionary(forKey: key) { (responseDictionary) in

--- a/Sources/Shared/Result.swift
+++ b/Sources/Shared/Result.swift
@@ -26,21 +26,6 @@
 
 import Foundation
 
-/**
- `Result` describes a general final output of a process that can be either successful or unsuccessful
- 
- - Success: action successful, returns a result of type `ResultType`
- - Failure: action failed, returns an `NSError`
- */
-public enum Result<ResultType> {
-        /// action successful, returns a result of type `ResultType`
-    case success(result: ResultType)
-    
-        /// action failed, returns an `NSError`
-    case failure(error: NSError)
-}
-
-/// `ResultCompletion` creates a generic typealias to generally define completion blocks that return a `Result`
-public enum ResultCompletion<ResultType> {
-    public typealias T = (Result<ResultType>) -> Void
+public enum ResultCompletion<ResultType, E: Error> {
+    public typealias T = (Result<ResultType, E>) -> Void
 }

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -159,7 +159,7 @@ final public class VimeoClient {
      
      - returns: a `RequestToken` for the in-flight request
      */
-    public func request<ModelType>(_ request: Request<ModelType>, completionQueue: DispatchQueue = DispatchQueue.main, completion: @escaping ResultCompletion<Response<ModelType>>.T) -> RequestToken {
+    public func request<ModelType>(_ request: Request<ModelType>, completionQueue: DispatchQueue = DispatchQueue.main, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) -> RequestToken {
         if request.useCache {
             self.responseCache.response(forRequest: request) { result in
                 
@@ -176,17 +176,17 @@ final public class VimeoClient {
                         
                         completionQueue.async {
                             
-                            completion(.failure(error: error))
+                            completion(.failure(error))
                         }
                     }
                     
                 case .failure(let error):
                     
-                    self.handleError(error, request: request)
+                    self.handleError(error as NSError, request: request)
                     
                     completionQueue.async {
                         
-                        completion(.failure(error: error))
+                        completion(.failure(error))
                     }
                 }
             }
@@ -262,7 +262,7 @@ final public class VimeoClient {
     
     // MARK: - Private task completion handlers
     
-    private func handleTaskSuccess<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, responseObject: Any?, isCachedResponse: Bool = false, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>>.T) {
+    private func handleTaskSuccess<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, responseObject: Any?, isCachedResponse: Bool = false, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) {
         guard let responseDictionary = responseObject as? ResponseDictionary
         else {
             if ModelType.self == VIMNullResponse.self {
@@ -273,7 +273,7 @@ final public class VimeoClient {
                 let response = Response(model: nullResponseObject, json: [:]) as! Response<ModelType>
 
                 completionQueue.async {
-                    completion(.success(result: response as Response<ModelType>))
+                    completion(.success(response as Response<ModelType>))
                 }
             }
             else {
@@ -341,7 +341,7 @@ final public class VimeoClient {
             }
             
             completionQueue.async {
-                completion(.success(result: response))
+                completion(.success(response))
             }
         }
         catch let error {
@@ -351,7 +351,7 @@ final public class VimeoClient {
         }
     }
     
-    private func handleTaskFailure<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, error: NSError?, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>>.T) {
+    private func handleTaskFailure<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, error: NSError?, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) {
         let error = error ?? NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.undefined.rawValue, userInfo: [NSLocalizedDescriptionKey: "Undefined error"])
         
         if error.code == NSURLErrorCancelled {
@@ -371,7 +371,7 @@ final public class VimeoClient {
         }
         
         completionQueue.async {
-            completion(.failure(error: error))
+            completion(.failure(error))
         }
     }
     

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -159,7 +159,7 @@ final public class VimeoClient {
      
      - returns: a `RequestToken` for the in-flight request
      */
-    public func request<ModelType>(_ request: Request<ModelType>, completionQueue: DispatchQueue = DispatchQueue.main, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) -> RequestToken {
+    public func request<ModelType>(_ request: Request<ModelType>, completionQueue: DispatchQueue = DispatchQueue.main, completion: @escaping ResultCompletion<Response<ModelType>, NSError>.T) -> RequestToken {
         if request.useCache {
             self.responseCache.response(forRequest: request) { result in
                 
@@ -182,7 +182,7 @@ final public class VimeoClient {
                     
                 case .failure(let error):
                     
-                    self.handleError(error as NSError, request: request)
+                    self.handleError(error, request: request)
                     
                     completionQueue.async {
                         
@@ -262,7 +262,7 @@ final public class VimeoClient {
     
     // MARK: - Private task completion handlers
     
-    private func handleTaskSuccess<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, responseObject: Any?, isCachedResponse: Bool = false, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) {
+    private func handleTaskSuccess<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, responseObject: Any?, isCachedResponse: Bool = false, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, NSError>.T) {
         guard let responseDictionary = responseObject as? ResponseDictionary
         else {
             if ModelType.self == VIMNullResponse.self {
@@ -351,7 +351,7 @@ final public class VimeoClient {
         }
     }
     
-    private func handleTaskFailure<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, error: NSError?, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, Error>.T) {
+    private func handleTaskFailure<ModelType>(forRequest request: Request<ModelType>, task: URLSessionDataTask?, error: NSError?, completionQueue: DispatchQueue, completion: @escaping ResultCompletion<Response<ModelType>, NSError>.T) {
         let error = error ?? NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.undefined.rawValue, userInfo: [NSLocalizedDescriptionKey: "Undefined error"])
         
         if error.code == NSURLErrorCancelled {

--- a/Tests/Shared/Request+ProgrammedContent.swift
+++ b/Tests/Shared/Request+ProgrammedContent.swift
@@ -112,7 +112,7 @@ class Request_ProgrammedContent: XCTestCase {
             case .success(_):
                 XCTFail("This test should not return a success")
                 
-            case .failure(let error):
+            case .failure(let error as NSError):
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error.vimeoInvalidParametersErrorCodesString, "2218")
                 XCTAssertEqual(error.vimeoServerErrorCode!, 2204)

--- a/Tests/Shared/Request+ProgrammedContent.swift
+++ b/Tests/Shared/Request+ProgrammedContent.swift
@@ -112,7 +112,7 @@ class Request_ProgrammedContent: XCTestCase {
             case .success(_):
                 XCTFail("This test should not return a success")
                 
-            case .failure(let error as NSError):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error.vimeoInvalidParametersErrorCodesString, "2218")
                 XCTAssertEqual(error.vimeoServerErrorCode!, 2204)


### PR DESCRIPTION
#### Ticket

[VIM-7148](https://vimean.atlassian.net/browse/VIM-7148)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Now that VimeoNetworking is on Swift 5 we can safely remove the custom `Result` type defined by the library in favor of the native Swift version.

#### Implementation Summary

Our custom Result type only specializes the success value so to be able to use Swift's version we have to add a second specialization of `Error` type wherever Result was used.

#### How to Test

- Build and run, ensure all tests pass