### PR TITLE
[WIP] VIM-XXXX: Introduces SessionManaging protocol for dependency abstraction

### DIFF
--- a/Sources/Shared/AuthenticationController.swift
+++ b/Sources/Shared/AuthenticationController.swift
@@ -181,7 +181,7 @@ final public class AuthenticationController {
         let urlString = self.configuration.baseUrl.appendingPathComponent(Constants.CodeGrantAuthorizationPath).absoluteString
         
         var error: NSError?
-        let urlRequest = VimeoRequestSerializer(appConfiguration: self.configuration).request(withMethod: VimeoClient.Method.GET.rawValue, urlString: urlString, parameters: parameters, error: &error)
+        let urlRequest = VimeoRequestSerializer(appConfiguration: self.configuration).request(withMethod: HTTPMethod.get.rawValue, urlString: urlString, parameters: parameters, error: &error)
         
         guard let url = urlRequest.url, error == nil
         else {

--- a/Sources/Shared/Core/HTTPMethod.swift
+++ b/Sources/Shared/Core/HTTPMethod.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A typesafe representation of all available HTTP methods
-enum HTTPMethod: String {
+public enum HTTPMethod: String {
     /// The CONNECT method
     case connect        = "CONNECT"
     

--- a/Sources/Shared/Core/SessionManaging.swift
+++ b/Sources/Shared/Core/SessionManaging.swift
@@ -17,15 +17,10 @@ public protocol AuthenticationListeningDelegate {
     func clientDidClearAccount()
 }
 
-/// A protocol representing a type that can be canceled
-public protocol Cancelable {
-    func cancel()
-}
-
 /// Wrapper for the response returned by the session manager
-public struct SessionManagingResponse {
+public struct SessionManagingResponse<T> {
     let task: URLSessionDataTask?
-    let value: Any?
+    let value: T?
     let error: Error?
 }
 
@@ -38,9 +33,9 @@ public protocol SessionManaging {
     /// Entrypoint for requests to be run by the session manager
     func request(
         with endpoint: EndpointType,
-        then callback: @escaping (SessionManagingResponse) -> Void
+        then callback: @escaping (SessionManagingResponse<Any>) -> Void
     ) -> Cancelable?
-
+    
 }
 
 /// A protocol representing an endpoint to which requests can be sent to
@@ -51,5 +46,10 @@ public protocol EndpointType {
 }
 
 extension Request: EndpointType {}
+
+/// A protocol representing a type that can be canceled
+public protocol Cancelable {
+    func cancel()
+}
 
 extension URLSessionDataTask: Cancelable {}

--- a/Sources/Shared/Core/SessionManaging.swift
+++ b/Sources/Shared/Core/SessionManaging.swift
@@ -22,21 +22,12 @@ public protocol Cancelable {
     func cancel()
 }
 
-/// Wrapper for the error returned by the session manager
-/// It can optionally include the corresponding task that generated the error
-public struct SessionManagingError: Error {
-    let task: URLSessionDataTask?
-    let error: Error
-}
-
 /// Wrapper for the response returned by the session manager
-/// including the corresponding task that originated the response value (if any)
 public struct SessionManagingResponse {
-    let task: URLSessionDataTask
+    let task: URLSessionDataTask?
     let value: Any?
+    let error: Error?
 }
-
-public typealias SessionManagingResult = (Result<SessionManagingResponse, SessionManagingError>) -> Void
 
 /// A protocol describing the requirements of a SessionManaging type
 public protocol SessionManaging {
@@ -47,7 +38,7 @@ public protocol SessionManaging {
     /// Entrypoint for requests to be run by the session manager
     func request(
         with endpoint: EndpointType,
-        then callback: @escaping SessionManagingResult
+        then callback: @escaping (SessionManagingResponse) -> Void
     ) -> Cancelable?
 
 }

--- a/Sources/Shared/Core/SessionManaging.swift
+++ b/Sources/Shared/Core/SessionManaging.swift
@@ -40,12 +40,14 @@ public protocol SessionManaging {
 
 /// A protocol representing an endpoint to which requests can be sent to
 public protocol EndpointType {
-    var path: String { get }
+    var uri: String { get }
     var parameters: Any? { get }
     var method: HTTPMethod { get }
 }
 
-extension Request: EndpointType {}
+extension Request: EndpointType {
+    public var uri: String { return path }
+}
 
 /// A protocol representing a type that can be canceled
 public protocol Cancelable {

--- a/Sources/Shared/Core/SessionManaging.swift
+++ b/Sources/Shared/Core/SessionManaging.swift
@@ -1,0 +1,51 @@
+//
+//  VimeoSessionManaging.swift
+//  VimeoNetworking
+//
+//  Created by Rogerio de Paula Assis on 9/5/19.
+//  Copyright © 2019 Vimeo. All rights reserved.
+//
+
+import Foundation
+
+/// The protocols declared in this file have been created to abstract our dependency
+/// on AFNetworking and the Vimeo subclasses that inherit from it,
+/// Specifically `VimeoSessionManager`, `VimeoRequestSerializer` and `VimeoResponseSerializer`
+
+public protocol AuthenticationListeningDelegate {
+    func clientDidAuthenticate(with account: VIMAccount)
+    func clientDidClearAccount()
+}
+
+public protocol Cancellable {
+    func cancel()
+}
+
+public struct SessionManagingError: Error {
+    let task: URLSessionDataTask?
+    let error: Error
+}
+
+public struct SessionManagingResponse {
+    let task: URLSessionDataTask
+    let value: Any?
+}
+
+public typealias SessionManagingResult = (Result<SessionManagingResponse, SessionManagingError>) -> Void
+
+public protocol SessionManaging {
+    func invalidate()
+    func request(
+        _ endpoint: EndpointType,
+        then callback: @escaping SessionManagingResult
+    ) -> Cancellable?
+
+}
+
+public protocol EndpointType {
+    var path: String { get }
+    var parameters: Any? { get }
+    var method: HTTPMethod { get }
+}
+
+extension Request: EndpointType {}

--- a/Sources/Shared/Core/SessionManaging.swift
+++ b/Sources/Shared/Core/SessionManaging.swift
@@ -11,21 +11,26 @@ import Foundation
 /// The protocols declared in this file have been created to abstract our dependency
 /// on AFNetworking and the Vimeo subclasses that inherit from it,
 /// Specifically `VimeoSessionManager`, `VimeoRequestSerializer` and `VimeoResponseSerializer`
-
+/// The goal is to make it easier for these dependencies to be swapped out when needed.
 public protocol AuthenticationListeningDelegate {
     func clientDidAuthenticate(with account: VIMAccount)
     func clientDidClearAccount()
 }
 
-public protocol Cancellable {
+/// A protocol representing a type that can be canceled
+public protocol Cancelable {
     func cancel()
 }
 
+/// Wrapper for the error returned by the session manager
+/// It can optionally include the corresponding task that generated the error
 public struct SessionManagingError: Error {
     let task: URLSessionDataTask?
     let error: Error
 }
 
+/// Wrapper for the response returned by the session manager
+/// including the corresponding task that originated the response value (if any)
 public struct SessionManagingResponse {
     let task: URLSessionDataTask
     let value: Any?
@@ -33,15 +38,21 @@ public struct SessionManagingResponse {
 
 public typealias SessionManagingResult = (Result<SessionManagingResponse, SessionManagingError>) -> Void
 
+/// A protocol describing the requirements of a SessionManaging type
 public protocol SessionManaging {
+    
+    /// Used to invalidate the session manager
     func invalidate()
+    
+    /// Entrypoint for requests to be run by the session manager
     func request(
-        _ endpoint: EndpointType,
+        with endpoint: EndpointType,
         then callback: @escaping SessionManagingResult
-    ) -> Cancellable?
+    ) -> Cancelable?
 
 }
 
+/// A protocol representing an endpoint to which requests can be sent to
 public protocol EndpointType {
     var path: String { get }
     var parameters: Any? { get }
@@ -49,3 +60,5 @@ public protocol EndpointType {
 }
 
 extension Request: EndpointType {}
+
+extension URLSessionDataTask: Cancelable {}

--- a/Sources/Shared/Request+Authentication.swift
+++ b/Sources/Shared/Request+Authentication.swift
@@ -74,7 +74,7 @@ extension Request where ModelType: VIMAccount {
         let parameters = [GrantTypeKey: GrantTypeClientCredentials,
                           ScopeKey: Scope.combine(scopes)]
         
-        return Request(method: .POST, path: AuthenticationPathClientCredentials, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathClientCredentials, parameters: parameters)
     }
     
     /**
@@ -90,7 +90,7 @@ extension Request where ModelType: VIMAccount {
                           CodeKey: code,
                           RedirectURIKey: redirectURI]
         
-        return Request(method: .POST, path: AuthenticationPathCodeGrant, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathCodeGrant, parameters: parameters)
     }
     
     /**
@@ -108,7 +108,7 @@ extension Request where ModelType: VIMAccount {
                           UsernameKey: email,
                           PasswordKey: password]
         
-        return Request(method: .POST, path: AuthenticationPathAccessToken, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathAccessToken, parameters: parameters)
     }
     
     /**
@@ -117,7 +117,7 @@ extension Request where ModelType: VIMAccount {
      - returns: a new `Request`
      */
     static func verifyAccessTokenRequest() -> Request {
-        return Request(method: .GET, path: AuthenticationPathAccessTokenVerify)
+        return Request(method: .get, path: AuthenticationPathAccessTokenVerify)
     }
     
     /**
@@ -137,7 +137,7 @@ extension Request where ModelType: VIMAccount {
                           PasswordKey: password,
                           MarketingOptIn: marketingOptIn]
         
-        return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathUsers, parameters: parameters)
     }
     
     /**
@@ -153,7 +153,7 @@ extension Request where ModelType: VIMAccount {
                           ScopeKey: Scope.combine(scopes),
                           TokenKey: facebookToken]
         
-        return Request(method: .POST, path: AuthenticationPathFacebookToken, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathFacebookToken, parameters: parameters)
     }
     
     /**
@@ -169,7 +169,7 @@ extension Request where ModelType: VIMAccount {
                           TokenKey: facebookToken,
                           MarketingOptIn: marketingOptIn]
         
-        return Request(method: .POST, path: AuthenticationPathUsers, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathUsers, parameters: parameters)
     }
     
     /**
@@ -184,7 +184,7 @@ extension Request where ModelType: VIMAccount {
         let parameters = [PinCodeKey: userCode,
                           DeviceCodeKey: deviceCode]
         
-        return Request(method: .POST, path: AuthenticationPathPinCodeAuthorize, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathPinCodeAuthorize, parameters: parameters)
     }
     
     /**
@@ -197,7 +197,7 @@ extension Request where ModelType: VIMAccount {
     static func appTokenExchangeRequest(withAccessToken accessToken: String) -> Request {
         let parameters = [AccessTokenKey: accessToken]
         
-        return Request(method: .POST, path: AuthenticationPathAppTokenExchange, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathAppTokenExchange, parameters: parameters)
     }
 }
 
@@ -208,7 +208,7 @@ extension Request where ModelType: VIMNullResponse {
      - returns: a new `Request`
      */
     public static func deleteTokensRequest() -> Request {
-        return Request(method: .DELETE, path: AuthenticationPathTokens, retryPolicy: .TryThreeTimes)
+        return Request(method: .delete, path: AuthenticationPathTokens, retryPolicy: .TryThreeTimes)
     }
     
     /**
@@ -221,7 +221,7 @@ extension Request where ModelType: VIMNullResponse {
     public static func resetPasswordRequest(withEmail email: String) -> Request {
         let path = "/users/\(email)/password/reset"
         
-        return Request(method: .POST, path: path)
+        return Request(method: .post, path: path)
     }
 }
 
@@ -241,6 +241,6 @@ extension Request where ModelType: PinCodeInfo {
         let parameters = [GrantTypeKey: GrantTypePinCode,
                           ScopeKey: Scope.combine(scopes)]
         
-        return Request(method: .POST, path: AuthenticationPathPinCode, parameters: parameters)
+        return Request(method: .post, path: AuthenticationPathPinCode, parameters: parameters)
     }
 }

--- a/Sources/Shared/Request+Comment.swift
+++ b/Sources/Shared/Request+Comment.swift
@@ -19,6 +19,6 @@ public extension Request {
     static func postCommentRequest(forURI uri: String, text: String) -> Request {
         let parameters = ["text": text]
         
-        return Request(method: .POST, path: uri, parameters: parameters)
+        return Request(method: .post, path: uri, parameters: parameters)
     }
 }

--- a/Sources/Shared/Request+Configs.swift
+++ b/Sources/Shared/Request+Configs.swift
@@ -20,10 +20,10 @@ extension Request {
         let path = "/configs"
         
         if cache {
-            return Request(method: .GET, path: path, useCache: true)
+            return Request(method: .get, path: path, useCache: true)
         }
         else {
-            return Request(method: .GET, path: path, cacheResponse: true)
+            return Request(method: .get, path: path, cacheResponse: true)
         }
     }
 }

--- a/Sources/Shared/Request+Notifications.swift
+++ b/Sources/Shared/Request+Notifications.swift
@@ -21,7 +21,7 @@ public extension Request {
     static func setDeviceAsActiveToReceiveNotifications(forNotificationsURI notificationsURI: String, deviceToken: String) -> Request {
         let subscriptionsURI = Request.subscriptionsURI(forNotificationsURI: notificationsURI, deviceToken: deviceToken)
 
-        return Request(method: .PUT, path: subscriptionsURI, parameters: nil)
+        return Request(method: .put, path: subscriptionsURI, parameters: nil)
     }
 
     /// Retrieve the notification subscriptions.
@@ -30,7 +30,7 @@ public extension Request {
     static func getNotificationSubscriptionRequest(forNotificationsURI notificationsURI: String, deviceToken: String) -> Request {
         let subscriptionsURI = Request.subscriptionsURI(forNotificationsURI: notificationsURI, deviceToken: deviceToken)
 
-        return Request(method: .GET, path: subscriptionsURI, parameters: nil)
+        return Request(method: .get, path: subscriptionsURI, parameters: nil)
     }
 
     /// Create a request that updates the push notification subscriptions
@@ -40,7 +40,7 @@ public extension Request {
     static func updateNotificationSubscriptionsRequest(withSubscription subscription: VimeoClient.RequestParametersDictionary, notificationsURI: String, deviceToken: String) -> Request {
         let subscriptionsURI = Request.subscriptionsURI(forNotificationsURI: notificationsURI, deviceToken: deviceToken)
 
-        return Request(method: .PATCH, path: subscriptionsURI, parameters: subscription)
+        return Request(method: .patch, path: subscriptionsURI, parameters: subscription)
     }
 
     // MARK: - Helper
@@ -51,7 +51,7 @@ public extension Request {
     
     static func markNotificationAsNotNewRequest(forNotification notification: VIMNotification, notificationsURI: String) -> Request {
         guard let latestURI = notification.uri else {
-            return Request(method: .PATCH, path: notificationsURI, parameters: nil)
+            return Request(method: .patch, path: notificationsURI, parameters: nil)
         }
 
         let parameters = [
@@ -59,7 +59,7 @@ public extension Request {
             "new" : "false"
         ]
 
-        return Request(method: .PATCH, path: notificationsURI, parameters: parameters)
+        return Request(method: .patch, path: notificationsURI, parameters: parameters)
     }
 
     static func markNotificationsAsSeenRequest(forNotifications notifications: [VIMNotification], notificationsURI: String) -> Request {
@@ -73,6 +73,6 @@ public extension Request {
             }
         }
 
-        return Request(method: .PATCH, path: notificationsURI, parameters: parameters)
+        return Request(method: .patch, path: notificationsURI, parameters: parameters)
     }
 }

--- a/Sources/Shared/Request+Picture.swift
+++ b/Sources/Shared/Request+Picture.swift
@@ -20,7 +20,7 @@ public extension Request {
     static func createPictureRequest(forUserURI userURI: String) -> Request {
         let uri = "\(userURI)/pictures"
         
-        return Request(method: .POST, path: uri)
+        return Request(method: .post, path: uri)
     }
     
     /**
@@ -31,7 +31,7 @@ public extension Request {
      - returns: a new `Request`
      */
     static func deletePictureRequest(forPictureURI pictureURI: String) -> Request {
-        return Request(method: .DELETE, path: pictureURI)
+        return Request(method: .delete, path: pictureURI)
     }
     
     /**
@@ -44,6 +44,6 @@ public extension Request {
     static func activatePictureRequest(forPictureURI pictureURI: String) -> Request {
         let parameters = ["active": "true"]
         
-        return Request(method: .PATCH, path: pictureURI, parameters: parameters)
+        return Request(method: .patch, path: pictureURI, parameters: parameters)
     }
 }

--- a/Sources/Shared/Request+Toggle.swift
+++ b/Sources/Shared/Request+Toggle.swift
@@ -39,6 +39,6 @@ public extension Request {
      - returns: a new `Request`
      */
     static func toggle(forURI uri: String, newValue: Bool) -> Request {
-        return Request(method: newValue ? .PUT : .DELETE, path: uri)
+        return Request(method: newValue ? .put : .delete, path: uri)
     }
 }

--- a/Sources/Shared/Request+User.swift
+++ b/Sources/Shared/Request+User.swift
@@ -129,6 +129,6 @@ public extension Request {
      - returns: the new `Request`
      */
     static func patchUser(withUserURI userURI: String, parameters: VimeoClient.RequestParametersDictionary) -> Request {
-        return Request(method: .PATCH, path: userURI, parameters: parameters)
+        return Request(method: .patch, path: userURI, parameters: parameters)
     }
 }

--- a/Sources/Shared/Request+Video.swift
+++ b/Sources/Shared/Request+Video.swift
@@ -109,7 +109,7 @@ public extension Request {
      - returns: a new `Request`
      */
     static func patchVideoRequest(withVideoURI videoURI: String, parameters: VimeoClient.RequestParametersDictionary) -> Request {
-        return Request(method: .PATCH, path: videoURI, parameters: parameters)
+        return Request(method: .patch, path: videoURI, parameters: parameters)
     }
     
     /**
@@ -120,6 +120,6 @@ public extension Request {
      - returns: a new `Request`
      */
     static func deleteVideoRequest(forVideoURI videoURI: String) -> Request {
-        return Request(method: .DELETE, path: videoURI)
+        return Request(method: .delete, path: videoURI)
     }
 }

--- a/Sources/Shared/Request.swift
+++ b/Sources/Shared/Request.swift
@@ -47,9 +47,9 @@ public enum RetryPolicy {
      
      - returns: the default retry policy for the given `Method`
      */
-    static func defaultPolicyForMethod(for method: VimeoClient.Method) -> RetryPolicy {
+    static func defaultPolicyForMethod(for method: HTTPMethod) -> RetryPolicy {
         switch method {
-        case .GET, .DELETE, .PATCH, .POST, .PUT:
+        case .get, .delete, .patch, .post, .put, .connect, .head, .options, .trace:
             return .singleAttempt
         }
     }
@@ -72,25 +72,25 @@ public struct Request<ModelType: MappableResponse> {
     
     // MARK: -
     
-        /// HTTP method (e.g. `.GET`, `.POST`)
-    public let method: VimeoClient.Method
+    /// HTTP method (e.g. `.GET`, `.POST`)
+    public let method: HTTPMethod
     
-        /// request url path (e.g. `/me`, `/videos/123456`)
+    /// request url path (e.g. `/me`, `/videos/123456`)
     public let path: String
     
-        /// any parameters to include with the request
+    /// any parameters to include with the request
     public let parameters: Any?
 
-        /// query a nested JSON key path for the response model object to be returned
+    /// query a nested JSON key path for the response model object to be returned
     public let modelKeyPath: String?
     
-        /// describes how this request should query for cached responses
+    /// describes how this request should query for cached responses
     public let useCache: Bool
     
-        /// whether a successful response to this request should be stored in cache
+    /// whether a successful response to this request should be stored in cache
     public let cacheResponse: Bool
     
-        /// describes how the request should handle retrying after failure
+    /// describes how the request should handle retrying after failure
     internal(set) public var retryPolicy: RetryPolicy
     
     // MARK: -
@@ -108,7 +108,7 @@ public struct Request<ModelType: MappableResponse> {
      
      - returns: an initialized `Request`
      */
-    public init(method: VimeoClient.Method = .GET,
+    public init(method: HTTPMethod = .get,
                 path: String,
                 parameters: Any? = nil,
                 modelKeyPath: String? = nil,

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -198,10 +198,9 @@ final public class VimeoClient {
             return RequestToken(path: request.path, task: nil)
         }
         else {
-            let task = self.sessionManager?.request(with: request, then: { result in
+            let task = self.sessionManager?.request(with: request, then: { response in
                 DispatchQueue.global(qos: .userInitiated).async {
-                    switch result {
-                    case .success(let response):
+                    if response.error == nil {
                         self.handleTaskSuccess(
                             forRequest: request,
                             task: response.task,
@@ -209,12 +208,11 @@ final public class VimeoClient {
                             completionQueue: completionQueue,
                             completion: completion
                         )
-
-                    case .failure(let error):
+                    } else {
                         self.handleTaskFailure(
                             forRequest: request,
-                            task: error.task,
-                            error: error.error as NSError,
+                            task: response.task,
+                            error: response.error as NSError?,
                             completionQueue: completionQueue,
                             completion: completion
                         )

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -41,7 +41,7 @@ final public class VimeoClient {
         public let path: String?
         
         /// The data task of the request
-        public let task: Cancellable?
+        public let task: Cancelable?
         
         /**
          Cancel the request
@@ -198,7 +198,7 @@ final public class VimeoClient {
             return RequestToken(path: request.path, task: nil)
         }
         else {
-            let task = self.sessionManager?.request(request, then: { result in
+            let task = self.sessionManager?.request(with: request, then: { result in
                 DispatchQueue.global(qos: .userInitiated).async {
                     switch result {
                     case .success(let response):

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -33,24 +33,6 @@ import Foundation
 final public class VimeoClient {
     // MARK: -
     
-    /// HTTP methods available for requests
-    public enum Method: String {
-        /// Retrieve a resource
-        case GET
-        
-        /// Create a new resource
-        case POST
-        
-        /// Set a resource
-        case PUT
-        
-        /// Update a resource
-        case PATCH
-        
-        /// Remove a resource
-        case DELETE
-    }
-    
     /**
      *  `RequestToken` stores a reference to an in-flight request
      */
@@ -59,7 +41,7 @@ final public class VimeoClient {
         public let path: String?
         
         /// The data task of the request
-        public let task: URLSessionDataTask?
+        public let task: Cancellable?
         
         /**
          Cancel the request
@@ -83,8 +65,9 @@ final public class VimeoClient {
     
     // MARK: -
     
-        /// Session manager handles the http session data tasks and request/response serialization
-    fileprivate var sessionManager: VimeoSessionManager? = nil
+    /// Session manager handles the http session data tasks and request/response serialization
+    public typealias SessionManagingAuthenticationListening = SessionManaging & AuthenticationListeningDelegate
+    fileprivate var sessionManager: SessionManagingAuthenticationListening? = nil
     
         /// response cache handles all memory and disk caching of response dictionaries
     private let responseCache = ResponseCache()
@@ -129,7 +112,7 @@ final public class VimeoClient {
     public init(
         appConfiguration: AppConfiguration? = nil,
         reachabilityManager: ReachabilityManaging? = VimeoReachabilityProvider.reachabilityManager,
-        sessionManager: VimeoSessionManager? = nil
+        sessionManager: SessionManagingAuthenticationListening? = nil
     ) {
         self.reachabilityManager = reachabilityManager
         if let appConfiguration = appConfiguration,
@@ -215,48 +198,48 @@ final public class VimeoClient {
             return RequestToken(path: request.path, task: nil)
         }
         else {
-            let success: (URLSessionDataTask, Any?) -> Void = { (task, responseObject) in
-                
+            let task = self.sessionManager?.request(request, then: { result in
                 DispatchQueue.global(qos: .userInitiated).async {
-                    
-                    self.handleTaskSuccess(forRequest: request, task: task, responseObject: responseObject, completionQueue: completionQueue, completion: completion)
-                }
-            }
-            
-            let failure: (URLSessionDataTask?, Error) -> Void = { (task, error) in
-                
-                DispatchQueue.global(qos: .userInitiated).async {
+                    switch result {
+                    case .success(let response):
+                        self.handleTaskSuccess(
+                            forRequest: request,
+                            task: response.task,
+                            responseObject: response.value,
+                            completionQueue: completionQueue,
+                            completion: completion
+                        )
 
-                    self.handleTaskFailure(forRequest: request, task: task, error: error as NSError, completionQueue: completionQueue, completion: completion)
+                    case .failure(let error):
+                        self.handleTaskFailure(
+                            forRequest: request,
+                            task: error.task,
+                            error: error.error as NSError,
+                            completionQueue: completionQueue,
+                            completion: completion
+                        )
+                    }
                 }
-            }
-            
-            let path = request.path
-            let parameters = request.parameters
-            
-            let task: URLSessionDataTask?
-            
-            switch request.method {
-            case .GET:
-                task = self.sessionManager?.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
-            case .POST:
-                task = self.sessionManager?.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
-            case .PUT:
-                task = self.sessionManager?.put(path, parameters: parameters, success: success, failure: failure)
-            case .PATCH:
-                task = self.sessionManager?.patch(path, parameters: parameters, success: success, failure: failure)
-            case .DELETE:
-                task = self.sessionManager?.delete(path, parameters: parameters, success: success, failure: failure)
-            }
+            })
             
             guard let requestTask = task else {
                 let description = "Session manager did not return a task"
                 
                 assertionFailure(description)
                 
-                let error = NSError(domain: type(of: self).ErrorDomain, code: LocalErrorCode.requestMalformed.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
+                let error = NSError(
+                    domain: type(of: self).ErrorDomain,
+                    code: LocalErrorCode.requestMalformed.rawValue,
+                    userInfo: [NSLocalizedDescriptionKey: description]
+                )
                 
-                self.handleTaskFailure(forRequest: request, task: task, error: error, completionQueue: completionQueue, completion: completion)
+                self.handleTaskFailure(
+                    forRequest: request,
+                    task: nil,
+                    error: error,
+                    completionQueue: completionQueue,
+                    completion: completion
+                )
                 
                 return RequestToken(path: request.path, task: nil)
             }
@@ -467,7 +450,7 @@ extension VimeoClient {
             configureSessionManagerBlock: configureSessionManagerBlock
         )
         
-        self._sharedClient.sessionManager?.invalidateSessionCancelingTasks(false)
+        self._sharedClient.sessionManager?.invalidate()
         self._sharedClient.sessionManager = defaultSessionManager
         self._sharedClient.reachabilityManager = reachabilityManager
                 

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -67,7 +67,7 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
     
     public func request(
         with endpoint: EndpointType,
-        then callback: @escaping (SessionManagingResponse) -> Void
+        then callback: @escaping (SessionManagingResponse<Any>) -> Void
     ) -> Cancelable? {
         let path = endpoint.path
         let parameters = endpoint.parameters
@@ -82,7 +82,7 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
         }
         
         let failureCallback: SessionManagingDataTaskFailure = { dataTask, error in
-            let response = SessionManagingResponse(
+            let response = SessionManagingResponse<Any>(
                 task: dataTask,
                 value: nil,
                 error: error

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -69,7 +69,7 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
         with endpoint: EndpointType,
         then callback: @escaping (SessionManagingResponse<Any>) -> Void
     ) -> Cancelable? {
-        let path = endpoint.path
+        let path = endpoint.uri
         let parameters = endpoint.parameters
         
         var task: Cancelable?

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -46,7 +46,11 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
      
      - returns: an initialized `VimeoSessionManager`
      */
-    required public init(baseUrl: URL, sessionConfiguration: URLSessionConfiguration, requestSerializer: VimeoRequestSerializer) {
+    required public init(
+        baseUrl: URL,
+        sessionConfiguration: URLSessionConfiguration,
+        requestSerializer: VimeoRequestSerializer
+    ) {
         super.init(baseURL: baseUrl, sessionConfiguration: sessionConfiguration)
         
         self.requestSerializer = requestSerializer
@@ -63,7 +67,7 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
     
     public func request(
         with endpoint: EndpointType,
-        then callback: @escaping SessionManagingResult
+        then callback: @escaping (SessionManagingResponse) -> Void
     ) -> Cancelable? {
         let path = endpoint.path
         let parameters = endpoint.parameters
@@ -71,13 +75,19 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
         var task: Cancelable?
         
         let successCallback: SessionManagingDataTaskSuccess = { dataTask, value in
-            let response = SessionManagingResponse(task: dataTask, value: value)
-            callback(Result.success(response))
+            let response = SessionManagingResponse(
+                task: dataTask, value: value, error: nil
+            )
+            callback(response)
         }
         
         let failureCallback: SessionManagingDataTaskFailure = { dataTask, error in
-            let sessionError = SessionManagingError(task: dataTask, error: error)
-            callback(Result.failure(sessionError))
+            let response = SessionManagingResponse(
+                task: dataTask,
+                value: nil,
+                error: error
+            )
+            callback(response)
         }
         
         switch endpoint.method {

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -72,40 +72,30 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
         let path = endpoint.uri
         let parameters = endpoint.parameters
         
-        var task: Cancelable?
-        
-        let successCallback: SessionManagingDataTaskSuccess = { dataTask, value in
-            let response = SessionManagingResponse(
-                task: dataTask, value: value, error: nil
-            )
+        let success: SessionManagingDataTaskSuccess = { dataTask, value in
+            let response = SessionManagingResponse(task: dataTask, value: value, error: nil)
             callback(response)
         }
         
-        let failureCallback: SessionManagingDataTaskFailure = { dataTask, error in
-            let response = SessionManagingResponse<Any>(
-                task: dataTask,
-                value: nil,
-                error: error
-            )
+        let failure: SessionManagingDataTaskFailure = { dataTask, error in
+            let response = SessionManagingResponse<Any>(task: dataTask, value: nil, error: error)
             callback(response)
         }
         
         switch endpoint.method {
         case .get:
-            task = self.get(path, parameters: parameters, progress: nil, success: successCallback, failure: failureCallback)
+            return self.get(path, parameters: parameters, progress: nil, success: success, failure: failure)
         case .post:
-            task = self.post(path, parameters: parameters, progress: nil, success: successCallback, failure: failureCallback)
+            return self.post(path, parameters: parameters, progress: nil, success: success, failure: failure)
         case .put:
-            task = self.put(path, parameters: parameters, success: successCallback, failure: failureCallback)
+            return self.put(path, parameters: parameters, success: success, failure: failure)
         case .patch:
-            task = self.patch(path, parameters: parameters, success: successCallback, failure: failureCallback)
+            return self.patch(path, parameters: parameters, success: success, failure: failure)
         case .delete:
-            task = self.delete(path, parameters: parameters, success: successCallback, failure: failureCallback)
+            return self.delete(path, parameters: parameters, success: success, failure: failure)
         case .connect, .head, .options, .trace:
-            break
-        }
-        
-        return task
+            return nil
+        }                
     }
 }
 

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -31,8 +31,6 @@ private typealias SessionManagingDataTaskSuccess = ((URLSessionDataTask, Any?) -
 private typealias SessionManagingDataTaskFailure = ((URLSessionDataTask?, Error) -> Void)
 private typealias SessionManagingDataTaskProgress = (Progress) -> Void
 
-extension URLSessionDataTask: Cancellable {}
-
 /** `VimeoSessionManager` handles networking and serialization for raw HTTP requests.  It is a direct subclass of `AFHTTPSessionManager` and it's designed to be used internally by `VimeoClient`.  For the majority of purposes, it would be better to use `VimeoClient` and a `Request` object to better encapsulate this logic, since the latter provides richer functionality overall.
  */
 final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
@@ -64,13 +62,13 @@ final public class VimeoSessionManager: AFHTTPSessionManager, SessionManaging {
     }
     
     public func request(
-        _ endpoint: EndpointType,
+        with endpoint: EndpointType,
         then callback: @escaping SessionManagingResult
-    ) -> Cancellable? {
+    ) -> Cancelable? {
         let path = endpoint.path
         let parameters = endpoint.parameters
         
-        var task: Cancellable?
+        var task: Cancelable?
         
         let successCallback: SessionManagingDataTaskSuccess = { dataTask, value in
             let response = SessionManagingResponse(task: dataTask, value: value)

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -129,6 +129,5 @@ extension VimeoSessionManager: AuthenticationListeningDelegate {
         }
         
         requestSerializer.accessTokenProvider = nil
-    }
-    
+    }    
 }

--- a/Sources/iOS/Request+Trigger.swift
+++ b/Sources/iOS/Request+Trigger.swift
@@ -26,7 +26,7 @@ extension Request {
     public static func registerDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersDictionary) -> Request {
         let uri = self.uri(forDeviceToken: deviceToken)
         
-        return Request(method: .PUT, path: uri, parameters: parameters)
+        return Request(method: .put, path: uri, parameters: parameters)
     }
     
     /**
@@ -41,7 +41,7 @@ extension Request {
     public static func unregisterDeviceForPushNotifications(withDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersDictionary) -> Request {
         let uri = self.uri(forDeviceToken: deviceToken)
 
-        return Request(method: .DELETE, path: uri, parameters: parameters)
+        return Request(method: .delete, path: uri, parameters: parameters)
     }
     
     /**
@@ -53,7 +53,7 @@ extension Request {
      - returns: a new `Request`
      */
     public static func addPushNotificationTrigger(withParameters parameters: VimeoClient.RequestParametersDictionary) -> Request {
-        return Request(method: .POST, path: self.TriggersURI, parameters: parameters)
+        return Request(method: .post, path: self.TriggersURI, parameters: parameters)
     }
     
     /**
@@ -65,7 +65,7 @@ extension Request {
      - returns: a new `Request`
      */
     public static func removePushNotificationTrigger(forTriggerURI triggerURI: String) -> Request {
-        return Request(method: .DELETE, path: triggerURI)
+        return Request(method: .delete, path: triggerURI)
     }
     
     /**
@@ -79,7 +79,7 @@ extension Request {
     public static func pushNotificationTriggers(forDeviceToken deviceToken: String, parameters: VimeoClient.RequestParametersArray) -> Request {
         let uri = self.uri(forDeviceToken: deviceToken) + self.TriggersURI
 
-        return Request(method: .PUT, path: uri, parameters: parameters, modelKeyPath: "data")
+        return Request(method: .put, path: uri, parameters: parameters, modelKeyPath: "data")
     }
     
     // MARK: Helpers

--- a/Tests/Shared/Core/URLEncodingTests.swift
+++ b/Tests/Shared/Core/URLEncodingTests.swift
@@ -10,12 +10,6 @@ import Foundation
 import XCTest
 @testable import VimeoNetworking
 
-extension URLRequest: URLRequestConvertible {
-    public func asURLRequest() throws -> URLRequest {
-        return self
-    }
-}
-
 class URLParameterEncodingTestCase: XCTestCase {
     
     let urlRequest = URLRequest(url: URL(string: "https://example.com/")!)

--- a/Tests/Shared/RequestTestUtilities.swift
+++ b/Tests/Shared/RequestTestUtilities.swift
@@ -48,7 +48,7 @@ class RequestComparisons {
     }
     
     static func ValidateDefaults<ModelType>(request: Request<ModelType>) -> Bool {
-        return request.method == .GET
+        return request.method == .get
             && request.parameters == nil
             && request.modelKeyPath == nil
             && request.cacheResponse == false

--- a/Tests/Shared/RequestTests.swift
+++ b/Tests/Shared/RequestTests.swift
@@ -48,19 +48,19 @@ class RequestTests: XCTestCase {
     }
     
     func test_RetryPolicy_DefaultPolicyForMethodShouldReturnSingleAttempt() {
-        var defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .GET)
+        var defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .get)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(defaultPolicy, .singleAttempt), "RetryPolicy.defaultPolicyForMethod should return singleAttempt for all methods")
         
-        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .POST)
+        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .post)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(defaultPolicy, .singleAttempt), "RetryPolicy.defaultPolicyForMethod should return singleAttempt for all methods")
 
-        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .PUT)
+        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .put)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(defaultPolicy, .singleAttempt), "RetryPolicy.defaultPolicyForMethod should return singleAttempt for all methods")
 
-        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .PATCH)
+        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .patch)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(defaultPolicy, .singleAttempt), "RetryPolicy.defaultPolicyForMethod should return singleAttempt for all methods")
         
-        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .DELETE)
+        defaultPolicy = RetryPolicy.defaultPolicyForMethod(for: .delete)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(defaultPolicy, .singleAttempt), "RetryPolicy.defaultPolicyForMethod should return singleAttempt for all methods")
     }
     
@@ -80,7 +80,7 @@ class RequestTests: XCTestCase {
     
     func test_Request_setValuesThroughConstructor() {
         let testPath = "/test"
-        let request = Request<VIMNullResponse>(method: .POST,
+        let request = Request<VIMNullResponse>(method: .post,
                                                path: testPath,
                                                parameters: ["param" : "test field"],
                                                modelKeyPath: "data",
@@ -91,7 +91,7 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(request.path, testPath)
         XCTAssertEqual(request.URI, "/test?param=test%20field")
         XCTAssertTrue(request.cacheResponse)
-        XCTAssertEqual(request.method, .POST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.useCache, true)
         XCTAssertTrue(RequestComparisons.CompareRetryPolicies(request.retryPolicy, .multipleAttempts(attemptCount: 3, initialDelay: 2.0)))
     }

--- a/VimeoNetworking.xcodeproj/project.pbxproj
+++ b/VimeoNetworking.xcodeproj/project.pbxproj
@@ -693,6 +693,9 @@
 		5B62639F2320605700B25462 /* JSONEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B62639B2320605700B25462 /* JSONEncodingTests.swift */; };
 		5B6263A02320605700B25462 /* JSONEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B62639B2320605700B25462 /* JSONEncodingTests.swift */; };
 		5B6263A12320605700B25462 /* JSONEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B62639B2320605700B25462 /* JSONEncodingTests.swift */; };
+		5B6263B32321402B00B25462 /* SessionManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6263B22321402B00B25462 /* SessionManaging.swift */; };
+		5B6263B42321402B00B25462 /* SessionManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6263B22321402B00B25462 /* SessionManaging.swift */; };
+		5B6263B52321402B00B25462 /* SessionManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6263B22321402B00B25462 /* SessionManaging.swift */; };
 		5B69E4E922DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
 		5B69E4EA22DE2E29009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
 		5B69E4EB22DE2E2A009E84B6 /* VIMUserAccountTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */; };
@@ -1003,6 +1006,7 @@
 		5B6263892320603200B25462 /* VimeoNetworkingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VimeoNetworkingError.swift; sourceTree = "<group>"; };
 		5B62639A2320605700B25462 /* URLEncodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLEncodingTests.swift; sourceTree = "<group>"; };
 		5B62639B2320605700B25462 /* JSONEncodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingTests.swift; sourceTree = "<group>"; };
+		5B6263B22321402B00B25462 /* SessionManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManaging.swift; sourceTree = "<group>"; };
 		5B69E4E522DE2E07009E84B6 /* VIMUserAccountTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VIMUserAccountTypeTests.swift; sourceTree = "<group>"; };
 		5B79213A22C2A58A00FC1928 /* AFNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AFNetworking.framework; sourceTree = "<group>"; };
 		5B79213D22C2A59300FC1928 /* AFNetworking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AFNetworking.framework; sourceTree = "<group>"; };
@@ -1485,6 +1489,7 @@
 				5B6263872320603200B25462 /* URLEncoding.swift */,
 				5B6263892320603200B25462 /* VimeoNetworkingError.swift */,
 				5B62636023203B0700B25462 /* URLRequestConvertible.swift */,
+				5B6263B22321402B00B25462 /* SessionManaging.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2411,6 +2416,7 @@
 				5B5EF15022B441A4005C66BE /* VIMTrigger.m in Sources */,
 				5B5EF09F22B441A4005C66BE /* VIMTag.m in Sources */,
 				5B5EF07822B441A3005C66BE /* VIMSizeQuota.swift in Sources */,
+				5B6263B32321402B00B25462 /* SessionManaging.swift in Sources */,
 				5B5EF1D722B441A4005C66BE /* AccountStore.swift in Sources */,
 				5B5EF1CB22B441A4005C66BE /* VimeoRequestSerializer.swift in Sources */,
 				5B5EF02422B441A3005C66BE /* Request+ProgrammedContent.swift in Sources */,
@@ -2541,6 +2547,7 @@
 				5B5EF17222B441A4005C66BE /* VIMComment.m in Sources */,
 				5B5EF15122B441A4005C66BE /* VIMTrigger.m in Sources */,
 				5B5EF0A022B441A4005C66BE /* VIMTag.m in Sources */,
+				5B6263B42321402B00B25462 /* SessionManaging.swift in Sources */,
 				5B5EF07922B441A3005C66BE /* VIMSizeQuota.swift in Sources */,
 				5B5EF1D822B441A4005C66BE /* AccountStore.swift in Sources */,
 				5B5EF1CC22B441A4005C66BE /* VimeoRequestSerializer.swift in Sources */,
@@ -2651,6 +2658,7 @@
 				5B5EF1BE22B441A4005C66BE /* Request.swift in Sources */,
 				5B5EF02922B441A3005C66BE /* Objc_ExceptionCatcher.m in Sources */,
 				5B5EF16722B441A4005C66BE /* VIMPreference.m in Sources */,
+				5B6263B52321402B00B25462 /* SessionManaging.swift in Sources */,
 				5B5EF03822B441A3005C66BE /* Result.swift in Sources */,
 				5B5EF1CA22B441A4005C66BE /* Dictionary+Extension.swift in Sources */,
 				5B5EF0DA22B441A4005C66BE /* VIMVODItem.m in Sources */,


### PR DESCRIPTION
#### Ticket

[VIM-XXXX](https://vimean.atlassian.net/browse/VIM-XXXX)

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

This PR introduces several protocol declarations with the main goal of making it easier to abstract and eventually remove our dependency on `AFNetworking`.

#### Implementation Summary

The key changes to pay attention to can be seen in `VimeoClient`, where we replaced the dependency on `VimeoSessionManager` by a composition of 2 protocols: `SessionManaging` and `AuthenticationListenerDelegate`.

Also some of the interactions with the `VimeoSessionManager` that previously occurred inside `VimeoClient` have been moved to the session manager subclass itself. This greatly simplified the protocol requirements for `SessionManaging` to a single `request` method that takes an `EndPointType` and a callback closure.

In a future PR this protocol will be extended to also allow for `Decodable` types to be serialized.

#### How to Test

This PR doesn't introduce any real functional changes so simply ensure that you can build & run, and that all tests pass. Also please take it for a spin in the app by checking out [this branch](feature/VIM-XXXX_AFNetworkingDeprecation).
