### PR TITLE
VIM-XXXX: 404 Not Found Extension on NSError

### DIFF
--- a/Sources/Shared/NSError+Extensions.swift
+++ b/Sources/Shared/NSError+Extensions.swift
@@ -35,12 +35,12 @@ public enum VimeoErrorKey: String {
 
 /// Convenience methods used to parse `NSError`s returned by Vimeo api responses
 @objc public extension NSError {
-        /// Returns true if the error is a 503 Service Unavailable error
+    /// Returns true if the error is a 503 Service Unavailable error
     var isServiceUnavailableError: Bool {
         return self.statusCode == HTTPStatusCode.serviceUnavailable.rawValue
     }
     
-        /// Returns true if the error is due to an invalid access token
+    /// Returns true if the error is due to an invalid access token
     var isInvalidTokenError: Bool {
         if let urlResponse = self.userInfo[AFNetworkingOperationFailingURLResponseErrorKey] as? HTTPURLResponse, urlResponse.statusCode == HTTPStatusCode.unauthorized.rawValue {
             if let header = urlResponse.allHeaderFields["Www-Authenticate"] as? String, header == "Bearer error=\"invalid_token\"" {
@@ -51,12 +51,12 @@ public enum VimeoErrorKey: String {
         return false
     }
     
-        /// Returns true if the error is due to the cancellation of a network task
+    /// Returns true if the error is due to the cancellation of a network task
     func isNetworkTaskCancellationError() -> Bool {
         return self.domain == NSURLErrorDomain && self.code == NSURLErrorCancelled
     }
     
-        /// Returns true if the error is a url connection error
+    /// Returns true if the error is a url connection error
     func isConnectionError() -> Bool {
         return [NSURLErrorTimedOut,
             NSURLErrorCannotFindHost,
@@ -64,6 +64,12 @@ public enum VimeoErrorKey: String {
             NSURLErrorDNSLookupFailed,
             NSURLErrorNotConnectedToInternet,
             NSURLErrorNetworkConnectionLost].contains(self.code)
+    }
+    
+    /// Returns true if the error code is 404 Not Found
+    var is404NotFoundError: Bool {
+        let response = userInfo[AFNetworkingOperationFailingURLResponseErrorKey] as? HTTPURLResponse
+        return response?.statusCode == 404
     }
     
     /**


### PR DESCRIPTION
#### Ticket

[VIM-7242](https://vimean.atlassian.net/browse/VIM-7242)

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

This ticket adds an extension to NSError that provides a way for consumers of this API to check for a 404 error code. The goal of this addition is to hide the implementation details of error checking that depends on `AFNetworking`.

This is required as part of the work to remove our dependency on `VimeoUpload` in [this PR](https://github.com/vimeo/VimeoUpload/pull/230)
