### PR TITLE
VIM-7371: Adds support for embed-only privacy setting

### DIFF
--- a/Sources/Shared/Models/VIMPrivacy.h
+++ b/Sources/Shared/Models/VIMPrivacy.h
@@ -35,6 +35,7 @@ extern NSString * __nonnull VIMPrivacy_Password;
 extern NSString * __nonnull VIMPrivacy_Unlisted;
 extern NSString * __nonnull VIMPrivacy_Disabled;
 extern NSString * __nonnull VIMPrivacy_Stock;
+extern NSString * __nonnull VIMPrivacy_EmbedOnly;
 
 @interface VIMPrivacy : VIMModelObject
 

--- a/Sources/Shared/Models/VIMPrivacy.m
+++ b/Sources/Shared/Models/VIMPrivacy.m
@@ -35,6 +35,7 @@ NSString *VIMPrivacy_Password = @"password";
 NSString *VIMPrivacy_Unlisted = @"unlisted";
 NSString *VIMPrivacy_Disabled = @"disable";
 NSString *VIMPrivacy_Stock = @"stock";
+NSString *VIMPrivacy_EmbedOnly = @"embed_only";
 
 @implementation VIMPrivacy
 


### PR DESCRIPTION
Adds the "embed_only" privacy option as a constant on `VIMPrivacy`. This value is required for hiding showcases from vimeo.com, while allowing them to be embedded elsewhere. 