### PR TITLE
VIM-XXXX: VimeoRequestSerializer refactor

### DIFF
--- a/Sources/Shared/AuthenticationController.swift
+++ b/Sources/Shared/AuthenticationController.swift
@@ -181,7 +181,9 @@ final public class AuthenticationController {
         let urlString = self.configuration.baseUrl.appendingPathComponent(Constants.CodeGrantAuthorizationPath).absoluteString
         
         var error: NSError?
-        let urlRequest = VimeoRequestSerializer(appConfiguration: self.configuration).request(withMethod: HTTPMethod.get.rawValue, urlString: urlString, parameters: parameters, error: &error)
+        let serializer = VimeoRequestSerializer(appConfiguration: self.configuration)
+        let urlRequest = serializer
+            .request(withMethod: .get, urlString: urlString, parameters: parameters, error: &error)
         
         guard let url = urlRequest.url, error == nil
         else {

--- a/Sources/Shared/AuthenticationController.swift
+++ b/Sources/Shared/AuthenticationController.swift
@@ -182,11 +182,14 @@ final public class AuthenticationController {
         
         var error: NSError?
         let serializer = VimeoRequestSerializer(appConfiguration: self.configuration)
-        let urlRequest = serializer
-            .request(withMethod: .get, urlString: urlString, parameters: parameters, error: &error)
+        let urlRequest = serializer.request(
+            withMethod: .get,
+            urlString: urlString,
+            parameters: parameters,
+            error: &error
+        )
         
-        guard let url = urlRequest.url, error == nil
-        else {
+        guard let url = urlRequest.url, error == nil else {
             fatalError("Could not make code grant auth URL")
         }
         

--- a/Sources/Shared/VimeoRequestSerializer.swift
+++ b/Sources/Shared/VimeoRequestSerializer.swift
@@ -104,16 +104,14 @@ final public class VimeoRequestSerializer {
         withParameters parameters: Any?,
         error: NSErrorPointer
     ) -> URLRequest? {
-        if var request = jsonSerializer.request(
+        guard let request = jsonSerializer.request(
             bySerializingRequest: request,
             withParameters: parameters,
             error: error
-        ) {
-            request = self.requestConfiguringHeaders(fromRequest: request)
-            return request
+        ) else {
+            return nil
         }
-
-        return nil
+        return self.requestConfiguringHeaders(fromRequest: request)
     }
     
     // MARK: Header Helpers
@@ -159,10 +157,8 @@ final public class VimeoRequestSerializer {
     }
     
     private func requestModifyingUserAgentHeader(fromRequest request: URLRequest) -> URLRequest {
-        let infoDictionary = Bundle(for: type(of: self)).infoDictionary
-        guard let frameworkVersion = infoDictionary?["CFBundleShortVersionString"] as? String else {
+        guard let frameworkVersion = Bundle(for: type(of: self)).shortVersionString else {
             assertionFailure("Unable to get the framework version")
-            
             return request
         }
         
@@ -189,6 +185,13 @@ final public class VimeoRequestSerializer {
         request.setValue(modifiedUserAgent, forHTTPHeaderField: .userAgentKey)
         
         return request
+    }
+}
+
+
+private extension Bundle {
+    var shortVersionString: String? {
+        return infoDictionary?["CFBundleShortVersionString"] as? String
     }
 }
 

--- a/Sources/Shared/VimeoRequestSerializer.swift
+++ b/Sources/Shared/VimeoRequestSerializer.swift
@@ -26,15 +26,10 @@
 
 import Foundation
 
-/** `VimeoRequestSerializer` is an `AFHTTPRequestSerializer` that primarily handles adding Vimeo-specific authorization headers to outbound requests.  It can be initialized with either a dynamic `AccessTokenProvider` or a static `AppConfiguration`.
- */
-final public class VimeoRequestSerializer: AFJSONRequestSerializer {
-    
-    private struct Constants {
-        static let AcceptHeaderKey = "Accept"
-        static let AuthorizationHeaderKey = "Authorization"
-        static let UserAgentKey = "User-Agent"
-    }
+/// `VimeoRequestSerializer` handles request serialization as well as adding Vimeo-specific authorization
+/// headers to outbound requests.
+/// It can be initialized with either a dynamic `AccessTokenProvider` or a static `AppConfiguration`.
+final public class VimeoRequestSerializer {
     
     public typealias AccessTokenProvider = () -> String?
     
@@ -45,7 +40,10 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
     
     // for unauthenticated requests
     private let appConfiguration: AppConfiguration?
-    
+
+    // Internal JSON serializer
+    private let jsonSerializer: AFJSONRequestSerializer
+
     // MARK: - Initialization
     
     /**
@@ -56,12 +54,14 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
      
      - returns: an initialized `VimeoRequestSerializer`
      */
-    init(accessTokenProvider: @escaping AccessTokenProvider, apiVersion: String) {
+    init(
+        accessTokenProvider: @escaping AccessTokenProvider,
+        apiVersion: String,
+        jsonSerializer: AFJSONRequestSerializer = AFJSONRequestSerializer()
+    ) {
         self.accessTokenProvider = accessTokenProvider
         self.appConfiguration = nil
-        
-        super.init()
-
+        self.jsonSerializer = jsonSerializer
         self.configureDefaultHeaders(withAPIVersion: apiVersion)
     }
     
@@ -75,59 +75,54 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
     init(appConfiguration: AppConfiguration) {
         self.accessTokenProvider = nil
         self.appConfiguration = appConfiguration
-        
-        super.init()
+        self.jsonSerializer = AFJSONRequestSerializer()
         
         self.configureDefaultHeaders(withAPIVersion: appConfiguration.apiVersion)
     }
     
-    /**
-     **NOT SUPPORTED**
-     */
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    // MARK: - Public
     
-    // MARK: Overrides
-    
-    public override func request(withMethod method: String, urlString URLString: String, parameters: Any?, error: NSErrorPointer) -> NSMutableURLRequest {
-        var request = super.request(withMethod: method, urlString: URLString, parameters: parameters, error: error) as URLRequest
-        
+    public func request(
+        withMethod method: HTTPMethod,
+        urlString URLString: String,
+        parameters: Any?,
+        error: NSErrorPointer
+    ) -> NSMutableURLRequest {
+        var request = jsonSerializer.request(
+            withMethod: method.rawValue,
+            urlString: URLString,
+            parameters: parameters,
+            error: error
+        ) as URLRequest
         request = self.requestConfiguringHeaders(fromRequest: request)
         
         return (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
     }
     
-    public override func multipartFormRequest(withMethod method: String, urlString URLString: String, parameters: [String : Any]?, constructingBodyWith block: ((AFMultipartFormData) -> Void)?, error: NSErrorPointer) -> NSMutableURLRequest {
-        var request = super.multipartFormRequest(withMethod: method, urlString: URLString, parameters: parameters, constructingBodyWith: block, error: error) as URLRequest
-        
-        request = self.requestConfiguringHeaders(fromRequest: request)
-        
-        return (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
-    }
-    
-    public override func request(withMultipartForm request: URLRequest, writingStreamContentsToFile fileURL: URL, completionHandler handler: ((Error?) -> Void)? = nil) -> NSMutableURLRequest {
-        var request = super.request(withMultipartForm: request, writingStreamContentsToFile: fileURL, completionHandler: handler) as URLRequest
-        
-        request = self.requestConfiguringHeaders(fromRequest: request)
-        
-        return (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
-    }
-    
-    public override func request(bySerializingRequest request: URLRequest, withParameters parameters: Any?, error: NSErrorPointer) -> URLRequest? {
-        if var request = super.request(bySerializingRequest: request, withParameters: parameters, error: error) {
+    public func request(
+        bySerializingRequest request: URLRequest,
+        withParameters parameters: Any?,
+        error: NSErrorPointer
+    ) -> URLRequest? {
+        if var request = jsonSerializer.request(
+            bySerializingRequest: request,
+            withParameters: parameters,
+            error: error
+        ) {
             request = self.requestConfiguringHeaders(fromRequest: request)
-            
             return request
         }
-        
+
         return nil
     }
     
     // MARK: Header Helpers
     
     private func configureDefaultHeaders(withAPIVersion apiVersion: String) {
-        self.setValue("application/vnd.vimeo.*+json; version=\(apiVersion)", forHTTPHeaderField: Constants.AcceptHeaderKey)
+        self.jsonSerializer.setValue(
+            "application/vnd.vimeo.*+json; version=\(apiVersion)",
+            forHTTPHeaderField: .acceptHeaderKey
+        )
     }
 
     private func requestConfiguringHeaders(fromRequest request: URLRequest) -> URLRequest {
@@ -144,7 +139,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
         
         if let token = self.accessTokenProvider?() {
             let value = "Bearer \(token)"
-            request.setValue(value, forHTTPHeaderField: Constants.AuthorizationHeaderKey)
+            request.setValue(value, forHTTPHeaderField: .authorizationHeaderKey)
         }
         else if let appConfiguration = self.appConfiguration {
             let clientID = appConfiguration.clientIdentifier
@@ -156,7 +151,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
             
             if let base64String = base64String {
                 let headerValue = "Basic \(base64String)"
-                request.setValue(headerValue, forHTTPHeaderField: Constants.AuthorizationHeaderKey)
+                request.setValue(headerValue, forHTTPHeaderField: .authorizationHeaderKey)
             }
         }
         
@@ -164,7 +159,8 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
     }
     
     private func requestModifyingUserAgentHeader(fromRequest request: URLRequest) -> URLRequest {
-        guard let frameworkVersion = Bundle(for: type(of: self)).infoDictionary?["CFBundleShortVersionString"] as? String else {
+        let infoDictionary = Bundle(for: type(of: self)).infoDictionary
+        guard let frameworkVersion = infoDictionary?["CFBundleShortVersionString"] as? String else {
             assertionFailure("Unable to get the framework version")
             
             return request
@@ -174,7 +170,7 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
         
         let frameworkString = "VimeoNetworking/\(frameworkVersion)"
         
-        guard let existingUserAgent = request.value(forHTTPHeaderField: Constants.UserAgentKey) else {
+        guard let existingUserAgent = request.value(forHTTPHeaderField: .userAgentKey) else {
             // DISCUSSION: AFNetworking doesn't set a User Agent for tvOS (look at the init method in AFHTTPRequestSerializer.m).
             // So, on tvOS the User Agent will only specify the framework. System information might be something we want to add
             // in the future if AFNetworking isn't providing it. [ghking] 6/19/17
@@ -183,15 +179,22 @@ final public class VimeoRequestSerializer: AFJSONRequestSerializer {
                 assertionFailure("An existing user agent was not found")
             #endif
             
-            request.setValue(frameworkString, forHTTPHeaderField: Constants.UserAgentKey)
+            request.setValue(frameworkString, forHTTPHeaderField: .userAgentKey)
 
             return request
         }
         
         let modifiedUserAgent = "\(existingUserAgent) \(frameworkString)"
         
-        request.setValue(modifiedUserAgent, forHTTPHeaderField: Constants.UserAgentKey)
+        request.setValue(modifiedUserAgent, forHTTPHeaderField: .userAgentKey)
         
         return request
     }
+}
+
+// MARK: - Private header keys
+private extension String  {
+    static let acceptHeaderKey = "Accept"
+    static let authorizationHeaderKey = "Authorization"
+    static let userAgentKey = "User-Agent"
 }


### PR DESCRIPTION
#### Ticket

[VIM-XXXX](https://vimean.atlassian.net/browse/VIM-XXXX)

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

The goal of this PR is to remove `VimeoRequestSerializer`'s inheritance from AFNetworking. 

#### Implementation Summary

The change here is fairly straightforward in that we are instantiating a private version of the `AFNetworking` serializer and using it as needed. We then only expose what is currently required by the consumers of this API and removing any overriden methods that are not used.

The next step that is beyond the scope of this PR is to abstract the AFNetworking serializer as a protocol which will enable us to replace it in the future.

#### How to Test

- Build and run, and ensure all unit tests pass.
