### PR TITLE
VIM-XXXX: VimeoResponseSerializer refactor

### DIFF
--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -26,8 +26,8 @@
 
 import Foundation
 
-/// `VimeoResponseSerializer` serializes, defines our accept header, as well as
-/// parses out some Vimeo-specific error information.
+/// `VimeoResponseSerializer` defines our accept header, serializes responses
+///  and parses out some Vimeo-specific error information.
 final public class VimeoResponseSerializer {
 
     private struct Constants {

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -28,22 +28,39 @@ import Foundation
 
 /** `VimeoResponseSerializer` is an `AFJSONResponseSerializer` that defines our accept header, as well as parses out some Vimeo-specific error information.
  */
-final public class VimeoResponseSerializer: AFJSONResponseSerializer {
+final public class VimeoResponseSerializer {
     private struct Constants {
         static let ErrorDomain = "VimeoResponseSerializerErrorDomain"
     }
+
+    /// Getter and setter for acceptableContentTypes property on the Vimeo/JSON response serializer
+    public var acceptableContentTypes: Set<String>? {
+        get { return self.jsonResponseSerializer.acceptableContentTypes }
+        set { self.jsonResponseSerializer.acceptableContentTypes = newValue }
+    }
+
+    // The internal response serializer use to serialize network responses
+    private let jsonResponseSerializer: AFJSONResponseSerializer
+
+    init(jsonResponseSerializer: AFJSONResponseSerializer = AFJSONResponseSerializer()) {
+        self.jsonResponseSerializer = jsonResponseSerializer
+        self.jsonResponseSerializer.acceptableContentTypes = VimeoResponseSerializer.acceptableContentTypes()
+        self.jsonResponseSerializer.readingOptions = .allowFragments
+    }
+
+    /// Creates a response object decoded from the data associated with a specified response.
+    func responseObject(
+        for response: URLResponse?,
+        data: Data?,
+        error: NSErrorPointer
+    ) -> Any? {
+        return self.jsonResponseSerializer.responseObject(
+            for: response,
+            data: data,
+            error: error
+        )
+    }
     
-    override init() {
-        super.init()
-
-        self.acceptableContentTypes = VimeoResponseSerializer.acceptableContentTypes()
-        self.readingOptions = .allowFragments
-    }
-
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-        
     // MARK: Public API
 
     /**

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -114,6 +114,8 @@ final public class VimeoResponseSerializer {
         try self.checkStatusCodeValidity(response: response)
     }
 
+    // MARK: Private API
+
     /**
      Check that a download task response has a valid status code
      
@@ -121,7 +123,7 @@ final public class VimeoResponseSerializer {
      
      - throws: an error if the status code is invalid
      */
-    public func checkStatusCodeValidity(response: URLResponse?) throws {
+    private func checkStatusCodeValidity(response: URLResponse?) throws {
         if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode < 200 || httpResponse.statusCode > 299 {
             let userInfo = [NSLocalizedDescriptionKey: "Invalid http status code for download task."]
             throw NSError(domain: Constants.ErrorDomain, code: 0, userInfo: userInfo)
@@ -137,7 +139,7 @@ final public class VimeoResponseSerializer {
      
      - returns: downloaded data serialized into JSON dictionary
      */
-    public func dictionaryFromDownloadTaskResponse(url: URL?) throws -> [String: Any] {
+    private func dictionaryFromDownloadTaskResponse(url: URL?) throws -> [String: Any] {
         guard let url = url else {
             let userInfo = [NSLocalizedDescriptionKey: "Url for completed download task is nil."]
             throw NSError(domain: Constants.ErrorDomain, code: 0, userInfo: userInfo)
@@ -160,8 +162,6 @@ final public class VimeoResponseSerializer {
         
         return dictionary!
     }
-    
-    // MARK: Private API
 
     private func errorInfo(fromResponse response: URLResponse?, responseObject: Any?) -> [String: Any]? {
         var errorInfo: [String: Any] = [:]

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -53,7 +53,7 @@ final public class VimeoResponseSerializer {
     func responseObject(
         for response: URLResponse?,
         data: Data?
-    ) throws -> Any? {
+    ) -> Result<JSON, Error> {
         var error: NSError?
         let value = self.jsonResponseSerializer.responseObject(
             for: response,
@@ -61,9 +61,12 @@ final public class VimeoResponseSerializer {
             error: &error
         )
         if let error = error {
-            throw error
+            return .failure(error)
+        } else if let unwrappedValue = value {
+            return .success(unwrappedValue)
+        } else {
+            return .failure(VimeoNetworkingError.unknownError)
         }
-        return value
     }
     
     // MARK: Public API

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -26,20 +26,21 @@
 
 import Foundation
 
-/** `VimeoResponseSerializer` is an `AFJSONResponseSerializer` that defines our accept header, as well as parses out some Vimeo-specific error information.
- */
+/// `VimeoResponseSerializer` serializes, defines our accept header, as well as
+/// parses out some Vimeo-specific error information.
 final public class VimeoResponseSerializer {
+
     private struct Constants {
         static let ErrorDomain = "VimeoResponseSerializerErrorDomain"
     }
 
-    /// Getter and setter for acceptableContentTypes property on the Vimeo/JSON response serializer
+    /// Getter and setter for acceptableContentTypes property on the underlying response serializer
     public var acceptableContentTypes: Set<String>? {
         get { return self.jsonResponseSerializer.acceptableContentTypes }
         set { self.jsonResponseSerializer.acceptableContentTypes = newValue }
     }
 
-    // The internal response serializer use to serialize network responses
+    // The response serializer used to serialize data responses
     private let jsonResponseSerializer: AFJSONResponseSerializer
 
     init(jsonResponseSerializer: AFJSONResponseSerializer = AFJSONResponseSerializer()) {
@@ -51,14 +52,18 @@ final public class VimeoResponseSerializer {
     /// Creates a response object decoded from the data associated with a specified response.
     func responseObject(
         for response: URLResponse?,
-        data: Data?,
-        error: NSErrorPointer
-    ) -> Any? {
-        return self.jsonResponseSerializer.responseObject(
+        data: Data?
+    ) throws -> Any? {
+        var error: NSError?
+        let value = self.jsonResponseSerializer.responseObject(
             for: response,
             data: data,
-            error: error
+            error: &error
         )
+        if let error = error {
+            throw error
+        }
+        return value
     }
     
     // MARK: Public API

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -436,18 +436,9 @@ private func process(
         guard data.isEmpty == false else {
             return Result.success([:])
         }
-        var maybeError: NSError?
-        let maybeJSON = serializer.responseObject(
+        return serializer.responseObject(
             for: response,
-            data: data,
-            error: &maybeError
+            data: data
         )
-        if let error = maybeError {
-            return Result.failure(error)
-        } else if let json = maybeJSON {
-            return Result.success(json)
-        } else {
-            return Result.failure(VimeoNetworkingError.unknownError)
-        }
     }
 }


### PR DESCRIPTION
#### Ticket

[VIM-XXXX](https://vimean.atlassian.net/browse/VIM-XXXX)

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

The goal of this PR is to remove `VimeoResponseSerializer`'s inheritance from AFNetworking. 

#### Implementation Summary

The change here is fairly straightforward in that we are instantiating a private version of the `AFNetworking` response serializer and using it as needed. We then only expose what is currently required by the consumers of this API.

The next step that is beyond the scope of this PR is to abstract the AFNetworking serializer as a protocol which will enable us to replace it in the future.

#### How to Test

- Build and run, and ensure all unit tests pass.
