### PR TITLE
Re-structure Networking classes

### DIFF
--- a/Sources/Shared/Core/AuthenticatingListeningDelegate.swift
+++ b/Sources/Shared/Core/AuthenticatingListeningDelegate.swift
@@ -13,7 +13,7 @@ public protocol AuthenticationListeningDelegate {
 
     /// Called when authentication completes successfully
     /// - Parameter account: the new authenticated account
-    func clientDidAuthenticate(with account: VIMAccount)
+    func clientDidAuthenticate(with accessToken: String?)
 
     /// Called when a client is logged out
     func clientDidClearAccount()

--- a/Sources/Shared/VimeoClient.swift
+++ b/Sources/Shared/VimeoClient.swift
@@ -121,7 +121,7 @@ final public class VimeoClient {
     public internal(set) var currentAccount: VIMAccount? {
         didSet {
             if let authenticatedAccount = self.currentAccount {
-                self.sessionManager?.clientDidAuthenticate(with: authenticatedAccount)
+                self.sessionManager?.clientDidAuthenticate(with: authenticatedAccount.accessToken)
             }
             else {
                 self.sessionManager?.clientDidClearAccount()

--- a/Sources/Shared/VimeoRequestSerializer.swift
+++ b/Sources/Shared/VimeoRequestSerializer.swift
@@ -54,7 +54,7 @@ open class RequestSerializer {
      
      - returns: an initialized `VimeoRequestSerializer`
      */
-    init(
+    public init(
         accessTokenProvider: @escaping AccessTokenProvider,
         apiVersion: String,
         jsonSerializer: AFJSONRequestSerializer = AFJSONRequestSerializer()
@@ -72,7 +72,7 @@ open class RequestSerializer {
      
      - returns: an initialized `VimeoRequestSerializer`
      */
-    init(appConfiguration: AppConfiguration) {
+    public init(appConfiguration: AppConfiguration) {
         self.accessTokenProvider = nil
         self.appConfiguration = appConfiguration
         self.jsonSerializer = AFJSONRequestSerializer()
@@ -116,11 +116,11 @@ open class RequestSerializer {
 
     // MARK: - Protected(only for subclasses overrides)
 
-    public func acceptHeaderValue(withAPIVersion apiVersion: String) -> String? {
+    open func acceptHeaderValue(withAPIVersion apiVersion: String) -> String? {
         return nil
     }
 
-    public func requestAddingAuthorizationHeader(fromRequest request: URLRequest) -> URLRequest {
+    open func requestAddingAuthorizationHeader(fromRequest request: URLRequest) -> URLRequest {
         var request = request
         
         if let token = self.accessTokenProvider?() {
@@ -144,7 +144,7 @@ open class RequestSerializer {
         return request
     }
 
-    public func requestModifyingUserAgentHeader(fromRequest request: URLRequest) -> URLRequest {
+    open func requestModifyingUserAgentHeader(fromRequest request: URLRequest) -> URLRequest {
         return request
     }
 

--- a/Sources/Shared/VimeoRequestSerializer.swift
+++ b/Sources/Shared/VimeoRequestSerializer.swift
@@ -29,7 +29,7 @@ import Foundation
 /// `RequestSerializer` is a base class for requests serialization. It's interface provides override methods,
 /// which allow to configure headers for outbound requests.
 /// It can be initialized with either a dynamic `AccessTokenProvider` or a static `AppConfiguration`.
-public class RequestSerializer {
+open class RequestSerializer {
     
     public typealias AccessTokenProvider = () -> String?
     

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -38,7 +38,7 @@ open class ResponseSerializer {
     // The response serializer used to serialize data responses
     private let jsonResponseSerializer: AFJSONResponseSerializer
 
-    init(jsonResponseSerializer: AFJSONResponseSerializer = AFJSONResponseSerializer()) {
+    public init(jsonResponseSerializer: AFJSONResponseSerializer = AFJSONResponseSerializer()) {
         self.jsonResponseSerializer = jsonResponseSerializer
         self.jsonResponseSerializer.readingOptions = self.defaultReadingOptions
         if let defaultTypes = self.defaultAcceptableContentTypes {
@@ -49,7 +49,7 @@ open class ResponseSerializer {
     // MARK: Public API
 
     /// Creates a response object decoded from the data associated with a specified response.
-    public func responseObject(
+    open func responseObject(
         for response: URLResponse?,
         data: Data?
     ) -> Result<JSON, Error> {
@@ -68,11 +68,11 @@ open class ResponseSerializer {
         }
     }
 
-    public var defaultAcceptableContentTypes: Set<String>? {
+    open var defaultAcceptableContentTypes: Set<String>? {
         return nil
     }
 
-    public var defaultReadingOptions: JSONSerialization.ReadingOptions {
+    open var defaultReadingOptions: JSONSerialization.ReadingOptions {
         return JSONSerialization.ReadingOptions(rawValue: 0)
     }
 }

--- a/Sources/Shared/VimeoResponseSerializer.swift
+++ b/Sources/Shared/VimeoResponseSerializer.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 // `ResponseSerializer` is a base class for validating and decoding JSON responses.
-public class ResponseSerializer {
+open class ResponseSerializer {
 
     /// Getter and setter for acceptableContentTypes property on the underlying response serializer
     public var acceptableContentTypes: Set<String>? {

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -411,8 +411,7 @@ extension SessionManager: AuthenticationListeningDelegate {
 
      - parameter account: the new account
      */
-    public func clientDidAuthenticate(with account: VIMAccount) {
-        let accessToken = account.accessToken
+    public func clientDidAuthenticate(with accessToken: String?) {
         jsonRequestSerializer.accessTokenProvider = {
             return accessToken
         }

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -33,7 +33,7 @@ private typealias SessionManagingDataTaskProgress = (Progress) -> Void
 /** `SessionManager` handles networking and serialization for raw HTTP requests.
  Internally, it uses  an `AFHTTPSessionManager` instance to handle requests.
  */
-public class SessionManager: NSObject, SessionManaging {
+open class SessionManager: NSObject, SessionManaging {
 
     // MARK: - Public
 

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -77,7 +77,7 @@ open class SessionManager: NSObject, SessionManaging {
      - returns: an initialized `SessionManager`
      */
     required public init(
-        baseUrl: URL,
+        baseUrl: URL?,
         sessionConfiguration: URLSessionConfiguration,
         requestSerializer: RequestSerializer,
         responseSerializer: ResponseSerializer
@@ -432,7 +432,7 @@ extension SessionManager: AuthenticationListeningDelegate {
 final public class VimeoSessionManager: SessionManager {
 
     required public init(
-        baseUrl: URL,
+        baseUrl: URL?,
         sessionConfiguration: URLSessionConfiguration,
         requestSerializer: RequestSerializer,
         responseSerializer: ResponseSerializer
@@ -452,7 +452,7 @@ final public class VimeoSessionManager: SessionManager {
     }
 
     convenience public init(
-        baseUrl: URL,
+        baseUrl: URL?,
         sessionConfiguration: URLSessionConfiguration,
         requestSerializer: RequestSerializer
     ) {

--- a/Tests/Shared/VimeoSessionManagerTests.swift
+++ b/Tests/Shared/VimeoSessionManagerTests.swift
@@ -124,7 +124,7 @@ class VimeoSessionManagerTests: XCTestCase {
         let testAccount = VIMAccount()
         testAccount.accessToken = "TestAccessToken"
         
-        sessionManager.clientDidAuthenticate(with: testAccount)
+        sessionManager.clientDidAuthenticate(with: testAccount.accessToken)
         
         let requestSerializer = sessionManager.jsonRequestSerializer
         
@@ -145,7 +145,7 @@ class VimeoSessionManagerTests: XCTestCase {
         
         let requestSerializer = sessionManager.jsonRequestSerializer
         
-        sessionManager.clientDidAuthenticate(with: testAccount)
+        sessionManager.clientDidAuthenticate(with: testAccount.accessToken)
         XCTAssertNotNil(requestSerializer.accessTokenProvider)
         
         sessionManager.clientDidClearAccount()


### PR DESCRIPTION
#### Ticket

[LiveKit-435](https://github.vimeows.com/Vimeo/vimeo-live-mobile-issues/issues/435?email_source=notifications&email_token=AAAAEHJI5G6JDSTWRUZTYD3QQ37L5A5CNFSM4AAB4PBKYY3PNVWWK3TUL52HS4DFVREXG43VMVBW63LNMVXHJKTDN5WW2ZLOORPWSZGOAAB7VSY)

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

- In order, to re-use Vimeo Networking functionality for Youtube API requests, we have to detach base classes - SessionManager, RequestSerializer and ResponseSerializer. Their corresponding subclasses will contain Vimeo and Youtube specific stuff.

#### Implementation Summary

- N/A

#### Reviewer Tips

- N/A

#### How to Test

- N/A