### PR TITLE
Makes JSON and URL encoders public

### DIFF
--- a/Sources/Shared/Core/JSONEncoding.swift
+++ b/Sources/Shared/Core/JSONEncoding.swift
@@ -20,7 +20,7 @@ private extension String {
 public struct JSONEncoding: ParameterEncoding {
     
     /// Returns a default `JSONEncoding` instance.
-    static let `default` = JSONEncoding()
+    public static let `default` = JSONEncoding()
     
     /// The writing options to be used by the JSON serializer
     private let options: JSONSerialization.WritingOptions

--- a/Sources/Shared/Core/JSONEncoding.swift
+++ b/Sources/Shared/Core/JSONEncoding.swift
@@ -17,7 +17,7 @@ private extension String {
 /// The type used to create a JSON encoded body of parameters to be added to the request URL.
 /// Parameters are encoded using Foundation's `JSONSerialization` serializer.
 /// and the request's `Content-Type` is set to `application/json`.
-struct JSONEncoding: ParameterEncoding {
+public struct JSONEncoding: ParameterEncoding {
     
     /// Returns a default `JSONEncoding` instance.
     static let `default` = JSONEncoding()
@@ -28,7 +28,7 @@ struct JSONEncoding: ParameterEncoding {
     /// Creates and returns a `JSONEncoding` instance using the specified options.
     ///
     /// - Parameter options: the options for JSON serializing the parameters
-    init(options: JSONSerialization.WritingOptions = []) {
+    public init(options: JSONSerialization.WritingOptions = []) {
         self.options = options
     }
     
@@ -40,7 +40,7 @@ struct JSONEncoding: ParameterEncoding {
     ///
     /// - Returns: the encoded URLRequest instance
     /// - Throws: an error if the encoding process fails.
-    func encode(_ requestConvertible: URLRequestConvertible, with parameters: Any?) throws -> URLRequest {
+    public func encode(_ requestConvertible: URLRequestConvertible, with parameters: Any?) throws -> URLRequest {
         var urlRequest = try requestConvertible.asURLRequest()
         
         guard let parameters = parameters else {

--- a/Sources/Shared/Core/ParameterEncoding.swift
+++ b/Sources/Shared/Core/ParameterEncoding.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 /// The type that describes how parameters are used in a `URLRequest`.
-protocol ParameterEncoding {
+public protocol ParameterEncoding {
     func encode(_ requestConvertible: URLRequestConvertible, with parameters: Any?) throws -> URLRequest
 }

--- a/Sources/Shared/Core/URLEncoding.swift
+++ b/Sources/Shared/Core/URLEncoding.swift
@@ -8,12 +8,6 @@
 
 import Foundation
 
-/// Constants
-private extension String {
-    static let contentTypeHeaderField                   = "Content-Type"
-    static let contentTypeFormUrlEncodedHeaderValue     = "application/x-www-form-urlencoded; charset=utf-8"
-}
-
 /// The dictionary of parameters for a given `URLRequest`.
 public typealias Parameters = [String: Any]
 
@@ -23,7 +17,7 @@ public typealias Parameters = [String: Any]
 ///
 /// Collection types are encoded using the convention of appending `[]` to the key for array values (`foo[]=1&foo[]=2`).
 /// For dictionary values, the key surrounded by square brackets is used (`foo[bar]=baz`).
-struct URLEncoding: ParameterEncoding {
+public struct URLEncoding: ParameterEncoding {
     
     /// Returns a default `URLEncoding` instance.
     static var `default`: URLEncoding { return URLEncoding() }
@@ -36,7 +30,7 @@ struct URLEncoding: ParameterEncoding {
     ///
     /// - Returns: the encoded URLRequest instance
     /// - Throws: an error if the encoding process fails.
-    func encode(_ requestConvertible: URLRequestConvertible, with parameters: Any?) throws -> URLRequest {
+    public func encode(_ requestConvertible: URLRequestConvertible, with parameters: Any?) throws -> URLRequest {
         var urlRequest = try requestConvertible.asURLRequest()
         
         guard let unwrappedParameters = parameters as? Parameters else {
@@ -141,4 +135,10 @@ private extension String {
         
         return addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? self
     }
+}
+
+/// Constants
+private extension String {
+    static let contentTypeHeaderField                   = "Content-Type"
+    static let contentTypeFormUrlEncodedHeaderValue     = "application/x-www-form-urlencoded; charset=utf-8"
 }

--- a/Sources/Shared/Core/URLEncoding.swift
+++ b/Sources/Shared/Core/URLEncoding.swift
@@ -20,7 +20,7 @@ public typealias Parameters = [String: Any]
 public struct URLEncoding: ParameterEncoding {
     
     /// Returns a default `URLEncoding` instance.
-    static var `default`: URLEncoding { return URLEncoding() }
+    public static var `default`: URLEncoding { return URLEncoding() }
     
     /// Creates a URL request by encoding parameters and adding them to an existing request.
     ///


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

Changes visibility of JSON and URL encoders, and the Encoding protocol to public.
This will allow clients consuming the API to use the encoders in their own adhoc requests.
