### PR TITLE
Use authCode for connect facebook

### DIFF
--- a/Sources/Shared/Request+ConnectedApp.swift
+++ b/Sources/Shared/Request+ConnectedApp.swift
@@ -45,11 +45,9 @@ public extension Request {
 
         var tokenKey: String
         switch appType {
-        case .facebook:
-            tokenKey = .accessToken
         case .twitter:
             tokenKey = .accessTokenSecret
-        case .linkedin, .youtube:
+        case .facebook, .linkedin, .youtube:
             tokenKey = .authCode
         }
 


### PR DESCRIPTION
#### Ticket

Fix issue with connect facebook

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- cannot connect to facebook, always receive 404 error code

#### Implementation Summary

- Replace `accessToken` to `authCode` for facebook connect

#### How to Test

- Try connect to facebook
