### PR TITLE
Add isActive member on VIMPictureCollection

### DIFF
--- a/Sources/Shared/Models/VIMPictureCollection.h
+++ b/Sources/Shared/Models/VIMPictureCollection.h
@@ -32,6 +32,7 @@
 
 @property (strong, nonatomic, nullable) NSString *uri;
 @property (strong, nonatomic, nullable) NSArray *pictures;
+@property (nonatomic, assign) BOOL isActive;
 
 - (nullable VIMPicture *)pictureForHeight:(float)height;
 - (nullable VIMPicture *)pictureForWidth:(float)width;

--- a/Sources/Shared/Models/VIMPictureCollection.m
+++ b/Sources/Shared/Models/VIMPictureCollection.m
@@ -27,6 +27,12 @@
 #import "VIMPictureCollection.h"
 #import "VIMPicture.h"
 
+@interface VIMPictureCollection ()
+
+@property (retain, nonatomic) NSNumber *active;
+
+@end
+
 @implementation VIMPictureCollection
 
 - (VIMPicture *)pictureForWidth:(float)width
@@ -90,6 +96,14 @@
     }
     
     return nil;
+}
+
+- (void)didFinishMapping
+{
+    if (self.active && [self.active isKindOfClass:[NSNumber class]])
+    {
+        self.isActive = [self.active boolValue];
+    }
 }
 
 @end

--- a/Sources/Shared/Models/VIMPictureCollection.m
+++ b/Sources/Shared/Models/VIMPictureCollection.m
@@ -29,7 +29,7 @@
 
 @interface VIMPictureCollection ()
 
-@property (retain, nonatomic) NSNumber *active;
+@property (strong, nonatomic) NSNumber *active;
 
 @end
 


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [ ] Resolved any merge conflicts
- [ ] No build errors or warnings are introduced
- [ ] New files are written in Swift
- [ ] New classes contain license headers
- [ ] New classes have Documentation
- [ ] New public methods have Documentation

#### Issue Summary

- We need to be able to tell whether a given picture collection is active for the resource it is associated with.

#### Implementation Summary

- Add public property accessible as `isActive` add private property for the backend name `active` which we translate to the public property after mapping.

#### How to Test

- Build and run tests.
