### PR TITLE
WRKFL-XXX: Turn `isActive` Into Read-only Property

### DIFF
--- a/Sources/Shared/Models/VIMPictureCollection.h
+++ b/Sources/Shared/Models/VIMPictureCollection.h
@@ -32,7 +32,7 @@
 
 @property (strong, nonatomic, nullable) NSString *uri;
 @property (strong, nonatomic, nullable) NSArray *pictures;
-@property (nonatomic, assign) BOOL isActive;
+@property (nonatomic, readonly) BOOL isActive;
 
 - (nullable VIMPicture *)pictureForHeight:(float)height;
 - (nullable VIMPicture *)pictureForWidth:(float)width;

--- a/Sources/Shared/Models/VIMPictureCollection.m
+++ b/Sources/Shared/Models/VIMPictureCollection.m
@@ -30,6 +30,7 @@
 @interface VIMPictureCollection ()
 
 @property (strong, nonatomic) NSNumber *active;
+@property (nonatomic, readwrite) BOOL isActive;
 
 @end
 


### PR DESCRIPTION
## Ticket

N/A

## Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

## Issue Summary

This PR turned the `isActive` property of `VIMPictureCollection` into a read-only property.

## Implementation Summary

N/A

## Reviewer Tips

N/A

## How to Test

N/A
