### PR TITLE
expose VideoTranscodeStatus's properties

### DIFF
--- a/Sources/Shared/Models/VideoTranscodeStatus.swift
+++ b/Sources/Shared/Models/VideoTranscodeStatus.swift
@@ -30,13 +30,13 @@ import Foundation
 public struct VideoTranscodeStatus: Decodable {
     
     /// Current state of transcoding
-    var state: TranscodeState
+    public var state: TranscodeState
     
     /// Percentage of transcoding completed
-    var progress: Int
+    public var progress: Int
     
     /// Time in seconds remaining until completion
-    var timeLeft: TimeInterval
+    public var timeLeft: TimeInterval
     
     /// Current state of the transcoding process
     ///


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- *This PR exposes `state`, `progress` and `timeLeft` properties of VideoTranscodeStatus model.*

#### Implementation Summary

- *A public access modifier was added to `state`, `progress` and `timeLeft` properties of VideoTranscodeStatus model.*

#### How to Test

- *Check if you can access `state`, `progress` and `timeLeft` properties of VideoTranscodeStatus model from outside the framework.*
