### PR TITLE
Fixes baseURL override being ignored

### DIFF
--- a/Sources/Shared/AppConfiguration.swift
+++ b/Sources/Shared/AppConfiguration.swift
@@ -56,7 +56,7 @@ public struct AppConfiguration {
         self.scopes = scopes
         self.keychainService = keychainService
         self.keychainAccessGroup = keychainAccessGroup
-        self.apiVersion = apiVersion ?? VimeoDefaultAPIVersionString
-        self.baseUrl = baseUrl ?? VimeoBaseURL
+        self.apiVersion = apiVersion ?? VimeoSessionManager.apiVersion
+        self.baseUrl = baseUrl ?? VimeoSessionManager.baseURL
     }
 }

--- a/Sources/Shared/AppConfiguration.swift
+++ b/Sources/Shared/AppConfiguration.swift
@@ -56,7 +56,7 @@ public struct AppConfiguration {
         self.scopes = scopes
         self.keychainService = keychainService
         self.keychainAccessGroup = keychainAccessGroup
-        self.apiVersion = apiVersion ?? VimeoSessionManager.apiVersion
+        self.apiVersion = apiVersion ?? VimeoDefaultAPIVersionString
         self.baseUrl = baseUrl ?? VimeoSessionManager.baseURL
     }
 }

--- a/Sources/Shared/Constants.swift
+++ b/Sources/Shared/Constants.swift
@@ -29,4 +29,4 @@ import Foundation
 public var VimeoBaseURL: URL { return VimeoSessionManager.baseURL }
 
  /// Default API version to use for requests
-internal let VimeoDefaultAPIVersionString = "3.4"
+internal let VimeoDefaultAPIVersionString: String = "3.4"

--- a/Sources/Shared/Constants.swift
+++ b/Sources/Shared/Constants.swift
@@ -26,9 +26,7 @@
 
 import Foundation
 
-// TODO: Revert this constant's scope. [VN] (05/16/2018)
-/// Base URL for the Vimeo API
-public let VimeoBaseURL = URL(string: "https://api.vimeo.com")!
+public var VimeoBaseURL: URL { return VimeoSessionManager.baseURL }
 
  /// Default API version to use for requests
 internal let VimeoDefaultAPIVersionString = "3.4"

--- a/Sources/Shared/Constants.swift
+++ b/Sources/Shared/Constants.swift
@@ -29,4 +29,4 @@ import Foundation
 public var VimeoBaseURL: URL { return VimeoSessionManager.baseURL }
 
  /// Default API version to use for requests
-internal let VimeoDefaultAPIVersionString: String = "3.4"
+internal let VimeoDefaultAPIVersionString = "3.4"

--- a/Sources/Shared/Core/EndpointType.swift
+++ b/Sources/Shared/Core/EndpointType.swift
@@ -30,5 +30,5 @@ public protocol EndpointType: URLRequestConvertible {
 }
 
 extension EndpointType {
-    var baseURL: URL { return VimeoBaseURL }
+    var baseURL: URL { return VimeoSessionManager.baseURL }
 }

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -43,9 +43,6 @@ final public class VimeoSessionManager: NSObject, SessionManaging {
     /// Base URL for the Vimeo API
     public internal(set) static var baseURL = URL(string: "https://api.vimeo.com")!
 
-     /// Default API version to use for requests
-    public private(set) static var apiVersion = "3.4"
-
     /// Getter and setter for the securityPolicy property on AFHTTPSessionManager
     @objc public var securityPolicy: SecurityPolicy {
         get { return self.httpSessionManager.securityPolicy }

--- a/Sources/Shared/VimeoSessionManager.swift
+++ b/Sources/Shared/VimeoSessionManager.swift
@@ -40,6 +40,12 @@ final public class VimeoSessionManager: NSObject, SessionManaging {
 
     // MARK: - Public
 
+    /// Base URL for the Vimeo API
+    public internal(set) static var baseURL = URL(string: "https://api.vimeo.com")!
+
+     /// Default API version to use for requests
+    public private(set) static var apiVersion = "3.4"
+
     /// Getter and setter for the securityPolicy property on AFHTTPSessionManager
     @objc public var securityPolicy: SecurityPolicy {
         get { return self.httpSessionManager.securityPolicy }
@@ -84,7 +90,11 @@ final public class VimeoSessionManager: NSObject, SessionManaging {
         sessionConfiguration: URLSessionConfiguration,
         requestSerializer: VimeoRequestSerializer
     ) {
-        self.httpSessionManager = AFHTTPSessionManager(baseURL: baseUrl, sessionConfiguration: sessionConfiguration)
+        self.httpSessionManager = AFHTTPSessionManager(
+            baseURL: baseUrl,
+            sessionConfiguration: sessionConfiguration
+        )
+        VimeoSessionManager.baseURL = baseUrl
         self.httpSessionManager.requestSerializer = AFHTTPRequestSerializer()
         self.httpSessionManager.responseSerializer = AFHTTPResponseSerializer()
         self.jsonRequestSerializer = requestSerializer

--- a/Tests/Shared/RequestTests.swift
+++ b/Tests/Shared/RequestTests.swift
@@ -110,4 +110,16 @@ class RequestTests: XCTestCase {
         let params = associatedRequest.parameters as! VimeoClient.RequestParametersDictionary
         XCTAssertEqual(params["next_page"] as! String, "2")
     }
+
+    func test_Request_usesSpecifiedBaseURL() {
+        var expectedURL = URL(string: "https://api.vimeo.com")!
+        VimeoSessionManager.baseURL = expectedURL
+        let request = Request<VIMNullResponse>(path: "/test")
+        XCTAssertEqual(request.baseURL, expectedURL)
+
+        expectedURL = URL(string: "https://custom.api.vimeo.com")!
+        VimeoSessionManager.baseURL = expectedURL
+        XCTAssertEqual(request.baseURL, expectedURL)
+
+    }
 }

--- a/Tests/Shared/VimeoSessionManagerTests.swift
+++ b/Tests/Shared/VimeoSessionManagerTests.swift
@@ -27,21 +27,25 @@
 import XCTest
 @testable import VimeoNetworking
 
-let TestVimeoBaseURL = URL(string: "https://api.vimeo.com")!
 
 class VimeoSessionManagerTests: XCTestCase {
     func test_VimeoSessionManager_defaultBaseUrl() {
+        // Given a default base URL and configuration that doesn't specify a custom URL
+        let testVimeoBaseURL = URL(string: "https://api.vimeo.com")!
+        VimeoSessionManager.baseURL = testVimeoBaseURL
         let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
                                              clientSecret: "{TEST CLIENT SECRET}",
                                              scopes: [.Public, .Private, .Purchased, .Create, .Edit, .Delete, .Interact, .Upload],
                                              keychainService: "com.vimeo.keychain_service",
                                              apiVersion: "3.3")
-    
+        // When I create a new session manager
         let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration, configureSessionManagerBlock: nil)
-        XCTAssertEqual(sessionManager.httpSessionManager.baseURL, TestVimeoBaseURL)
+        // Then it should use the default base URL
+        XCTAssertEqual(sessionManager.httpSessionManager.baseURL, testVimeoBaseURL)
     }
     
     func test_VimeoSessionManager_canSetBaseUrl() {
+        // Given a configuration that specifies a base URL
         let testApiServer = URL(string: "https://test.api.vimeo.com")!
         let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
                                              clientSecret: "{TEST CLIENT SECRET}",
@@ -49,12 +53,14 @@ class VimeoSessionManagerTests: XCTestCase {
                                              keychainService: "com.vimeo.keychain_service",
                                              apiVersion: "3.3",
                                              baseUrl: testApiServer)
-        
+        // When I create a new session manager
         let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration, configureSessionManagerBlock: nil)
+        // Then it should use the URL specified by the configuration object
         XCTAssertEqual(sessionManager.httpSessionManager.baseURL, testApiServer)
     }
     
     func test_VimeoSessionManager_canCreateTasksWithOverridenBaseUrl() {
+        // Given a configuration that specifies a base URL
         let testApiServer = URL(string: "https://test.api.vimeo.com")!
         let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
                                              clientSecret: "{TEST CLIENT SECRET}",
@@ -62,12 +68,14 @@ class VimeoSessionManagerTests: XCTestCase {
                                              keychainService: "com.vimeo.keychain_service",
                                              apiVersion: "3.3",
                                              baseUrl: testApiServer)
-        
+
+        // When I create a new session manager
         let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration, configureSessionManagerBlock: nil)
         
         let testPath = "/test/api/endpoint"
         let testUrl = testApiServer.appendingPathComponent(testPath)
-        
+
+        // Then the tasks created should use the base URL specified by the configuration object
         var task = sessionManager.httpSessionManager.get(testPath, parameters: nil, progress: nil, success: nil, failure: nil)
         XCTAssertEqual(task?.currentRequest?.url, testUrl)
         
@@ -85,17 +93,22 @@ class VimeoSessionManagerTests: XCTestCase {
     }
     
     func test_VimeoSessionManager_canCreateTasksWithDefaultBaseUrl() {
+        // Given a default base URL and configuration that doesn't specify a custom URL
+        let testVimeoBaseURL = URL(string: "https://api.vimeo.com")!
+        VimeoSessionManager.baseURL = testVimeoBaseURL
         let configuration = AppConfiguration(clientIdentifier: "{TEST CLIENT ID}",
                                              clientSecret: "{TEST CLIENT SECRET}",
                                              scopes: [.Public, .Private, .Purchased, .Create, .Edit, .Delete, .Interact, .Upload],
                                              keychainService: "com.vimeo.keychain_service",
                                              apiVersion: "3.3")
-        
+
+        // When I create a new session manager
         let sessionManager = VimeoSessionManager.defaultSessionManager(appConfiguration: configuration, configureSessionManagerBlock: nil)
         
         let testPath = "/test/api/endpoint"
-        let testUrl = TestVimeoBaseURL.appendingPathComponent(testPath)
-        
+        let testUrl = testVimeoBaseURL.appendingPathComponent(testPath)
+
+        // Then the tasks created should use the default base URL
         var task = sessionManager.httpSessionManager.get(testPath, parameters: nil, progress: nil, success: nil, failure: nil)
         XCTAssertEqual(task?.currentRequest?.url, testUrl)
         


### PR DESCRIPTION
#### Ticket

N/A

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

The default implementation of `baseURL` in `EndpointType` always points to the URL defined in the `Constants.swift` file (see [here](https://github.com/vimeo/VimeoNetworking/blob/develop/Sources/Shared/Core/EndpointType.swift#L33) for details).
This means even if a custom base URL is supplied with an `AppConfiguration` instance, it will be ignored for all `Request` types, preventing us from using that customization point.

The goal of this PR is to address this issue while maintaining backwards compatibility with the current public API.

#### Implementation Summary

- Creates a new `baseURL` static var inside `VimeoSessionManager` to replace the one in `Constants.swift`.
- Introduces the ability (internal to the framework) to modify that URL
- Updates `EndpointType` default baseURL implementation to point to this new var
- Updates `Constants.swift` to use the value of this new var (this is for backwards compatiblity since this property is currently marked as public)
- Updates unit tests to ensure they are testing the new behavior

#### How to Test

- Create an AppConfiguration object with a custom baseURL
- Use that object to create a new VimeoSessionManager instance
- Ensure the `baseURL` value in `VimeoSessionManager` is set to the custom base URL
- Create a new Request object of any type
- Ensure the request `baseURL` property reflects the custom URL provided