### PR TITLE
Adds additional YouTube-specific publishing blocker

### DIFF
--- a/Sources/Shared/Models/PublishJobConnection.swift
+++ b/Sources/Shared/Models/PublishJobConnection.swift
@@ -76,8 +76,8 @@ public class PublishJobBlockers: VIMModelObject {
     }()
 
     /// Current blockers that will prevent posting to YouTube. If `nil`, publishing is not blocked for this platform.
-    public lazy var youtube: PublishBlockers? = {
-        return PublishBlockers(blockers: self.youtubeBlockers)
+    public lazy var youtube: YouTubeBlockers? = {
+        return YouTubeBlockers(blockers: self.youtubeBlockers)
     }()
 
     public override func getObjectMapping() -> Any! {
@@ -201,6 +201,13 @@ public class LinkedInBockers: PublishBlockers {
     }()
 }
 
+/// Reasons for which a video cannot be published, specific to YouTube.
+public class YouTubeBlockers: PublishBlockers {
+    public lazy var noChannels: Bool = {
+        return self.blockers?.contains(.youTubeNoChannels) ?? false
+    }()
+}
+
 /// Parameters describing maximum values for a video post on a social media platform.
 @objcMembers
 public class PublishConstraints: VIMModelObject {
@@ -217,6 +224,7 @@ private extension String {
     static let duration = "duration"
     static let facebookNoPages = "fb_no_pages"
     static let linkedInNoOrganizations = "li_no_organizations"
+    static let youTubeNoChannels = "yt_no_channel"
     static let publishBlockers = "publish_blockers"
     static let publishConstraints = "publish_constraints"
     static let publishDestinations = "publish_destinations"

--- a/Tests/Fixtures/publish-to-social-connection.json
+++ b/Tests/Fixtures/publish-to-social-connection.json
@@ -6,7 +6,7 @@
     ],
     "publish_blockers": {
         "facebook": ["size", "duration", "fb_no_pages"],
-        "youtube": null,
+        "youtube": ["yt_no_channel"],
         "linkedin": ["size", "duration", "li_no_organizations"],
         "twitter": null
     },

--- a/Tests/Shared/PublishJobConnectionTests.swift
+++ b/Tests/Shared/PublishJobConnectionTests.swift
@@ -55,6 +55,7 @@ class PublishJobConnectionTests: XCTestCase {
 
         XCTAssertFalse(try XCTUnwrap(connection.publishBlockers?.youtube?.size))
         XCTAssertFalse(try XCTUnwrap(connection.publishBlockers?.youtube?.duration))
+        XCTAssertTrue(try XCTUnwrap(connection.publishBlockers?.youtube?.noChannels))
     }
 
     func test_publishConstraints_areParsedAsExpected() throws {


### PR DESCRIPTION
### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Implementation Summary
Added `yt_no_channel` as a blocker for publishing to YouTube, when the destination account doesn't yet have any channels to publish to. 

This can be accessed in the same way that other blockers are accessed: `connection.publishBlockers?.youtube?.noChannels`

### How to Test
Ensure that unit tests pass.