### PR TITLE
COLLAB-512: Add has_access_only parameter to team members request

### DIFF
--- a/Sources/Shared/Request+Teams.swift
+++ b/Sources/Shared/Request+Teams.swift
@@ -36,7 +36,7 @@ public extension Request {
         hasAccessOnly: Bool? = nil,
         filterString: String? = nil
     ) -> Request {
-        let hasAccessOnlyPair = hasAccessOnly.map { "\(String.hasAccessOnly)=\($0)" }
+        let hasAccessOnlyPair = hasAccessOnly.map { "\(String.hasAccessOnlyKey)=\($0)" }
         let filterStringPair = filterString.map { "\(String.fieldsKey)=\($0)" }
         let parametersString = [
             hasAccessOnlyPair,
@@ -56,6 +56,6 @@ public extension Request {
 // MARK: - Constants
 
 private extension String {
-    static let hasAccessOnly = "has_access_only"
+    static let hasAccessOnlyKey = "has_access_only"
     static let fieldsKey = "fields"
 }

--- a/Sources/Shared/Request+Teams.swift
+++ b/Sources/Shared/Request+Teams.swift
@@ -28,15 +28,34 @@ public extension Request {
 
     /// Returns a new request to fetch an array of team members.
     /// - Parameter uri: The team member's URI.
+    /// - Parameter hasAccessOnly: Flag that determines the set of players to be returned. When `true` it returns only
+    /// the list of players added to the folder. When `false` returns all team members.
     /// - Parameter filterString: The filter string to be applied to the fields request parameter.
-    static func getTeamMembers(forURI uri: String, filterString: String? = nil) -> Request {
-
-        let path = filterString.map { "\(uri)?\(String.fieldsKey)=\($0)" } ?? uri
-
+    static func getTeamMembers(
+        forURI uri: String,
+        hasAccessOnly: Bool? = nil,
+        filterString: String? = nil
+    ) -> Request {
+        let hasAccessOnlyPair = hasAccessOnly.map { "\(String.hasAccessOnly)=\($0)" }
+        let filterStringPair = filterString.map { "\(String.fieldsKey)=\($0)" }
+        let parametersString = [
+            hasAccessOnlyPair,
+            filterStringPair
+        ]
+        .compactMap { $0 }
+        .joined(separator: "&" )
+        let path = [
+            uri,
+            parametersString
+        ]
+        .joined(separator: "?")
         return Request(path: path)
     }
 }
 
+// MARK: - Constants
+
 private extension String {
+    static let hasAccessOnly = "has_access_only"
     static let fieldsKey = "fields"
 }


### PR DESCRIPTION
#### Ticket

[COLLAB-512](https://vimean.atlassian.net/browse/COLLAB-512)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Fix an issue where all team members are returned for a user instead of returning only the team_members with access to the folder

#### Implementation Summary

- Add parameter that appends a filter parameter to the `getTeamMembersRequest`

#### Reviewer Tips

- N/A

#### How to Test

- N/A