### PR TITLE
MPS-270: Fix Crash Related to Comments Count

### DIFF
--- a/Sources/Shared/Models/VIMConnection.m
+++ b/Sources/Shared/Models/VIMConnection.m
@@ -86,7 +86,7 @@ NSString *const VIMConnectionNamePublishToSocial = @"publish_to_social";
 - (void)didFinishMapping
 {
     if (self.total != nil && [self.total isKindOfClass: [NSNumber class]] == NO) {
-        NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
+        NSAssert(false, @"Error: Detected instance where `connection.total` is unexpectedly not an `NSNumber`.");
         self.total = @0;
     }
 }

--- a/Sources/Shared/Models/VIMConnection.m
+++ b/Sources/Shared/Models/VIMConnection.m
@@ -85,7 +85,7 @@ NSString *const VIMConnectionNamePublishToSocial = @"publish_to_social";
 
 - (void)didFinishMapping
 {
-    if ([self.total isKindOfClass: [NSNumber class]] == NO) {
+    if (self.total != nil && [self.total isKindOfClass: [NSNumber class]] == NO) {
         NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
         self.total = @0;
     }

--- a/Sources/Shared/Models/VIMConnection.m
+++ b/Sources/Shared/Models/VIMConnection.m
@@ -83,4 +83,12 @@ NSString *const VIMConnectionNamePublishToSocial = @"publish_to_social";
     return (self.options && [self.options containsObject:@"POST"]);
 }
 
+- (void)didFinishMapping
+{
+    if ([self.total isKindOfClass: [NSNumber class]] == NO) {
+        NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
+        self.total = @0;
+    }
+}
+
 @end

--- a/Sources/Shared/Models/VIMNotificationsConnection.m
+++ b/Sources/Shared/Models/VIMNotificationsConnection.m
@@ -20,6 +20,8 @@
 
 - (void)didFinishMapping
 {
+    [super didFinishMapping];
+
     // This is a migration for the outage on 2/20/18 where these counts were being returned as empty arrays for some users.
     // https://vimean.atlassian.net/browse/VIM-5996 [ghking] 2/22/18
 

--- a/Sources/Shared/Models/VIMVODConnection.m
+++ b/Sources/Shared/Models/VIMVODConnection.m
@@ -20,6 +20,8 @@
 
 - (void)didFinishMapping
 {
+    [super didFinishMapping];
+
     self.extraVideosCount = self.extra_total;
     self.mainVideosCount = self.main_total;
     self.viewableVideosCount = self.viewable_total;

--- a/Sources/Shared/Models/VIMVideo.m
+++ b/Sources/Shared/Models/VIMVideo.m
@@ -542,21 +542,17 @@ NSString *VIMContentRating_Safe = @"safe";
 {
     VIMConnection *commentsConnection = [self connectionWithName:VIMConnectionNameComments];
 
-    if (self.canViewComments)
-    {
-        if ([commentsConnection.total respondsToSelector:@selector(intValue)])
-        {
-            return commentsConnection.total.intValue;
-        }
-        else
-        {
-            NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
+    if (self.canViewComments == NO)
+        return 0;
 
-            return 0;
-        }
+    if ([commentsConnection.total respondsToSelector:@selector(intValue)])
+    {
+        return commentsConnection.total.intValue;
     }
     else
     {
+        NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
+
         return 0;
     }
 }

--- a/Sources/Shared/Models/VIMVideo.m
+++ b/Sources/Shared/Models/VIMVideo.m
@@ -541,8 +541,24 @@ NSString *VIMContentRating_Safe = @"safe";
 - (NSInteger)commentsCount
 {
     VIMConnection *commentsConnection = [self connectionWithName:VIMConnectionNameComments];
-    
-    return (self.canViewComments ? commentsConnection.total.intValue : 0);
+
+    if (self.canViewComments)
+    {
+        if ([commentsConnection.total respondsToSelector:@selector(intValue)])
+        {
+            return commentsConnection.total.intValue;
+        }
+        else
+        {
+            NSAssert(false, @"Error: Detected instance where `NSNumber` is not `NSNumber`.");
+
+            return 0;
+        }
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 - (BOOL)is360

--- a/Sources/Shared/Models/VIMVideo.m
+++ b/Sources/Shared/Models/VIMVideo.m
@@ -550,7 +550,7 @@ NSString *VIMContentRating_Safe = @"safe";
         }
         else
         {
-            NSAssert(false, @"Error: Detected instance where `NSNumber` is not `NSNumber`.");
+            NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
 
             return 0;
         }

--- a/Sources/Shared/Models/VIMVideo.m
+++ b/Sources/Shared/Models/VIMVideo.m
@@ -542,19 +542,7 @@ NSString *VIMContentRating_Safe = @"safe";
 {
     VIMConnection *commentsConnection = [self connectionWithName:VIMConnectionNameComments];
 
-    if (self.canViewComments == NO)
-        return 0;
-
-    if ([commentsConnection.total respondsToSelector:@selector(intValue)])
-    {
-        return commentsConnection.total.intValue;
-    }
-    else
-    {
-        NSAssert(false, @"Error: Detected instance where `commentsConnection.total` is unexpectedly not an `NSNumber`.");
-
-        return 0;
-    }
+    return (self.canViewComments ? commentsConnection.total.intValue : 0);
 }
 
 - (BOOL)is360


### PR DESCRIPTION
## Ticket

[MPS-270](https://vimean.atlassian.net/browse/MPS-270)

## Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

## Issue Summary

This PR fixed the bug that caused a method call to `commentsCount()` of `VIMVideo` to crash the consumer apps. Now, the implementation of this method first checks if the `total` property of `VIMConnection` &mdash; which is of `NSNumber` type &mdash; can respond to the `intValue` property before attempting to get the value out.

## Implementation Summary

N/A

## Reviewer Tips

N/A

## How to Test

N/A
