### PR TITLE
MPS-290: Relaxes publish requirements for Facebook and YouTube

### DIFF
--- a/Sources/Shared/Models/SocialMediaPosts.swift
+++ b/Sources/Shared/Models/SocialMediaPosts.swift
@@ -129,14 +129,14 @@ public struct PublishToYouTubePost {
     public let privacy: Privacy
 
     /// The YouTube category identifier which this video falls into.
-    public let categoryID: String
+    public let categoryID: String?
 
     public init(
         title: String,
         description: String? = nil,
         tags: [String]? = nil,
         privacy: Privacy,
-        categoryID: String
+        categoryID: String? = nil
     ) {
         self.title = title
         self.description = description

--- a/Sources/Shared/Models/SocialMediaPosts.swift
+++ b/Sources/Shared/Models/SocialMediaPosts.swift
@@ -27,10 +27,10 @@
 public struct PublishToFacebookPost {
 
     /// The title of the post as it will appear on Facebook.
-    public let title: String
+    public let title: String?
 
     /// The description of the post as it will appear on Facebook.
-    public let description: String
+    public let description: String?
 
     /// The identifier of the Facebook page being posted to.
     public let destination: Int
@@ -51,8 +51,8 @@ public struct PublishToFacebookPost {
     public let allowSocialActions: Bool
 
     public init(
-        title: String,
-        description: String,
+        title: String? = nil,
+        description: String? = nil,
         destination: Int,
         categoryID: String? = nil,
         allowEmbedding: Bool,


### PR DESCRIPTION
### Pull Request Checklist
- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

### Ticket Summary
Update VimeoNetworking to reflect the changes to Facebook and YouTube posts, no longer requiring certain fields.

### Implementation Summary
Updated the relevant properties to make them optional, and provided a default value of `nil` for those parameters on the respective initializers.

### How to Test
- Unit test should not be affected by this change but it's best to make sure they still pass.