### PR TITLE
Bumps default API version to 3.4.2

### DIFF
--- a/Sources/Shared/Constants.swift
+++ b/Sources/Shared/Constants.swift
@@ -29,4 +29,4 @@ import Foundation
 public var VimeoBaseURL: URL { return VimeoSessionManager.baseURL }
 
  /// Default API version to use for requests
-internal let VimeoDefaultAPIVersionString = "3.4"
+internal let VimeoDefaultAPIVersionString = "3.4.2"


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [X] Resolved any merge conflicts
- [X] No build errors or warnings are introduced
- [X] New files are written in Swift
- [X] New classes contain license headers
- [X] New classes have Documentation
- [X] New public methods have Documentation

#### Issue Summary

* Bumps default API version to 3.4.2
