### PR TITLE
Add AFNetworking to Carthage instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Add the following to your Cartfile:
 
 ```
 github "vimeo/VimeoNetworking"
+github "AFNetworking/AFNetworking" == 3.1.0
 ```
 
 You can optionally specify a version number, or point directly to our `develop` branch. Note that breaking changes may be introduced into `develop` at any time, but those changes will always be behind a major or minor release version number.


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

It looks like installation via Carthage does not resolve and build the `AFNetworking` dependency.
Which results in
```
dyld: Library not loaded: @rpath/AFNetworking.framework/AFNetworking
Referenced from: ../Frameworks/VimeoNetworking.framework/VimeoNetworking
Reason: image not found
```

#### Implementation Summary

Managing `AFNetworking` directly in Cartfile alongside `VimeoNetworking` solves the problem. 
I realise that there must be plans for a proper solution, but in the meantime, I think it makes sense to update the documentation.

#### Reviewer Tips

N/A

#### How to Test

Follow Carthage installation instruction
